### PR TITLE
feat: add GenServer behaviours with options_schema callbacks

### DIFF
--- a/documentation/dsls/DSL-BB.md
+++ b/documentation/dsls/DSL-BB.md
@@ -1354,7 +1354,7 @@ bridge name, child_spec
 A parameter protocol bridge for remote access.
 
 Bridges expose robot parameters to remote clients (GCS, web UI, etc.)
-and receive parameter updates from them. They implement `BB.Parameter.Protocol`.
+and receive parameter updates from them. They implement `BB.Bridge`.
 
 #### Example
 

--- a/documentation/topics/safety.md
+++ b/documentation/topics/safety.md
@@ -8,15 +8,16 @@ SPDX-License-Identifier: Apache-2.0
 
 ## Overview
 
-BeamBots provides a software safety system through the `BB.Safety` behaviour and
+BeamBots provides a software safety system through the `BB.Safety` module and
 `BB.Safety.Controller`. This document explains how the system works and its limitations.
 
 ## How Safety Works
 
 The safety system has four key components:
 
-1. **BB.Safety behaviour**: Actuators, sensors, and controllers can implement the
-   `disarm/1` callback to handle hardware shutdown
+1. **Behaviour callbacks**: Actuators and controllers implement the `disarm/1` callback
+   via their behaviours (`BB.Actuator`, `BB.Controller`) to handle hardware shutdown.
+   Sensors can optionally implement `disarm/1` if they control hardware.
 2. **Registration**: Processes register with the safety controller on startup,
    providing hardware-specific options needed for stateless disarm
 3. **State management**: The controller tracks safety state per robot (`:disarmed`,
@@ -54,9 +55,9 @@ hardware safety controls for critical applications.
 ```elixir
 defmodule MyServo do
   use GenServer
-  @behaviour BB.Safety
+  use BB.Actuator
 
-  @impl BB.Safety
+  @impl BB.Actuator
   def disarm(opts) do
     # This callback can be called even if the GenServer process is dead
     pin = Keyword.fetch!(opts, :pin)

--- a/lib/bb/controller.ex
+++ b/lib/bb/controller.ex
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2025 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Controller do
+  @moduledoc """
+  Behaviour for controller GenServers in the BB framework.
+
+  Controllers manage hardware communication (I2C buses, serial ports, etc.)
+  and are typically shared by multiple actuators. They run at the robot level
+  and are supervised by `BB.ControllerSupervisor`.
+
+  ## Usage
+
+  The `use BB.Controller` macro:
+  - Adds `use GenServer` (you must implement GenServer callbacks)
+  - Adds `@behaviour BB.Controller`
+  - Optionally defines `options_schema/0` if you pass the `:options_schema` option
+
+  ## Options Schema
+
+  If your controller accepts configuration options, pass them via `:options_schema`:
+
+      defmodule MyI2CController do
+        use BB.Controller,
+          options_schema: [
+            bus: [type: :string, required: true, doc: "I2C bus name"],
+            address: [type: :integer, required: true, doc: "I2C device address"]
+          ]
+
+        @impl GenServer
+        def init(opts) do
+          bus = Keyword.fetch!(opts, :bus)
+          address = Keyword.fetch!(opts, :address)
+          bb = Keyword.fetch!(opts, :bb)
+          {:ok, %{bus: bus, address: address, bb: bb}}
+        end
+      end
+
+  For controllers that don't need configuration, omit `:options_schema`:
+
+      defmodule SimpleController do
+        use BB.Controller
+
+        # Must be used as bare module in DSL: controller :foo, SimpleController
+
+        @impl GenServer
+        def init(opts) do
+          bb = Keyword.fetch!(opts, :bb)
+          {:ok, %{bb: bb}}
+        end
+      end
+
+  ## Safety
+
+  If your controller manages hardware that needs to be made safe when disarmed,
+  implement the optional `disarm/1` callback:
+
+      defmodule MyController do
+        use BB.Controller, options_schema: [bus: [type: :string, required: true]]
+
+        @impl BB.Controller
+        def disarm(opts), do: disable_hardware(opts[:bus])
+      end
+
+  ## Auto-injected Options
+
+  The `:bb` option is automatically provided by the supervisor and should
+  NOT be included in your `options_schema`. It contains `%{robot: module, path: [atom]}`.
+  """
+
+  @doc """
+  Returns the options schema for this controller.
+
+  The schema should NOT include the `:bb` option - it is auto-injected.
+  If this callback is not implemented, the module cannot accept options
+  in the DSL (must be used as a bare module).
+  """
+  @callback options_schema() :: Spark.Options.t()
+
+  @doc """
+  Make the hardware safe.
+
+  Called with the opts provided at registration. Must work without GenServer state.
+  Only implement this if your controller manages hardware that needs to be disabled
+  when the robot is disarmed or crashes.
+  """
+  @callback disarm(opts :: keyword()) :: :ok | {:error, term()}
+
+  @optional_callbacks [options_schema: 0, disarm: 1]
+
+  @doc false
+  defmacro __using__(opts) do
+    schema_opts = opts[:options_schema]
+
+    quote do
+      use GenServer
+      @behaviour BB.Controller
+
+      unquote(
+        if schema_opts do
+          quote do
+            @__bb_options_schema Spark.Options.new!(unquote(schema_opts))
+
+            @impl BB.Controller
+            def options_schema, do: @__bb_options_schema
+
+            defoverridable options_schema: 0
+          end
+        end
+      )
+    end
+  end
+end

--- a/lib/bb/dsl.ex
+++ b/lib/bb/dsl.ex
@@ -228,7 +228,8 @@ defmodule BB.Dsl do
         doc: "A unique name for the sensor"
       ],
       child_spec: [
-        type: {:or, [:module, {:tuple, [:module, :keyword_list]}]},
+        type:
+          {:or, [{:behaviour, BB.Sensor}, {:tuple, [{:behaviour, BB.Sensor}, :keyword_list]}]},
         required: true,
         doc:
           "The child specification for the sensor process. Either a module or `{module, keyword_list}`"
@@ -252,7 +253,8 @@ defmodule BB.Dsl do
         doc: "A unique name for the actuator"
       ],
       child_spec: [
-        type: {:or, [:module, {:tuple, [:module, :keyword_list]}]},
+        type:
+          {:or, [{:behaviour, BB.Actuator}, {:tuple, [{:behaviour, BB.Actuator}, :keyword_list]}]},
         required: true,
         doc:
           "The child specification for the actuator process. Either a module or `{module, keyword_list}`"
@@ -670,7 +672,9 @@ defmodule BB.Dsl do
         doc: "A unique name for the controller"
       ],
       child_spec: [
-        type: {:or, [:module, {:tuple, [:module, :keyword_list]}]},
+        type:
+          {:or,
+           [{:behaviour, BB.Controller}, {:tuple, [{:behaviour, BB.Controller}, :keyword_list]}]},
         required: true,
         doc:
           "The child specification for the controller process. Either a module or `{module, keyword_list}`"
@@ -804,7 +808,7 @@ defmodule BB.Dsl do
     A parameter protocol bridge for remote access.
 
     Bridges expose robot parameters to remote clients (GCS, web UI, etc.)
-    and receive parameter updates from them. They implement `BB.Parameter.Protocol`.
+    and receive parameter updates from them. They implement `BB.Bridge`.
 
     ## Example
 
@@ -824,11 +828,7 @@ defmodule BB.Dsl do
       ],
       child_spec: [
         type:
-          {:or,
-           [
-             {:behaviour, BB.Parameter.Protocol},
-             {:tuple, [{:behaviour, BB.Parameter.Protocol}, :keyword_list]}
-           ]},
+          {:or, [{:behaviour, BB.Bridge}, {:tuple, [{:behaviour, BB.Bridge}, :keyword_list]}]},
         required: true,
         doc:
           "The child specification for the bridge process. Either a module or `{module, keyword_list}`"
@@ -878,5 +878,8 @@ defmodule BB.Dsl do
       __MODULE__.RobotTransformer,
       __MODULE__.CommandTransformer,
       __MODULE__.ParameterTransformer
+    ],
+    verifiers: [
+      __MODULE__.Verifiers.ValidateChildSpecs
     ]
 end

--- a/lib/bb/dsl/verifiers/validate_child_specs.ex
+++ b/lib/bb/dsl/verifiers/validate_child_specs.ex
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: 2025 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Dsl.Verifiers.ValidateChildSpecs do
+  @moduledoc """
+  Validates that child_spec options match the module's schema.
+
+  Behaviour validation is handled by Spark's schema types (e.g., `{:behaviour, BB.Sensor}`).
+  This verifier handles the additional validation:
+
+  - If options are provided in the DSL (as `{Module, opts}` tuple),
+    the module must define `options_schema/0`
+  - If `options_schema/0` is defined, the provided options are validated
+    against that schema
+  """
+
+  use Spark.Dsl.Verifier
+
+  alias BB.Dsl.{Actuator, Bridge, Controller, Joint, Link, Sensor}
+  alias Spark.Dsl.Verifier
+  alias Spark.Error.DslError
+
+  @impl true
+  def verify(dsl_state) do
+    module = Verifier.get_persisted(dsl_state, :module)
+
+    with :ok <- verify_controllers(dsl_state, module),
+         :ok <- verify_robot_sensors(dsl_state, module),
+         :ok <- verify_topology(dsl_state, module) do
+      verify_bridges(dsl_state, module)
+    end
+  end
+
+  defp verify_controllers(dsl_state, robot_module) do
+    dsl_state
+    |> Verifier.get_entities([:controllers])
+    |> Enum.reduce_while(:ok, fn %Controller{} = controller, :ok ->
+      case validate_child_spec(
+             controller.child_spec,
+             [:controllers, controller.name],
+             robot_module
+           ) do
+        :ok -> {:cont, :ok}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+  end
+
+  defp verify_robot_sensors(dsl_state, robot_module) do
+    dsl_state
+    |> Verifier.get_entities([:sensors])
+    |> Enum.reduce_while(:ok, fn %Sensor{} = sensor, :ok ->
+      case validate_child_spec(
+             sensor.child_spec,
+             [:sensors, sensor.name],
+             robot_module
+           ) do
+        :ok -> {:cont, :ok}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+  end
+
+  defp verify_bridges(dsl_state, robot_module) do
+    dsl_state
+    |> Verifier.get_entities([:parameters])
+    |> Enum.filter(&is_struct(&1, Bridge))
+    |> Enum.reduce_while(:ok, fn %Bridge{} = bridge, :ok ->
+      case validate_child_spec(
+             bridge.child_spec,
+             [:parameters, bridge.name],
+             robot_module
+           ) do
+        :ok -> {:cont, :ok}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+  end
+
+  defp verify_topology(dsl_state, robot_module) do
+    dsl_state
+    |> Verifier.get_entities([:topology])
+    |> verify_topology_entities([], robot_module)
+  end
+
+  defp verify_topology_entities(entities, path, robot_module) do
+    Enum.reduce_while(entities, :ok, fn entity, :ok ->
+      case verify_topology_entity(entity, path, robot_module) do
+        :ok -> {:cont, :ok}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+  end
+
+  defp verify_topology_entity(%Link{} = link, path, robot_module) do
+    link_path = path ++ [:topology, :link, link.name]
+
+    with :ok <- verify_link_sensors(link, link_path, robot_module) do
+      verify_topology_entities(link.joints, link_path, robot_module)
+    end
+  end
+
+  defp verify_topology_entity(%Joint{} = joint, path, robot_module) do
+    joint_path = path ++ [:joint, joint.name]
+
+    with :ok <- verify_joint_sensors(joint, joint_path, robot_module),
+         :ok <- verify_joint_actuators(joint, joint_path, robot_module) do
+      verify_nested_link(joint, path, robot_module)
+    end
+  end
+
+  defp verify_topology_entity(_entity, _path, _robot_module), do: :ok
+
+  defp verify_link_sensors(%Link{sensors: sensors}, path, robot_module) do
+    Enum.reduce_while(sensors, :ok, fn %Sensor{} = sensor, :ok ->
+      sensor_path = path ++ [:sensor, sensor.name]
+
+      case validate_child_spec(sensor.child_spec, sensor_path, robot_module) do
+        :ok -> {:cont, :ok}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+  end
+
+  defp verify_joint_sensors(%Joint{} = joint, path, robot_module) do
+    sensors = Map.get(joint, :sensors, [])
+
+    Enum.reduce_while(sensors, :ok, fn %Sensor{} = sensor, :ok ->
+      sensor_path = path ++ [:sensor, sensor.name]
+
+      case validate_child_spec(sensor.child_spec, sensor_path, robot_module) do
+        :ok -> {:cont, :ok}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+  end
+
+  defp verify_joint_actuators(%Joint{} = joint, path, robot_module) do
+    actuators = Map.get(joint, :actuators, [])
+
+    Enum.reduce_while(actuators, :ok, fn %Actuator{} = actuator, :ok ->
+      actuator_path = path ++ [:actuator, actuator.name]
+
+      case validate_child_spec(actuator.child_spec, actuator_path, robot_module) do
+        :ok -> {:cont, :ok}
+        {:error, error} -> {:halt, {:error, error}}
+      end
+    end)
+  end
+
+  defp verify_nested_link(%Joint{} = joint, path, robot_module) do
+    case Map.get(joint, :link) do
+      nil -> :ok
+      nested_link -> verify_topology_entity(nested_link, path, robot_module)
+    end
+  end
+
+  defp validate_child_spec(child_spec, path, robot_module) do
+    {module, opts} = normalize_child_spec(child_spec)
+    validate_options(module, opts, path, robot_module)
+  end
+
+  defp normalize_child_spec(module) when is_atom(module), do: {module, []}
+  defp normalize_child_spec({module, opts}) when is_atom(module), do: {module, opts}
+
+  defp validate_options(module, opts, path, robot_module) do
+    Code.ensure_loaded(module)
+    has_schema? = function_exported?(module, :options_schema, 0)
+    has_opts? = opts != []
+
+    cond do
+      has_opts? and not has_schema? ->
+        {:error,
+         DslError.exception(
+           module: robot_module,
+           path: path,
+           message: """
+           Module #{inspect(module)} does not define options_schema/0 but options were provided.
+
+           Either:
+           1. Use the module without options: #{inspect(module)}
+           2. Add options_schema/0 to #{inspect(module)} to accept options
+           """
+         )}
+
+      has_schema? ->
+        schema = module.options_schema()
+
+        case Spark.Options.validate(opts, schema) do
+          {:ok, _validated} ->
+            :ok
+
+          {:error, %Spark.Options.ValidationError{} = error} ->
+            {:error,
+             DslError.exception(
+               module: robot_module,
+               path: path,
+               message: """
+               Invalid options for #{inspect(module)}:
+
+               #{Exception.message(error)}
+
+               Expected schema:
+               #{format_schema(schema)}
+               """
+             )}
+        end
+
+      true ->
+        :ok
+    end
+  end
+
+  defp format_schema(%Spark.Options{schema: schema}) do
+    format_schema(schema)
+  end
+
+  defp format_schema(schema) when is_list(schema) do
+    Enum.map_join(schema, "\n", fn {key, opts} ->
+      type = Keyword.get(opts, :type, :any)
+      required = if Keyword.get(opts, :required, false), do: " (required)", else: ""
+
+      default =
+        if Keyword.has_key?(opts, :default),
+          do: " [default: #{inspect(Keyword.get(opts, :default))}]",
+          else: ""
+
+      doc = if opts[:doc], do: " - #{opts[:doc]}", else: ""
+
+      "  #{key}: #{inspect(type)}#{required}#{default}#{doc}"
+    end)
+  end
+end

--- a/lib/bb/parameter.ex
+++ b/lib/bb/parameter.ex
@@ -224,7 +224,7 @@ defmodule BB.Parameter do
 
       {:ok, 0.15} = BB.Parameter.get_remote(MyRobot, :mavlink, "PITCH_RATE_P")
   """
-  @spec get_remote(module(), atom(), BB.Parameter.Protocol.param_id()) ::
+  @spec get_remote(module(), atom(), BB.Bridge.param_id()) ::
           {:ok, term()} | {:error, term()}
   def get_remote(robot_module, bridge_name, param_id)
       when is_atom(robot_module) and is_atom(bridge_name) do
@@ -240,7 +240,7 @@ defmodule BB.Parameter do
 
       :ok = BB.Parameter.set_remote(MyRobot, :mavlink, "PITCH_RATE_P", 0.15)
   """
-  @spec set_remote(module(), atom(), BB.Parameter.Protocol.param_id(), term()) ::
+  @spec set_remote(module(), atom(), BB.Bridge.param_id(), term()) ::
           :ok | {:error, term()}
   def set_remote(robot_module, bridge_name, param_id, value)
       when is_atom(robot_module) and is_atom(bridge_name) do
@@ -259,7 +259,7 @@ defmodule BB.Parameter do
 
       :ok = BB.Parameter.subscribe_remote(MyRobot, :mavlink, "PITCH_RATE_P")
   """
-  @spec subscribe_remote(module(), atom(), BB.Parameter.Protocol.param_id()) ::
+  @spec subscribe_remote(module(), atom(), BB.Bridge.param_id()) ::
           :ok | {:error, term()}
   def subscribe_remote(robot_module, bridge_name, param_id)
       when is_atom(robot_module) and is_atom(bridge_name) do

--- a/lib/bb/sensor.ex
+++ b/lib/bb/sensor.ex
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2025 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Sensor do
+  @moduledoc """
+  Behaviour for sensor GenServers in the BB framework.
+
+  Sensors read from hardware or other sources and publish messages. They can
+  be attached at the robot level, to links, or to joints.
+
+  ## Usage
+
+  The `use BB.Sensor` macro:
+  - Adds `use GenServer` (you must implement GenServer callbacks)
+  - Adds `@behaviour BB.Sensor`
+  - Optionally defines `options_schema/0` if you pass the `:options_schema` option
+
+  ## Options Schema
+
+  If your sensor accepts configuration options, pass them via `:options_schema`:
+
+      defmodule MyTemperatureSensor do
+        use BB.Sensor,
+          options_schema: [
+            bus: [type: :string, required: true, doc: "I2C bus name"],
+            address: [type: :integer, required: true, doc: "I2C device address"],
+            poll_interval_ms: [type: :pos_integer, default: 1000, doc: "Poll interval"]
+          ]
+
+        @impl GenServer
+        def init(opts) do
+          # Options already validated at compile time
+          bus = Keyword.fetch!(opts, :bus)
+          address = Keyword.fetch!(opts, :address)
+          bb = Keyword.fetch!(opts, :bb)
+          {:ok, %{bus: bus, address: address, bb: bb}}
+        end
+      end
+
+  You can override the generated `options_schema/0` if needed:
+
+      defmodule MySensor do
+        use BB.Sensor, options_schema: [frequency: [type: :pos_integer, default: 50]]
+
+        @impl BB.Sensor
+        def options_schema do
+          # Custom implementation
+          Spark.Options.new!([...])
+        end
+      end
+
+  For sensors that don't need configuration, omit `:options_schema`:
+
+      defmodule SimpleSensor do
+        use BB.Sensor
+
+        # Must be used as bare module in DSL: sensor :temp, SimpleSensor
+
+        @impl GenServer
+        def init(opts) do
+          bb = Keyword.fetch!(opts, :bb)
+          {:ok, %{bb: bb}}
+        end
+      end
+
+  ## Safety
+
+  Most sensors don't require safety callbacks since they only read data.
+  If your sensor controls hardware that needs to be disabled on disarm
+  (e.g., a spinning LIDAR), implement the optional `disarm/1` callback:
+
+      defmodule MyHardwareSensor do
+        use BB.Sensor
+
+        @impl BB.Sensor
+        def disarm(opts), do: stop_hardware(opts)
+      end
+
+  ## Auto-injected Options
+
+  The `:bb` option is automatically provided by the supervisor and should
+  NOT be included in your `options_schema`. It contains `%{robot: module, path: [atom]}`.
+  """
+
+  @doc """
+  Returns the options schema for this sensor.
+
+  The schema should NOT include the `:bb` option - it is auto-injected.
+  If this callback is not implemented, the module cannot accept options
+  in the DSL (must be used as a bare module).
+  """
+  @callback options_schema() :: Spark.Options.t()
+
+  @doc """
+  Make the hardware safe.
+
+  Called with the opts provided at registration. Must work without GenServer state.
+  This callback is optional for sensors - only implement it if your sensor
+  controls hardware that needs to be disabled on disarm (e.g., a spinning LIDAR).
+  """
+  @callback disarm(opts :: keyword()) :: :ok | {:error, term()}
+
+  @optional_callbacks [options_schema: 0, disarm: 1]
+
+  @doc false
+  defmacro __using__(opts) do
+    schema_opts = opts[:options_schema]
+
+    quote do
+      use GenServer
+      @behaviour BB.Sensor
+
+      unquote(
+        if schema_opts do
+          quote do
+            @__bb_options_schema Spark.Options.new!(unquote(schema_opts))
+
+            @impl BB.Sensor
+            def options_schema, do: @__bb_options_schema
+
+            defoverridable options_schema: 0
+          end
+        end
+      )
+    end
+  end
+end

--- a/test/bb/bridge_test.exs
+++ b/test/bb/bridge_test.exs
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-defmodule BB.Parameter.ProtocolTest do
+defmodule BB.BridgeTest do
   use ExUnit.Case, async: false
 
   alias BB.Parameter

--- a/test/bb/controller_test.exs
+++ b/test/bb/controller_test.exs
@@ -8,12 +8,18 @@ defmodule BB.ControllerTest do
   alias BB.Process, as: BBProcess
 
   defmodule TestGenServer do
-    use GenServer
+    use BB.Controller,
+      options_schema: [
+        max_accel: [type: :float, required: false],
+        value: [type: :integer, required: false]
+      ]
 
+    @impl GenServer
     def init(opts) do
       {:ok, opts}
     end
 
+    @impl GenServer
     def handle_call(:get_state, _from, state) do
       {:reply, state, state}
     end

--- a/test/bb/dsl/parameter_test.exs
+++ b/test/bb/dsl/parameter_test.exs
@@ -60,25 +60,34 @@ defmodule BB.Dsl.ParameterTest do
 
   defmodule TestSensor do
     @moduledoc false
-    use GenServer
+    use BB.Sensor
 
     def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl GenServer
     def init(opts), do: {:ok, opts}
   end
 
   defmodule TestActuator do
     @moduledoc false
-    use GenServer
+    use BB.Actuator
+
+    @impl BB.Actuator
+    def disarm(_opts), do: :ok
 
     def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl GenServer
     def init(opts), do: {:ok, opts}
   end
 
   defmodule TestController do
     @moduledoc false
-    use GenServer
+    use BB.Controller
 
     def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl GenServer
     def init(opts), do: {:ok, opts}
   end
 

--- a/test/support/failing_actuator.ex
+++ b/test/support/failing_actuator.ex
@@ -4,10 +4,9 @@
 
 defmodule BB.Test.FailingActuator do
   @moduledoc false
-  use GenServer
-  @behaviour BB.Safety
+  use BB.Actuator, options_schema: [fail_mode: [type: :atom, required: false]]
 
-  @impl BB.Safety
+  @impl BB.Actuator
   def disarm(opts) do
     case opts[:fail_mode] do
       :error -> {:error, :hardware_failure}

--- a/test/support/mock_actuator.ex
+++ b/test/support/mock_actuator.ex
@@ -6,7 +6,7 @@ defmodule BB.Test.MockActuator do
   @moduledoc """
   Minimal mock actuator for testing.
   """
-  use GenServer
+  use BB.Actuator, options_schema: []
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: via(opts))
@@ -15,6 +15,9 @@ defmodule BB.Test.MockActuator do
   defp via(opts) do
     BB.Process.via(opts[:bb][:robot], opts[:bb][:name])
   end
+
+  @impl BB.Actuator
+  def disarm(_opts), do: :ok
 
   @impl GenServer
   def init(opts) do
@@ -35,4 +38,90 @@ defmodule BB.Test.MockActuator do
   def handle_info({:bb, _path, _message}, state) do
     {:noreply, state}
   end
+end
+
+# Aliases for various test module names
+defmodule ServoMotor do
+  @moduledoc false
+  use BB.Actuator,
+    options_schema: [
+      pwm_pin: [type: :pos_integer, required: false],
+      frequency: [type: :pos_integer, required: false]
+    ]
+
+  @impl BB.Actuator
+  def disarm(_opts), do: :ok
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule MainMotor do
+  @moduledoc false
+  use BB.Actuator
+
+  @impl BB.Actuator
+  def disarm(_opts), do: :ok
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule BrakeActuator do
+  @moduledoc false
+  use BB.Actuator, options_schema: [pin: [type: :pos_integer, required: false]]
+
+  @impl BB.Actuator
+  def disarm(_opts), do: :ok
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule ShoulderMotor do
+  @moduledoc false
+  use BB.Actuator
+
+  @impl BB.Actuator
+  def disarm(_opts), do: :ok
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule ElbowMotor do
+  @moduledoc false
+  use BB.Actuator
+
+  @impl BB.Actuator
+  def disarm(_opts), do: :ok
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule MyMotor do
+  @moduledoc false
+  use BB.Actuator
+
+  @impl BB.Actuator
+  def disarm(_opts), do: :ok
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule TestActuator do
+  @moduledoc false
+  use BB.Actuator,
+    options_schema: [
+      pin: [type: :pos_integer, required: false],
+      pwm_frequency: [type: :pos_integer, required: false]
+    ]
+
+  @impl BB.Actuator
+  def disarm(_opts), do: :ok
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
 end

--- a/test/support/test_sensor.ex
+++ b/test/support/test_sensor.ex
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2025 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule MySensor do
+  @moduledoc """
+  A minimal test sensor that implements BB.Sensor behaviour.
+  Used in DSL tests where a sensor module is required.
+  """
+  use BB.Sensor,
+    options_schema: [
+      frequency: [
+        type: :pos_integer,
+        doc: "Sample frequency",
+        default: 50
+      ]
+    ]
+
+  @impl GenServer
+  def init(opts) do
+    {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+  end
+end
+
+# Aliases for various test module names used in sensor_test.exs
+
+defmodule CameraSensor do
+  @moduledoc false
+  use BB.Sensor
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule ImuSensor do
+  @moduledoc false
+  use BB.Sensor
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule GpsSensor do
+  @moduledoc false
+  use BB.Sensor, options_schema: [port: [type: :string, required: false]]
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule BaseSensor do
+  @moduledoc false
+  use BB.Sensor
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule ChildSensor do
+  @moduledoc false
+  use BB.Sensor
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule Encoder do
+  @moduledoc false
+  use BB.Sensor, options_schema: [bus: [type: :atom, required: false]]
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule RobotSensor do
+  @moduledoc false
+  use BB.Sensor
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule LinkSensor do
+  @moduledoc false
+  use BB.Sensor
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule JointSensor do
+  @moduledoc false
+  use BB.Sensor
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end
+
+defmodule SomeSensor do
+  @moduledoc false
+  use BB.Sensor
+
+  @impl GenServer
+  def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+end


### PR DESCRIPTION
## Summary

- Add `BB.Controller`, `BB.Sensor`, and `BB.Bridge` behaviours with optional `options_schema/0` callbacks
- Extend `BB.Actuator` with the same pattern
- Each behaviour's `__using__/1` macro now includes `use GenServer`, simplifying implementations
- Add `ValidateChildSpecs` verifier for compile-time validation of child spec options against module schemas
- Merge `BB.Parameter.Protocol` into `BB.Bridge` for a cleaner API
- Move `disarm/1` callback from `BB.Safety` to `BB.Actuator` and `BB.Controller` behaviours

## Usage

```elixir
defmodule MyActuator do
  use BB.Actuator,
    options_schema: [
      pin: [type: :pos_integer, required: true],
      frequency: [type: :pos_integer, default: 50]
    ]

  @impl BB.Actuator
  def disarm(opts), do: :ok

  @impl GenServer
  def init(opts), do: {:ok, opts}
end
```

For modules with complex schemas, define the callback explicitly:

```elixir
defmodule MyController do
  use BB.Controller

  @impl BB.Controller
  def options_schema do
    Spark.Options.new!([...])
  end
end
```

## Test plan

- [x] All 488 tests pass
- [x] Dialyzer passes
- [x] Credo passes
- [x] Updated servo driver packages compile against new API