### PR TITLE
feat(safety): add hardware error reporting with auto-disarm

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -9,6 +9,7 @@ spark_locals_without_parens = [
   alpha: 1,
   argument: 2,
   argument: 3,
+  auto_disarm_on_error: 1,
   axis: 0,
   axis: 1,
   blue: 1,

--- a/documentation/dsls/DSL-BB.md
+++ b/documentation/dsls/DSL-BB.md
@@ -959,6 +959,7 @@ System-wide settings
 | [`registry_options`](#settings-registry_options){: #settings-registry_options } | `keyword` |  | Options passed to Registry.start_link/1. Defaults to `[partitions: System.schedulers_online()]` at runtime. |
 | [`supervisor_module`](#settings-supervisor_module){: #settings-supervisor_module } | `module` | `Supervisor` | The supervisor module to use |
 | [`parameter_store`](#settings-parameter_store){: #settings-parameter_store } | `module \| {module, keyword}` |  | Optional parameter persistence backend. Use a module or `{Module, opts}` tuple. |
+| [`auto_disarm_on_error`](#settings-auto_disarm_on_error){: #settings-auto_disarm_on_error } | `boolean` | `true` | Automatically disarm the robot when a hardware error is reported. Defaults to true. |
 
 
 

--- a/lib/bb/dsl.ex
+++ b/lib/bb/dsl.ex
@@ -646,6 +646,13 @@ defmodule BB.Dsl do
            ]},
         doc: "Optional parameter persistence backend. Use a module or `{Module, opts}` tuple.",
         required: false
+      ],
+      auto_disarm_on_error: [
+        type: :boolean,
+        doc:
+          "Automatically disarm the robot when a hardware error is reported. Defaults to true.",
+        required: false,
+        default: true
       ]
     ]
   }

--- a/lib/bb/dsl/info.ex
+++ b/lib/bb/dsl/info.ex
@@ -17,7 +17,8 @@ defmodule BB.Dsl.Info do
           registry_module: module,
           registry_options: keyword,
           supervisor_module: module,
-          parameter_store: module | {module, keyword} | nil
+          parameter_store: module | {module, keyword} | nil,
+          auto_disarm_on_error: boolean
         }
   def settings(robot_module) do
     registry_options =
@@ -29,7 +30,9 @@ defmodule BB.Dsl.Info do
       registry_options: registry_options,
       supervisor_module:
         Extension.get_opt(robot_module, [:settings], :supervisor_module, Supervisor),
-      parameter_store: Extension.get_opt(robot_module, [:settings], :parameter_store)
+      parameter_store: Extension.get_opt(robot_module, [:settings], :parameter_store),
+      auto_disarm_on_error:
+        Extension.get_opt(robot_module, [:settings], :auto_disarm_on_error, true)
     }
   end
 end

--- a/lib/bb/safety.ex
+++ b/lib/bb/safety.ex
@@ -157,4 +157,45 @@ defmodule BB.Safety do
       )
   """
   defdelegate register(module, opts), to: BB.Safety.Controller
+
+  @doc """
+  Report a hardware error from a component.
+
+  This function should be called by controllers, actuators, or sensors when
+  they detect a hardware error condition. The behaviour depends on the robot's
+  `auto_disarm_on_error` setting:
+
+  - If `true` (default): The robot is automatically disarmed
+  - If `false`: The error is published but no automatic action is taken
+
+  In both cases, a `BB.Safety.HardwareError` message is published to
+  `[:safety, :error]` for subscribers to handle.
+
+  ## Parameters
+
+  - `robot_module` - The robot module
+  - `path` - Path to the component reporting the error (e.g., `[:dynamixel, :servo_1]`)
+  - `error` - Component-specific error details
+
+  ## Example
+
+      # In a controller detecting servo overheating:
+      BB.Safety.report_error(MyRobot, [:dynamixel, :servo_1], {:hardware_error, 0x04})
+
+  ## Customising Error Handling
+
+  To implement custom error handling instead of auto-disarm:
+
+      defmodule MyRobot do
+        use BB
+
+        settings do
+          auto_disarm_on_error false
+        end
+      end
+
+      # Then subscribe to error events:
+      BB.subscribe(MyRobot, [:safety, :error])
+  """
+  defdelegate report_error(robot_module, path, error), to: BB.Safety.Controller
 end

--- a/lib/bb/safety/hardware_error.ex
+++ b/lib/bb/safety/hardware_error.ex
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Safety.HardwareError do
+  @moduledoc """
+  Payload type for hardware error events.
+
+  Published to `[:safety, :error]` when a component reports a hardware error.
+  Subscribe to receive notifications of hardware failures.
+
+  ## Example
+
+      BB.subscribe(MyRobot, [:safety, :error])
+
+      # Receive:
+      # {:bb, [:safety, :error], %BB.Message{payload: %BB.Safety.HardwareError{...}}}
+  """
+
+  defstruct [:path, :error]
+
+  use BB.Message,
+    schema: [
+      path: [
+        type: {:list, :atom},
+        required: true,
+        doc: "Path to the component that reported the error"
+      ],
+      error: [
+        type: :any,
+        required: true,
+        doc: "The error details (component-specific)"
+      ]
+    ]
+
+  @type t :: %__MODULE__{
+          path: [atom],
+          error: term
+        }
+end


### PR DESCRIPTION
## Summary

- Add `BB.Safety.report_error/3` API for controllers and actuators to report hardware errors
- Add `auto_disarm_on_error` setting (default: `true`) to control automatic disarm on error
- Add `BB.Safety.HardwareError` message type published to `[:safety, :error]`
- Update safety documentation with hardware error reporting section and examples

## Motivation

Controllers monitoring hardware (like servo drivers) need a way to report hardware errors to the safety system. By default, hardware errors should trigger a safe shutdown, but advanced users may want custom error handling.

## Changes

**New files:**
- `lib/bb/safety/hardware_error.ex` - Message type for error events

**Modified files:**
- `lib/bb/dsl.ex` - Added `auto_disarm_on_error` setting
- `lib/bb/dsl/info.ex` - Exposed new setting
- `lib/bb/safety.ex` - Added `report_error/3` API
- `lib/bb/safety/controller.ex` - Implemented error reporting logic
- `documentation/topics/safety.md` - Added documentation section
- `test/bb/safety/controller_test.exs` - Added tests

## Test plan

- [x] Tests for `report_error/3` publishing error messages
- [x] Tests for auto-disarm when `auto_disarm_on_error` is true
- [x] Tests for no auto-disarm when setting is false
- [x] All existing tests pass
- [x] `mix check --no-retry` passes