### PR TITLE
feat: add standard actuator command interface

### DIFF
--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -1,0 +1,366 @@
+# SPDX-FileCopyrightText: 2025 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Actuator do
+  @moduledoc """
+  Interface for sending commands to actuators.
+
+  Supports both pubsub delivery (for orchestration, logging, replay) and
+  direct GenServer delivery (for time-critical control paths).
+
+  ## Delivery Methods
+
+  - **Pubsub** (`set_position/4`, etc.) - Commands published to `[:actuator | path]`.
+    Enables logging, replay, and multi-subscriber patterns. Actuators receive
+    commands via `handle_info/2`.
+
+  - **Direct** (`set_position!/4`, etc.) - Commands sent directly via `BB.Process.cast`.
+    Lower latency for time-critical control. Actuators receive via `handle_cast/2`.
+
+  - **Synchronous** (`set_position_sync/5`, etc.) - Commands sent via `BB.Process.call`.
+    Returns acknowledgement or error. Actuators respond via `handle_call/3`.
+
+  ## Examples
+
+      # Pubsub delivery (for kinematics/orchestration)
+      BB.Actuator.set_position(MyRobot, [:base_link, :shoulder, :servo], 1.57)
+
+      # Direct delivery (for time-critical control)
+      BB.Actuator.set_position!(MyRobot, :shoulder_servo, 1.57)
+
+      # Synchronous with acknowledgement
+      {:ok, :accepted} = BB.Actuator.set_position_sync(MyRobot, :shoulder_servo, 1.57)
+  """
+
+  alias BB.Message
+  alias BB.Message.Actuator.Command
+
+  # ----------------------------------------------------------------------------
+  # Position Commands
+  # ----------------------------------------------------------------------------
+
+  @doc """
+  Send a position command via pubsub.
+
+  The command is published to `[:actuator | path]` where subscribers can
+  receive it via `handle_info({:bb, path, message}, state)`.
+
+  ## Options
+
+  - `:velocity` - Velocity hint (rad/s or m/s)
+  - `:duration` - Duration hint (milliseconds)
+  - `:command_id` - Correlation ID for feedback tracking
+
+  ## Examples
+
+      BB.Actuator.set_position(MyRobot, [:base_link, :shoulder, :servo], 1.57)
+      BB.Actuator.set_position(MyRobot, [:shoulder, :servo], 1.57, velocity: 0.5)
+  """
+  @spec set_position(module(), [atom()], number(), keyword()) :: :ok
+  def set_position(robot, path, position, opts \\ []) do
+    message = build_position_message(path, position, opts)
+    BB.publish(robot, [:actuator | path], message)
+  end
+
+  @doc """
+  Send a position command directly to an actuator (bypasses pubsub).
+
+  Uses `BB.Process.cast` for fire-and-forget delivery. The actuator receives
+  the command via `handle_cast({:command, message}, state)`.
+
+  ## Options
+
+  Same as `set_position/4`.
+  """
+  @spec set_position!(module(), atom(), number(), keyword()) :: :ok
+  def set_position!(robot, actuator_name, position, opts \\ []) do
+    message = build_position_message(actuator_name, position, opts)
+    BB.cast(robot, actuator_name, {:command, message})
+  end
+
+  @doc """
+  Send a position command and wait for acknowledgement.
+
+  Uses `BB.Process.call` for synchronous delivery. Returns the actuator's
+  response or raises on timeout.
+
+  ## Options
+
+  Same as `set_position/4`, plus:
+  - Fifth argument is timeout in milliseconds (default 5000)
+
+  ## Returns
+
+  - `{:ok, :accepted}` - Command accepted
+  - `{:ok, :accepted, map()}` - Command accepted with additional info
+  - `{:error, reason}` - Command rejected
+  """
+  @spec set_position_sync(module(), atom(), number(), keyword(), timeout()) ::
+          {:ok, :accepted | {:accepted, map()}} | {:error, term()}
+  def set_position_sync(robot, actuator_name, position, opts \\ [], timeout \\ 5000) do
+    message = build_position_message(actuator_name, position, opts)
+    BB.call(robot, actuator_name, {:command, message}, timeout)
+  end
+
+  defp build_position_message(frame_id, position, opts) do
+    frame_id = if is_list(frame_id), do: List.last(frame_id), else: frame_id
+
+    Message.new!(Command.Position, frame_id,
+      position: position * 1.0,
+      velocity: opts[:velocity],
+      duration: opts[:duration],
+      command_id: opts[:command_id]
+    )
+  end
+
+  # ----------------------------------------------------------------------------
+  # Velocity Commands
+  # ----------------------------------------------------------------------------
+
+  @doc """
+  Send a velocity command via pubsub.
+
+  ## Options
+
+  - `:duration` - Duration (milliseconds), nil = until stopped
+  - `:command_id` - Correlation ID for feedback tracking
+  """
+  @spec set_velocity(module(), [atom()], number(), keyword()) :: :ok
+  def set_velocity(robot, path, velocity, opts \\ []) do
+    message = build_velocity_message(path, velocity, opts)
+    BB.publish(robot, [:actuator | path], message)
+  end
+
+  @doc """
+  Send a velocity command directly to an actuator (bypasses pubsub).
+  """
+  @spec set_velocity!(module(), atom(), number(), keyword()) :: :ok
+  def set_velocity!(robot, actuator_name, velocity, opts \\ []) do
+    message = build_velocity_message(actuator_name, velocity, opts)
+    BB.cast(robot, actuator_name, {:command, message})
+  end
+
+  @doc """
+  Send a velocity command and wait for acknowledgement.
+  """
+  @spec set_velocity_sync(module(), atom(), number(), keyword(), timeout()) ::
+          {:ok, :accepted | {:accepted, map()}} | {:error, term()}
+  def set_velocity_sync(robot, actuator_name, velocity, opts \\ [], timeout \\ 5000) do
+    message = build_velocity_message(actuator_name, velocity, opts)
+    BB.call(robot, actuator_name, {:command, message}, timeout)
+  end
+
+  defp build_velocity_message(frame_id, velocity, opts) do
+    frame_id = if is_list(frame_id), do: List.last(frame_id), else: frame_id
+
+    Message.new!(Command.Velocity, frame_id,
+      velocity: velocity * 1.0,
+      duration: opts[:duration],
+      command_id: opts[:command_id]
+    )
+  end
+
+  # ----------------------------------------------------------------------------
+  # Effort Commands
+  # ----------------------------------------------------------------------------
+
+  @doc """
+  Send an effort (torque/force) command via pubsub.
+
+  ## Options
+
+  - `:duration` - Duration (milliseconds), nil = until stopped
+  - `:command_id` - Correlation ID for feedback tracking
+  """
+  @spec set_effort(module(), [atom()], number(), keyword()) :: :ok
+  def set_effort(robot, path, effort, opts \\ []) do
+    message = build_effort_message(path, effort, opts)
+    BB.publish(robot, [:actuator | path], message)
+  end
+
+  @doc """
+  Send an effort command directly to an actuator (bypasses pubsub).
+  """
+  @spec set_effort!(module(), atom(), number(), keyword()) :: :ok
+  def set_effort!(robot, actuator_name, effort, opts \\ []) do
+    message = build_effort_message(actuator_name, effort, opts)
+    BB.cast(robot, actuator_name, {:command, message})
+  end
+
+  @doc """
+  Send an effort command and wait for acknowledgement.
+  """
+  @spec set_effort_sync(module(), atom(), number(), keyword(), timeout()) ::
+          {:ok, :accepted | {:accepted, map()}} | {:error, term()}
+  def set_effort_sync(robot, actuator_name, effort, opts \\ [], timeout \\ 5000) do
+    message = build_effort_message(actuator_name, effort, opts)
+    BB.call(robot, actuator_name, {:command, message}, timeout)
+  end
+
+  defp build_effort_message(frame_id, effort, opts) do
+    frame_id = if is_list(frame_id), do: List.last(frame_id), else: frame_id
+
+    Message.new!(Command.Effort, frame_id,
+      effort: effort * 1.0,
+      duration: opts[:duration],
+      command_id: opts[:command_id]
+    )
+  end
+
+  # ----------------------------------------------------------------------------
+  # Trajectory Commands
+  # ----------------------------------------------------------------------------
+
+  @doc """
+  Send a trajectory command via pubsub.
+
+  ## Waypoint Structure
+
+  Each waypoint should be a keyword list or map with:
+  - `position` - Position (radians or metres)
+  - `velocity` - Velocity (rad/s or m/s)
+  - `acceleration` - Acceleration (rad/s² or m/s²)
+  - `time_from_start` - Time from trajectory start (milliseconds)
+
+  ## Options
+
+  - `:repeat` - Number of repetitions: positive integer or `:forever` (default 1)
+  - `:command_id` - Correlation ID for feedback tracking
+  """
+  @spec follow_trajectory(module(), [atom()], [keyword() | map()], keyword()) :: :ok
+  def follow_trajectory(robot, path, waypoints, opts \\ []) do
+    message = build_trajectory_message(path, waypoints, opts)
+    BB.publish(robot, [:actuator | path], message)
+  end
+
+  @doc """
+  Send a trajectory command directly to an actuator (bypasses pubsub).
+  """
+  @spec follow_trajectory!(module(), atom(), [keyword() | map()], keyword()) :: :ok
+  def follow_trajectory!(robot, actuator_name, waypoints, opts \\ []) do
+    message = build_trajectory_message(actuator_name, waypoints, opts)
+    BB.cast(robot, actuator_name, {:command, message})
+  end
+
+  @doc """
+  Send a trajectory command and wait for acknowledgement.
+  """
+  @spec follow_trajectory_sync(module(), atom(), [keyword() | map()], keyword(), timeout()) ::
+          {:ok, :accepted | {:accepted, map()}} | {:error, term()}
+  def follow_trajectory_sync(robot, actuator_name, waypoints, opts \\ [], timeout \\ 5000) do
+    message = build_trajectory_message(actuator_name, waypoints, opts)
+    BB.call(robot, actuator_name, {:command, message}, timeout)
+  end
+
+  defp build_trajectory_message(frame_id, waypoints, opts) do
+    frame_id = if is_list(frame_id), do: List.last(frame_id), else: frame_id
+
+    normalised_waypoints =
+      Enum.map(waypoints, fn wp ->
+        wp = if is_map(wp), do: Keyword.new(wp), else: wp
+
+        [
+          position: wp[:position] * 1.0,
+          velocity: wp[:velocity] * 1.0,
+          acceleration: wp[:acceleration] * 1.0,
+          time_from_start: wp[:time_from_start]
+        ]
+      end)
+
+    Message.new!(Command.Trajectory, frame_id,
+      waypoints: normalised_waypoints,
+      repeat: opts[:repeat] || 1,
+      command_id: opts[:command_id]
+    )
+  end
+
+  # ----------------------------------------------------------------------------
+  # Stop Commands
+  # ----------------------------------------------------------------------------
+
+  @doc """
+  Send a stop command via pubsub.
+
+  ## Options
+
+  - `:mode` - `:immediate` (default) or `:decelerate`
+  - `:command_id` - Correlation ID for feedback tracking
+  """
+  @spec stop(module(), [atom()], keyword()) :: :ok
+  def stop(robot, path, opts \\ []) do
+    message = build_stop_message(path, opts)
+    BB.publish(robot, [:actuator | path], message)
+  end
+
+  @doc """
+  Send a stop command directly to an actuator (bypasses pubsub).
+  """
+  @spec stop!(module(), atom(), keyword()) :: :ok
+  def stop!(robot, actuator_name, opts \\ []) do
+    message = build_stop_message(actuator_name, opts)
+    BB.cast(robot, actuator_name, {:command, message})
+  end
+
+  @doc """
+  Send a stop command and wait for acknowledgement.
+  """
+  @spec stop_sync(module(), atom(), keyword(), timeout()) ::
+          {:ok, :accepted | {:accepted, map()}} | {:error, term()}
+  def stop_sync(robot, actuator_name, opts \\ [], timeout \\ 5000) do
+    message = build_stop_message(actuator_name, opts)
+    BB.call(robot, actuator_name, {:command, message}, timeout)
+  end
+
+  defp build_stop_message(frame_id, opts) do
+    frame_id = if is_list(frame_id), do: List.last(frame_id), else: frame_id
+
+    Message.new!(Command.Stop, frame_id,
+      mode: opts[:mode] || :immediate,
+      command_id: opts[:command_id]
+    )
+  end
+
+  # ----------------------------------------------------------------------------
+  # Hold Commands
+  # ----------------------------------------------------------------------------
+
+  @doc """
+  Send a hold command via pubsub.
+
+  Instructs the actuator to actively maintain its current position.
+
+  ## Options
+
+  - `:command_id` - Correlation ID for feedback tracking
+  """
+  @spec hold(module(), [atom()], keyword()) :: :ok
+  def hold(robot, path, opts \\ []) do
+    message = build_hold_message(path, opts)
+    BB.publish(robot, [:actuator | path], message)
+  end
+
+  @doc """
+  Send a hold command directly to an actuator (bypasses pubsub).
+  """
+  @spec hold!(module(), atom(), keyword()) :: :ok
+  def hold!(robot, actuator_name, opts \\ []) do
+    message = build_hold_message(actuator_name, opts)
+    BB.cast(robot, actuator_name, {:command, message})
+  end
+
+  @doc """
+  Send a hold command and wait for acknowledgement.
+  """
+  @spec hold_sync(module(), atom(), keyword(), timeout()) ::
+          {:ok, :accepted | {:accepted, map()}} | {:error, term()}
+  def hold_sync(robot, actuator_name, opts \\ [], timeout \\ 5000) do
+    message = build_hold_message(actuator_name, opts)
+    BB.call(robot, actuator_name, {:command, message}, timeout)
+  end
+
+  defp build_hold_message(frame_id, opts) do
+    frame_id = if is_list(frame_id), do: List.last(frame_id), else: frame_id
+    Message.new!(Command.Hold, frame_id, command_id: opts[:command_id])
+  end
+end

--- a/lib/bb/message/actuator/begin_motion.ex
+++ b/lib/bb/message/actuator/begin_motion.ex
@@ -14,6 +14,8 @@ defmodule BB.Message.Actuator.BeginMotion do
   - `initial_position` - Position before motion begins (radians or metres)
   - `target_position` - Target position (radians or metres)
   - `expected_arrival` - When motion should complete (monotonic milliseconds)
+  - `command_id` - Optional correlation ID from the originating command
+  - `command_type` - Optional type of command that initiated this motion
 
   ## Example
 
@@ -29,7 +31,9 @@ defmodule BB.Message.Actuator.BeginMotion do
       )
   """
 
-  defstruct [:initial_position, :target_position, :expected_arrival]
+  @command_types [:position, :velocity, :effort, :trajectory]
+
+  defstruct [:initial_position, :target_position, :expected_arrival, :command_id, :command_type]
 
   use BB.Message,
     schema: [
@@ -43,12 +47,26 @@ defmodule BB.Message.Actuator.BeginMotion do
         type: :integer,
         required: true,
         doc: "Expected arrival time (monotonic milliseconds)"
+      ],
+      command_id: [
+        type: :reference,
+        required: false,
+        doc: "Correlation ID from originating command"
+      ],
+      command_type: [
+        type: {:in, @command_types},
+        required: false,
+        doc: "Type of command that initiated this motion"
       ]
     ]
+
+  @type command_type :: :position | :velocity | :effort | :trajectory
 
   @type t :: %__MODULE__{
           initial_position: float(),
           target_position: float(),
-          expected_arrival: integer()
+          expected_arrival: integer(),
+          command_id: reference() | nil,
+          command_type: command_type() | nil
         }
 end

--- a/lib/bb/message/actuator/command/effort.ex
+++ b/lib/bb/message/actuator/command/effort.ex
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Actuator.Command.Effort do
+  @moduledoc """
+  Command to apply a specific effort (torque/force) to an actuator.
+
+  The actuator will apply the specified effort until stopped, a new
+  command is received, or the optional duration expires.
+
+  ## Fields
+
+  - `effort` - Target effort (Nm for revolute, N for prismatic)
+  - `duration` - Optional duration (milliseconds), nil = until stopped
+  - `command_id` - Optional reference for correlating with feedback messages
+
+  ## Examples
+
+      alias BB.Message
+      alias BB.Message.Actuator.Command.Effort
+
+      # Apply torque
+      {:ok, msg} = Message.new(Effort, :gripper,
+        effort: 0.5
+      )
+
+      # Apply torque for fixed duration
+      {:ok, msg} = Message.new(Effort, :gripper,
+        effort: 0.5,
+        duration: 1000
+      )
+  """
+
+  defstruct [:effort, :duration, :command_id]
+
+  use BB.Message,
+    schema: [
+      effort: [
+        type: :float,
+        required: true,
+        doc: "Target effort (Nm or N)"
+      ],
+      duration: [
+        type: :pos_integer,
+        required: false,
+        doc: "Duration (milliseconds), nil = until stopped"
+      ],
+      command_id: [
+        type: :reference,
+        required: false,
+        doc: "Correlation ID for feedback"
+      ]
+    ]
+
+  @type t :: %__MODULE__{
+          effort: float(),
+          duration: pos_integer() | nil,
+          command_id: reference() | nil
+        }
+end

--- a/lib/bb/message/actuator/command/hold.ex
+++ b/lib/bb/message/actuator/command/hold.ex
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Actuator.Command.Hold do
+  @moduledoc """
+  Command an actuator to actively maintain its current position.
+
+  Unlike `Stop`, the actuator will actively resist external forces to
+  stay at its current position. This consumes power but provides rigidity.
+
+  ## Fields
+
+  - `command_id` - Optional reference for correlating with feedback messages
+
+  ## Examples
+
+      alias BB.Message
+      alias BB.Message.Actuator.Command.Hold
+
+      {:ok, msg} = Message.new(Hold, :shoulder, [])
+
+      # With correlation ID
+      {:ok, msg} = Message.new(Hold, :shoulder,
+        command_id: make_ref()
+      )
+
+  ## Notes
+
+  Not all actuators distinguish between stop and hold. RC servos, for example,
+  always hold their position when given a command. This command is most relevant
+  for motors with encoders or steppers where passive vs active holding differs.
+  """
+
+  defstruct [:command_id]
+
+  use BB.Message,
+    schema: [
+      command_id: [
+        type: :reference,
+        required: false,
+        doc: "Correlation ID for feedback"
+      ]
+    ]
+
+  @type t :: %__MODULE__{
+          command_id: reference() | nil
+        }
+end

--- a/lib/bb/message/actuator/command/position.ex
+++ b/lib/bb/message/actuator/command/position.ex
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2025 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Actuator.Command.Position do
+  @moduledoc """
+  Command to move an actuator to a target position.
+
+  ## Fields
+
+  - `position` - Target position (radians for revolute, metres for prismatic)
+  - `velocity` - Optional velocity hint (rad/s or m/s)
+  - `duration` - Optional duration hint (milliseconds)
+  - `command_id` - Optional reference for correlating with feedback messages
+
+  ## Examples
+
+      alias BB.Message
+      alias BB.Message.Actuator.Command.Position
+
+      # Simple position command
+      {:ok, msg} = Message.new(Position, :shoulder,
+        position: 1.57
+      )
+
+      # With velocity hint
+      {:ok, msg} = Message.new(Position, :shoulder,
+        position: 1.57,
+        velocity: 0.5
+      )
+
+      # With correlation ID for tracking
+      {:ok, msg} = Message.new(Position, :shoulder,
+        position: 1.57,
+        command_id: make_ref()
+      )
+  """
+
+  defstruct [:position, :velocity, :duration, :command_id]
+
+  use BB.Message,
+    schema: [
+      position: [
+        type: :float,
+        required: true,
+        doc: "Target position (radians or metres)"
+      ],
+      velocity: [
+        type: :float,
+        required: false,
+        doc: "Velocity hint (rad/s or m/s)"
+      ],
+      duration: [
+        type: :pos_integer,
+        required: false,
+        doc: "Duration hint (milliseconds)"
+      ],
+      command_id: [
+        type: :reference,
+        required: false,
+        doc: "Correlation ID for feedback"
+      ]
+    ]
+
+  @type t :: %__MODULE__{
+          position: float(),
+          velocity: float() | nil,
+          duration: pos_integer() | nil,
+          command_id: reference() | nil
+        }
+end

--- a/lib/bb/message/actuator/command/stop.ex
+++ b/lib/bb/message/actuator/command/stop.ex
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Actuator.Command.Stop do
+  @moduledoc """
+  Command to stop an actuator's motion.
+
+  After stopping, the actuator becomes passive and will not actively resist
+  external forces. Use `Hold` if you need the actuator to maintain position.
+
+  ## Fields
+
+  - `mode` - Stop mode: `:immediate` (default) or `:decelerate`
+  - `command_id` - Optional reference for correlating with feedback messages
+
+  ## Modes
+
+  - `:immediate` - Stop as quickly as possible (may be abrupt)
+  - `:decelerate` - Slow down smoothly before stopping
+
+  ## Examples
+
+      alias BB.Message
+      alias BB.Message.Actuator.Command.Stop
+
+      # Immediate stop
+      {:ok, msg} = Message.new(Stop, :shoulder, [])
+
+      # Decelerate to stop
+      {:ok, msg} = Message.new(Stop, :shoulder,
+        mode: :decelerate
+      )
+  """
+
+  @modes [:immediate, :decelerate]
+
+  defstruct mode: :immediate, command_id: nil
+
+  use BB.Message,
+    schema: [
+      mode: [
+        type: {:in, @modes},
+        required: false,
+        default: :immediate,
+        doc: "Stop mode: :immediate or :decelerate"
+      ],
+      command_id: [
+        type: :reference,
+        required: false,
+        doc: "Correlation ID for feedback"
+      ]
+    ]
+
+  @type mode :: :immediate | :decelerate
+
+  @type t :: %__MODULE__{
+          mode: mode(),
+          command_id: reference() | nil
+        }
+end

--- a/lib/bb/message/actuator/command/trajectory.ex
+++ b/lib/bb/message/actuator/command/trajectory.ex
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2025 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Actuator.Command.Trajectory do
+  @moduledoc """
+  Command an actuator to follow a trajectory defined by waypoints.
+
+  A trajectory specifies exact position, velocity, and acceleration at
+  each point in time, enabling smooth coordinated motion.
+
+  ## Fields
+
+  - `waypoints` - List of waypoint maps defining the trajectory
+  - `repeat` - Number of times to repeat: positive integer or `:forever` (default 1)
+  - `command_id` - Optional reference for correlating with feedback messages
+
+  ## Waypoint Structure
+
+  Each waypoint is a map with:
+
+  - `position` - Position at this waypoint (radians or metres)
+  - `velocity` - Velocity at this waypoint (rad/s or m/s)
+  - `acceleration` - Acceleration at this waypoint (rad/s² or m/s²)
+  - `time_from_start` - Time from trajectory start (milliseconds)
+
+  ## Examples
+
+      alias BB.Message
+      alias BB.Message.Actuator.Command.Trajectory
+
+      waypoints = [
+        %{position: 0.0, velocity: 0.0, acceleration: 0.5, time_from_start: 0},
+        %{position: 0.1, velocity: 0.3, acceleration: 0.2, time_from_start: 100},
+        %{position: 0.3, velocity: 0.4, acceleration: 0.0, time_from_start: 200},
+        %{position: 0.5, velocity: 0.3, acceleration: -0.2, time_from_start: 300},
+        %{position: 0.6, velocity: 0.0, acceleration: -0.5, time_from_start: 400}
+      ]
+
+      {:ok, msg} = Message.new(Trajectory, :shoulder,
+        waypoints: waypoints
+      )
+
+      # Repeat 5 times
+      {:ok, msg} = Message.new(Trajectory, :shoulder,
+        waypoints: waypoints,
+        repeat: 5
+      )
+
+      # Repeat forever (until stopped)
+      {:ok, msg} = Message.new(Trajectory, :shoulder,
+        waypoints: waypoints,
+        repeat: :forever
+      )
+  """
+
+  defstruct [:waypoints, :repeat, :command_id]
+
+  @waypoint_schema [
+    position: [type: :float, required: true, doc: "Position (radians or metres)"],
+    velocity: [type: :float, required: true, doc: "Velocity (rad/s or m/s)"],
+    acceleration: [type: :float, required: true, doc: "Acceleration (rad/s² or m/s²)"],
+    time_from_start: [
+      type: :non_neg_integer,
+      required: true,
+      doc: "Time from start (milliseconds)"
+    ]
+  ]
+
+  use BB.Message,
+    schema: [
+      waypoints: [
+        type: {:list, {:keyword_list, @waypoint_schema}},
+        required: true,
+        doc: "List of trajectory waypoints"
+      ],
+      repeat: [
+        type: {:or, [:pos_integer, {:in, [:forever]}]},
+        required: false,
+        default: 1,
+        doc: "Number of times to repeat (positive integer or :forever)"
+      ],
+      command_id: [
+        type: :reference,
+        required: false,
+        doc: "Correlation ID for feedback"
+      ]
+    ]
+
+  @type waypoint :: %{
+          position: float(),
+          velocity: float(),
+          acceleration: float(),
+          time_from_start: non_neg_integer()
+        }
+
+  @type t :: %__MODULE__{
+          waypoints: [waypoint()],
+          repeat: pos_integer() | :forever,
+          command_id: reference() | nil
+        }
+end

--- a/lib/bb/message/actuator/command/velocity.ex
+++ b/lib/bb/message/actuator/command/velocity.ex
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Actuator.Command.Velocity do
+  @moduledoc """
+  Command to set an actuator's velocity.
+
+  The actuator will move at the specified velocity until stopped, a new
+  command is received, or the optional duration expires.
+
+  ## Fields
+
+  - `velocity` - Target velocity (rad/s for revolute, m/s for prismatic)
+  - `duration` - Optional duration (milliseconds), nil = until stopped
+  - `command_id` - Optional reference for correlating with feedback messages
+
+  ## Examples
+
+      alias BB.Message
+      alias BB.Message.Actuator.Command.Velocity
+
+      # Continuous velocity
+      {:ok, msg} = Message.new(Velocity, :wheel,
+        velocity: 1.0
+      )
+
+      # Velocity for fixed duration
+      {:ok, msg} = Message.new(Velocity, :wheel,
+        velocity: 1.0,
+        duration: 500
+      )
+  """
+
+  defstruct [:velocity, :duration, :command_id]
+
+  use BB.Message,
+    schema: [
+      velocity: [
+        type: :float,
+        required: true,
+        doc: "Target velocity (rad/s or m/s)"
+      ],
+      duration: [
+        type: :pos_integer,
+        required: false,
+        doc: "Duration (milliseconds), nil = until stopped"
+      ],
+      command_id: [
+        type: :reference,
+        required: false,
+        doc: "Correlation ID for feedback"
+      ]
+    ]
+
+  @type t :: %__MODULE__{
+          velocity: float(),
+          duration: pos_integer() | nil,
+          command_id: reference() | nil
+        }
+end

--- a/lib/bb/message/actuator/end_motion.ex
+++ b/lib/bb/message/actuator/end_motion.ex
@@ -16,6 +16,7 @@ defmodule BB.Message.Actuator.EndMotion do
   - `reason` - Why motion ended (`:completed`, `:cancelled`, `:limit_reached`, `:fault`)
   - `detail` - Optional atom with additional context (e.g. `:end_stop`, `:stall`)
   - `message` - Optional human-readable information for operators
+  - `command_id` - Optional correlation ID from the originating command
 
   ## Examples
 
@@ -46,7 +47,7 @@ defmodule BB.Message.Actuator.EndMotion do
 
   @reasons [:completed, :cancelled, :limit_reached, :fault]
 
-  defstruct [:position, :reason, :detail, :message]
+  defstruct [:position, :reason, :detail, :message, :command_id]
 
   use BB.Message,
     schema: [
@@ -69,6 +70,11 @@ defmodule BB.Message.Actuator.EndMotion do
         type: :string,
         required: false,
         doc: "Human-readable information for operators"
+      ],
+      command_id: [
+        type: :reference,
+        required: false,
+        doc: "Correlation ID from originating command"
       ]
     ]
 
@@ -78,6 +84,7 @@ defmodule BB.Message.Actuator.EndMotion do
           position: float(),
           reason: reason(),
           detail: atom() | nil,
-          message: String.t() | nil
+          message: String.t() | nil,
+          command_id: reference() | nil
         }
 end


### PR DESCRIPTION
## Summary

Introduces a standardised interface for sending commands to actuators, supporting both pubsub delivery (for orchestration, logging, replay) and direct GenServer delivery (for time-critical control).

### Command Message Types

| Command | Description |
|---------|-------------|
| `Position` | Target position with optional velocity/duration hints |
| `Velocity` | Target velocity with optional duration |
| `Effort` | Target torque/force with optional duration |
| `Trajectory` | Waypoints with position/velocity/acceleration/time |
| `Stop` | Cease motion (`:immediate` or `:decelerate`) |
| `Hold` | Actively maintain current position |

### Delivery Module (`BB.Actuator`)

Three delivery methods for each command type:

- **Pubsub** (`set_position/4`, etc.) - For orchestration, enables logging and replay
- **Direct cast** (`set_position!/4`, etc.) - Fire-and-forget, lower latency
- **Synchronous** (`set_position_sync/5`, etc.) - Returns acknowledgement or error

### Enhanced Motion Messages

- `BeginMotion` - Added `command_id` and `command_type` for correlation
- `EndMotion` - Added `command_id` for correlation

### Example Usage

```elixir
# Pubsub delivery (kinematics/orchestration)
BB.Actuator.set_position(MyRobot, [:base_link, :shoulder, :servo], 1.57)

# Direct delivery (time-critical control)
BB.Actuator.set_position!(MyRobot, :shoulder_servo, 1.57)

# Synchronous with acknowledgement
{:ok, :accepted} = BB.Actuator.set_position_sync(MyRobot, :shoulder_servo, 1.57)

# Trajectory
waypoints = [
  [position: 0.0, velocity: 0.0, acceleration: 0.5, time_from_start: 0],
  [position: 0.5, velocity: 0.3, acceleration: 0.0, time_from_start: 200],
  [position: 1.0, velocity: 0.0, acceleration: -0.5, time_from_start: 400]
]
BB.Actuator.follow_trajectory(MyRobot, [:shoulder, :servo], waypoints)
```

## Test plan

- [x] All command message types compile and validate correctly
- [x] BB.Actuator delivery module compiles
- [x] Enhanced BeginMotion/EndMotion backward compatible
- [x] All 457 tests pass
- [x] `mix check --no-retry` passes