### PR TITLE
Trapezoidal motion profile and accurate position tracking in `BB.Sim.Actuator`

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 spark_locals_without_parens = [
+  acceleration: 1,
   actuator: 2,
   actuator: 3,
   allowed_states: 1,

--- a/documentation/dsls/DSL-BB.md
+++ b/documentation/dsls/DSL-BB.md
@@ -816,6 +816,7 @@ Limits applied to joint movement
 | [`velocity`](#topology-joint-limit-velocity){: #topology-joint-limit-velocity .spark-required} | `any` |  | Maximum velocity - both positive and negative - that can be commanded to the joint |
 | [`lower`](#topology-joint-limit-lower){: #topology-joint-limit-lower } | `any` |  | The lower joint limit |
 | [`upper`](#topology-joint-limit-upper){: #topology-joint-limit-upper } | `any` |  | The upper joint limit |
+| [`acceleration`](#topology-joint-limit-acceleration){: #topology-joint-limit-acceleration } | `any` |  | Maximum acceleration - both positive and negative - that can be commanded to the joint. Optional; when omitted, motion timing assumes a rectangular velocity profile. |
 
 
 

--- a/lib/bb/dsl.ex
+++ b/lib/bb/dsl.ex
@@ -149,6 +149,17 @@ defmodule BB.Dsl do
            ]},
         doc: "Maximum velocity - both positive and negative - that can be commanded to the joint",
         required: true
+      ],
+      acceleration: [
+        type:
+          {:or,
+           [
+             unit_type(compatible: :degree_per_square_second),
+             unit_type(compatible: :meter_per_square_second)
+           ]},
+        doc:
+          "Maximum acceleration - both positive and negative - that can be commanded to the joint. Optional; when omitted, motion timing assumes a rectangular velocity profile.",
+        required: false
       ]
     ]
   }
@@ -992,6 +1003,7 @@ defmodule BB.Dsl do
     transformers: [
       __MODULE__.DefaultNameTransformer,
       __MODULE__.TopologyTransformer,
+      __MODULE__.ValidateLimitUnitsTransformer,
       __MODULE__.SupervisorTransformer,
       __MODULE__.UniquenessTransformer,
       __MODULE__.RobotTransformer,

--- a/lib/bb/dsl/limit.ex
+++ b/lib/bb/dsl/limit.ex
@@ -11,7 +11,8 @@ defmodule BB.Dsl.Limit do
             lower: nil,
             upper: nil,
             effort: nil,
-            velocity: nil
+            velocity: nil,
+            acceleration: nil
 
   alias Spark.Dsl.Entity
 
@@ -21,6 +22,7 @@ defmodule BB.Dsl.Limit do
           lower: nil | Cldr.Unit.t(),
           upper: nil | Cldr.Unit.t(),
           effort: Cldr.Unit.t(),
-          velocity: Cldr.Unit.t()
+          velocity: Cldr.Unit.t(),
+          acceleration: nil | Cldr.Unit.t()
         }
 end

--- a/lib/bb/dsl/validate_limit_units_transformer.ex
+++ b/lib/bb/dsl/validate_limit_units_transformer.ex
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Dsl.ValidateLimitUnitsTransformer do
+  @moduledoc """
+  Validates that the units provided in a joint's `limit` block are compatible
+  with the joint's type.
+
+  The DSL schema permits both angular and linear units in `limit` fields so
+  that the same entity definition serves rotational and translational joints.
+  This transformer rejects the wrong-axis combinations before the
+  `BB.Dsl.RobotTransformer` attempts unit conversion:
+
+  - Rotational joints (`:revolute`, `:continuous`) require angular units
+    (`degree`, `degree_per_second`, `newton_meter`, `degree_per_square_second`).
+  - Linear joints (`:prismatic`) require linear units (`meter`,
+    `meter_per_second`, `newton`, `meter_per_square_second`).
+
+  Joints without degrees of freedom (`:fixed`, `:floating`, `:planar`) are not
+  checked — they typically have no `limit` block at all.
+  """
+
+  use Spark.Dsl.Transformer
+
+  alias BB.Cldr.Unit
+  alias BB.Dsl.{Joint, Limit, Link, ParamRef}
+  alias Spark.Dsl.Transformer
+  alias Spark.Error.DslError
+
+  @rotational_types [:revolute, :continuous]
+  @linear_types [:prismatic]
+
+  @rotational_units %{
+    lower: :degree,
+    upper: :degree,
+    velocity: :degree_per_second,
+    effort: :newton_meter,
+    acceleration: :degree_per_square_second
+  }
+
+  @linear_units %{
+    lower: :meter,
+    upper: :meter,
+    velocity: :meter_per_second,
+    effort: :newton,
+    acceleration: :meter_per_square_second
+  }
+
+  @doc false
+  @impl true
+  def after?(BB.Dsl.TopologyTransformer), do: true
+  def after?(_), do: false
+
+  @doc false
+  @impl true
+  def before?(BB.Dsl.RobotTransformer), do: true
+  def before?(_), do: false
+
+  @doc false
+  @impl true
+  def transform(dsl) do
+    module = Transformer.get_persisted(dsl, :module)
+
+    dsl
+    |> Transformer.get_entities([:topology])
+    |> walk_joints([])
+    |> Enum.reduce_while({:ok, dsl}, fn {joint, path}, {:ok, dsl} ->
+      case validate_joint(joint, path, module) do
+        :ok -> {:cont, {:ok, dsl}}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp walk_joints(entities, path_prefix) do
+    Enum.flat_map(entities, fn
+      %Link{} = link ->
+        link_path = path_prefix ++ [:link, link.name]
+        Enum.flat_map(link.joints, &walk_joints([&1], link_path))
+
+      %Joint{} = joint ->
+        joint_path = path_prefix ++ [:joint, joint.name]
+        nested = if joint.link, do: walk_joints([joint.link], path_prefix), else: []
+        [{joint, joint_path} | nested]
+
+      _ ->
+        []
+    end)
+  end
+
+  defp validate_joint(%Joint{limit: nil}, _path, _module), do: :ok
+
+  defp validate_joint(%Joint{type: type, limit: %Limit{} = limit}, path, module)
+       when type in @rotational_types do
+    check_fields(limit, @rotational_units, path, module, type)
+  end
+
+  defp validate_joint(%Joint{type: type, limit: %Limit{} = limit}, path, module)
+       when type in @linear_types do
+    check_fields(limit, @linear_units, path, module, type)
+  end
+
+  defp validate_joint(%Joint{}, _path, _module), do: :ok
+
+  defp check_fields(limit, expected_units, path, module, joint_type) do
+    Enum.reduce_while(expected_units, :ok, fn {field, expected_unit}, :ok ->
+      case Map.get(limit, field) do
+        nil ->
+          {:cont, :ok}
+
+        %ParamRef{} ->
+          {:cont, :ok}
+
+        %Cldr.Unit{} = value ->
+          if Unit.compatible?(value, expected_unit) do
+            {:cont, :ok}
+          else
+            {:halt, {:error, mismatch_error(module, path, field, value, expected_unit, joint_type)}}
+          end
+
+        _ ->
+          {:cont, :ok}
+      end
+    end)
+  end
+
+  defp mismatch_error(module, path, field, value, expected_unit, joint_type) do
+    DslError.exception(
+      module: module,
+      path: path ++ [:limit, field],
+      message: """
+      The unit `#{value.unit}` provided for `#{field}` is not compatible with a `#{joint_type}` joint.
+
+      Expected a unit compatible with `#{expected_unit}`.
+      """
+    )
+  end
+end

--- a/lib/bb/dsl/validate_limit_units_transformer.ex
+++ b/lib/bb/dsl/validate_limit_units_transformer.ex
@@ -105,25 +105,24 @@ defmodule BB.Dsl.ValidateLimitUnitsTransformer do
 
   defp check_fields(limit, expected_units, path, module, joint_type) do
     Enum.reduce_while(expected_units, :ok, fn {field, expected_unit}, :ok ->
-      case Map.get(limit, field) do
-        nil ->
-          {:cont, :ok}
-
-        %ParamRef{} ->
-          {:cont, :ok}
-
-        %Cldr.Unit{} = value ->
-          if Unit.compatible?(value, expected_unit) do
-            {:cont, :ok}
-          else
-            {:halt, {:error, mismatch_error(module, path, field, value, expected_unit, joint_type)}}
-          end
-
-        _ ->
-          {:cont, :ok}
-      end
+      check_field(Map.get(limit, field), field, expected_unit, path, module, joint_type)
     end)
   end
+
+  defp check_field(nil, _field, _expected_unit, _path, _module, _joint_type), do: {:cont, :ok}
+
+  defp check_field(%ParamRef{}, _field, _expected_unit, _path, _module, _joint_type),
+    do: {:cont, :ok}
+
+  defp check_field(%Cldr.Unit{} = value, field, expected_unit, path, module, joint_type) do
+    if Unit.compatible?(value, expected_unit) do
+      {:cont, :ok}
+    else
+      {:halt, {:error, mismatch_error(module, path, field, value, expected_unit, joint_type)}}
+    end
+  end
+
+  defp check_field(_value, _field, _expected_unit, _path, _module, _joint_type), do: {:cont, :ok}
 
   defp mismatch_error(module, path, field, value, expected_unit, joint_type) do
     DslError.exception(

--- a/lib/bb/message/actuator/begin_motion.ex
+++ b/lib/bb/message/actuator/begin_motion.ex
@@ -16,6 +16,13 @@ defmodule BB.Message.Actuator.BeginMotion do
   - `expected_arrival` - When motion should complete (monotonic milliseconds)
   - `command_id` - Optional correlation ID from the originating command
   - `command_type` - Optional type of command that initiated this motion
+  - `acceleration` - Optional acceleration magnitude (rad/s² or m/s²) used when
+    the motion follows a trapezoidal/triangular velocity profile. `nil`
+    indicates a rectangular profile and is the legacy behaviour.
+  - `peak_velocity` - Optional peak velocity magnitude (rad/s or m/s) achieved
+    during the motion. Paired with `acceleration` to fully describe a
+    trapezoidal or triangular profile. `nil` falls back to easing-based
+    interpolation.
 
   ## Example
 
@@ -33,7 +40,15 @@ defmodule BB.Message.Actuator.BeginMotion do
 
   @command_types [:position, :velocity, :effort, :trajectory]
 
-  defstruct [:initial_position, :target_position, :expected_arrival, :command_id, :command_type]
+  defstruct [
+    :initial_position,
+    :target_position,
+    :expected_arrival,
+    :command_id,
+    :command_type,
+    :acceleration,
+    :peak_velocity
+  ]
 
   use BB.Message,
     schema: [
@@ -57,6 +72,18 @@ defmodule BB.Message.Actuator.BeginMotion do
         type: {:in, @command_types},
         required: false,
         doc: "Type of command that initiated this motion"
+      ],
+      acceleration: [
+        type: {:or, [:float, nil]},
+        required: false,
+        doc:
+          "Acceleration magnitude (rad/s² or m/s²) for trapezoidal profiles. Nil means rectangular profile."
+      ],
+      peak_velocity: [
+        type: {:or, [:float, nil]},
+        required: false,
+        doc:
+          "Peak velocity magnitude (rad/s or m/s) during the motion. Paired with `acceleration`."
       ]
     ]
 
@@ -67,6 +94,8 @@ defmodule BB.Message.Actuator.BeginMotion do
           target_position: float(),
           expected_arrival: integer(),
           command_id: reference() | nil,
-          command_type: command_type() | nil
+          command_type: command_type() | nil,
+          acceleration: float() | nil,
+          peak_velocity: float() | nil
         }
 end

--- a/lib/bb/robot/builder.ex
+++ b/lib/bb/robot/builder.ex
@@ -285,8 +285,23 @@ defmodule BB.Robot.Builder do
         [:limits, :effort]
       )
 
-    limits = %{lower: lower, upper: upper, velocity: velocity, effort: effort}
-    subs = lower_subs ++ upper_subs ++ velocity_subs ++ effort_subs
+    {acceleration, acceleration_subs} =
+      convert_value_with_ref_or_nil(
+        limit.acceleration,
+        &Units.to_radians_per_square_second_or_nil/1,
+        joint_name,
+        [:limits, :acceleration]
+      )
+
+    limits = %{
+      lower: lower,
+      upper: upper,
+      velocity: velocity,
+      effort: effort,
+      acceleration: acceleration
+    }
+
+    subs = lower_subs ++ upper_subs ++ velocity_subs ++ effort_subs ++ acceleration_subs
     {limits, subs}
   end
 
@@ -318,8 +333,23 @@ defmodule BB.Robot.Builder do
     {effort, effort_subs} =
       convert_value_with_ref(limit.effort, &Units.to_newton/1, joint_name, [:limits, :effort])
 
-    limits = %{lower: lower, upper: upper, velocity: velocity, effort: effort}
-    subs = lower_subs ++ upper_subs ++ velocity_subs ++ effort_subs
+    {acceleration, acceleration_subs} =
+      convert_value_with_ref_or_nil(
+        limit.acceleration,
+        &Units.to_meters_per_square_second_or_nil/1,
+        joint_name,
+        [:limits, :acceleration]
+      )
+
+    limits = %{
+      lower: lower,
+      upper: upper,
+      velocity: velocity,
+      effort: effort,
+      acceleration: acceleration
+    }
+
+    subs = lower_subs ++ upper_subs ++ velocity_subs ++ effort_subs ++ acceleration_subs
     {limits, subs}
   end
 
@@ -340,8 +370,23 @@ defmodule BB.Robot.Builder do
         [:limits, :effort]
       )
 
-    limits = %{lower: nil, upper: nil, velocity: velocity, effort: effort}
-    subs = velocity_subs ++ effort_subs
+    {acceleration, acceleration_subs} =
+      convert_value_with_ref_or_nil(
+        limit.acceleration,
+        &Units.to_radians_per_square_second_or_nil/1,
+        joint_name,
+        [:limits, :acceleration]
+      )
+
+    limits = %{
+      lower: nil,
+      upper: nil,
+      velocity: velocity,
+      effort: effort,
+      acceleration: acceleration
+    }
+
+    subs = velocity_subs ++ effort_subs ++ acceleration_subs
     {limits, subs}
   end
 

--- a/lib/bb/robot/joint.ex
+++ b/lib/bb/robot/joint.ex
@@ -61,17 +61,20 @@ defmodule BB.Robot.Joint do
   - `lower`/`upper`: angle limits in radians
   - `velocity`: max angular velocity in rad/s
   - `effort`: max torque in N·m
+  - `acceleration`: max angular acceleration in rad/s² (optional)
 
   For prismatic joints:
   - `lower`/`upper`: position limits in meters
   - `velocity`: max linear velocity in m/s
   - `effort`: max effort in N·m (as defined in DSL)
+  - `acceleration`: max linear acceleration in m/s² (optional)
   """
   @type limits :: %{
           lower: float() | nil,
           upper: float() | nil,
           velocity: float(),
-          effort: float()
+          effort: float(),
+          acceleration: float() | nil
         }
 
   @typedoc """

--- a/lib/bb/robot/units.ex
+++ b/lib/bb/robot/units.ex
@@ -167,6 +167,38 @@ defmodule BB.Robot.Units do
   end
 
   @doc """
+  Convert a linear acceleration unit to metres per second squared (float).
+
+  ## Examples
+
+      iex> import BB.Unit
+      iex> BB.Robot.Units.to_meters_per_square_second(~u(9.81 meter_per_square_second))
+      9.81
+  """
+  @spec to_meters_per_square_second(Cldr.Unit.t()) :: float()
+  def to_meters_per_square_second(%Cldr.Unit{} = unit) do
+    unit
+    |> Cldr.Unit.convert!(:meter_per_square_second)
+    |> extract_float()
+  end
+
+  @doc """
+  Convert an angular acceleration unit to radians per second squared (float).
+
+  ## Examples
+
+      iex> import BB.Unit
+      iex> BB.Robot.Units.to_radians_per_square_second(~u(360 degree_per_square_second))
+      :math.pi() * 2
+  """
+  @spec to_radians_per_square_second(Cldr.Unit.t()) :: float()
+  def to_radians_per_square_second(%Cldr.Unit{} = unit) do
+    unit
+    |> Cldr.Unit.convert!(:radian_per_square_second)
+    |> extract_float()
+  end
+
+  @doc """
   Convert a linear damping coefficient to N·s/m (float).
 
   ## Examples
@@ -247,6 +279,14 @@ defmodule BB.Robot.Units do
   @spec to_radians_per_second_or_nil(Cldr.Unit.t() | nil) :: float() | nil
   def to_radians_per_second_or_nil(nil), do: nil
   def to_radians_per_second_or_nil(unit), do: to_radians_per_second(unit)
+
+  @spec to_meters_per_square_second_or_nil(Cldr.Unit.t() | nil) :: float() | nil
+  def to_meters_per_square_second_or_nil(nil), do: nil
+  def to_meters_per_square_second_or_nil(unit), do: to_meters_per_square_second(unit)
+
+  @spec to_radians_per_square_second_or_nil(Cldr.Unit.t() | nil) :: float() | nil
+  def to_radians_per_square_second_or_nil(nil), do: nil
+  def to_radians_per_square_second_or_nil(unit), do: to_radians_per_square_second(unit)
 
   @spec to_linear_damping_or_nil(Cldr.Unit.t() | nil) :: float() | nil
   def to_linear_damping_or_nil(nil), do: nil

--- a/lib/bb/sensor/open_loop_position_estimator.ex
+++ b/lib/bb/sensor/open_loop_position_estimator.ex
@@ -159,6 +159,8 @@ defmodule BB.Sensor.OpenLoopPositionEstimator do
       target_position: nil,
       expected_arrival: nil,
       command_time: nil,
+      acceleration: nil,
+      peak_velocity: nil,
       last_published: nil,
       tick_ref: nil
     }
@@ -185,7 +187,9 @@ defmodule BB.Sensor.OpenLoopPositionEstimator do
       | initial_position: cmd.initial_position,
         target_position: cmd.target_position,
         expected_arrival: cmd.expected_arrival,
-        command_time: now
+        command_time: now,
+        acceleration: cmd.acceleration,
+        peak_velocity: cmd.peak_velocity
     }
 
     state =
@@ -251,13 +255,58 @@ defmodule BB.Sensor.OpenLoopPositionEstimator do
   defp interpolate_position(state, now) do
     total_duration = state.expected_arrival - state.command_time
 
-    if total_duration <= 0 do
+    cond do
+      total_duration <= 0 ->
+        state.target_position
+
+      state.acceleration != nil and state.peak_velocity != nil ->
+        trapezoidal_position(state, now, total_duration)
+
+      true ->
+        elapsed = now - state.command_time
+        change = state.target_position - state.initial_position
+        apply(Ease, state.easing, [elapsed, state.initial_position, change, total_duration])
+    end
+  end
+
+  defp trapezoidal_position(state, now, total_duration_ms) do
+    distance = state.target_position - state.initial_position
+    direction = if distance >= 0, do: 1.0, else: -1.0
+    abs_distance = abs(distance)
+    a = state.acceleration
+    v = state.peak_velocity
+
+    if a == 0.0 or v == 0.0 or abs_distance == 0.0 do
       state.target_position
     else
-      elapsed = now - state.command_time
-      change = state.target_position - state.initial_position
+      t_accel_s = v / a
+      accel_duration_ms = round(t_accel_s * 1000)
+      elapsed_ms = now - state.command_time
+      total_ms = total_duration_ms
+      signed_accel = direction * a
+      signed_v = direction * v
 
-      apply(Ease, state.easing, [elapsed, state.initial_position, change, total_duration])
+      cond do
+        elapsed_ms <= 0 ->
+          state.initial_position
+
+        elapsed_ms >= total_ms ->
+          state.target_position
+
+        elapsed_ms < accel_duration_ms ->
+          t = elapsed_ms / 1000
+          state.initial_position + 0.5 * signed_accel * t * t
+
+        elapsed_ms > total_ms - accel_duration_ms ->
+          t_remaining = (total_ms - elapsed_ms) / 1000
+          state.target_position - 0.5 * signed_accel * t_remaining * t_remaining
+
+        true ->
+          accel_s = accel_duration_ms / 1000
+          cruise_elapsed_s = (elapsed_ms - accel_duration_ms) / 1000
+          accel_distance = 0.5 * signed_accel * accel_s * accel_s
+          state.initial_position + accel_distance + signed_v * cruise_elapsed_s
+      end
     end
   end
 

--- a/lib/bb/sensor/open_loop_position_estimator.ex
+++ b/lib/bb/sensor/open_loop_position_estimator.ex
@@ -271,42 +271,44 @@ defmodule BB.Sensor.OpenLoopPositionEstimator do
 
   defp trapezoidal_position(state, now, total_duration_ms) do
     distance = state.target_position - state.initial_position
-    direction = if distance >= 0, do: 1.0, else: -1.0
-    abs_distance = abs(distance)
     a = state.acceleration
     v = state.peak_velocity
 
-    if a == 0.0 or v == 0.0 or abs_distance == 0.0 do
-      state.target_position
-    else
-      t_accel_s = v / a
-      accel_duration_ms = round(t_accel_s * 1000)
-      elapsed_ms = now - state.command_time
-      total_ms = total_duration_ms
-      signed_accel = direction * a
-      signed_v = direction * v
+    cond do
+      a == 0.0 -> state.target_position
+      v == 0.0 -> state.target_position
+      distance == 0.0 -> state.target_position
+      true -> trapezoidal_phase(state, now, total_duration_ms, distance, a, v)
+    end
+  end
 
-      cond do
-        elapsed_ms <= 0 ->
-          state.initial_position
+  defp trapezoidal_phase(state, now, total_ms, distance, a, v) do
+    direction = if distance >= 0, do: 1.0, else: -1.0
+    accel_duration_ms = round(v / a * 1000)
+    elapsed_ms = now - state.command_time
+    signed_accel = direction * a
+    signed_v = direction * v
 
-        elapsed_ms >= total_ms ->
-          state.target_position
+    cond do
+      elapsed_ms <= 0 ->
+        state.initial_position
 
-        elapsed_ms < accel_duration_ms ->
-          t = elapsed_ms / 1000
-          state.initial_position + 0.5 * signed_accel * t * t
+      elapsed_ms >= total_ms ->
+        state.target_position
 
-        elapsed_ms > total_ms - accel_duration_ms ->
-          t_remaining = (total_ms - elapsed_ms) / 1000
-          state.target_position - 0.5 * signed_accel * t_remaining * t_remaining
+      elapsed_ms < accel_duration_ms ->
+        t = elapsed_ms / 1000
+        state.initial_position + 0.5 * signed_accel * t * t
 
-        true ->
-          accel_s = accel_duration_ms / 1000
-          cruise_elapsed_s = (elapsed_ms - accel_duration_ms) / 1000
-          accel_distance = 0.5 * signed_accel * accel_s * accel_s
-          state.initial_position + accel_distance + signed_v * cruise_elapsed_s
-      end
+      elapsed_ms > total_ms - accel_duration_ms ->
+        t_remaining = (total_ms - elapsed_ms) / 1000
+        state.target_position - 0.5 * signed_accel * t_remaining * t_remaining
+
+      true ->
+        accel_s = accel_duration_ms / 1000
+        cruise_elapsed_s = (elapsed_ms - accel_duration_ms) / 1000
+        accel_distance = 0.5 * signed_accel * accel_s * accel_s
+        state.initial_position + accel_distance + signed_v * cruise_elapsed_s
     end
   end
 

--- a/lib/bb/sim/actuator.ex
+++ b/lib/bb/sim/actuator.ex
@@ -33,7 +33,17 @@ defmodule BB.Sim.Actuator do
   alias BB.PubSub
   alias BB.Robot
 
-  defstruct [:bb, :joint, :current_position, :name, :joint_name]
+  defstruct [
+    :bb,
+    :joint,
+    :name,
+    :joint_name,
+    # Stored trajectory segment so a new command can compute the joint's actual
+    # current position (vs. its last commanded target). When `segment` is nil
+    # the joint is stationary at `current_position`.
+    :current_position,
+    :segment
+  ]
 
   @impl BB.Actuator
   def disarm(_opts), do: :ok
@@ -52,6 +62,7 @@ defmodule BB.Sim.Actuator do
       bb: bb,
       joint: joint,
       current_position: initial_position,
+      segment: nil,
       name: name,
       joint_name: joint_name
     }
@@ -96,15 +107,19 @@ defmodule BB.Sim.Actuator do
   end
 
   defp do_set_position(target_position, command_id, state) do
+    now = System.monotonic_time(:millisecond)
+    actual_current = position_at(state, now)
     clamped = clamp_position(target_position, state.joint)
-    travel_time_ms = calculate_travel_time(state.current_position, clamped, state.joint)
-    expected_arrival = System.monotonic_time(:millisecond) + travel_time_ms
+
+    profile = build_profile(actual_current, clamped, state.joint, now)
 
     message_opts = [
-      initial_position: state.current_position,
+      initial_position: actual_current,
       target_position: clamped,
-      expected_arrival: expected_arrival,
-      command_type: :position
+      expected_arrival: profile.expected_arrival,
+      command_type: :position,
+      acceleration: profile.acceleration,
+      peak_velocity: profile.peak_velocity
     ]
 
     message_opts =
@@ -117,8 +132,165 @@ defmodule BB.Sim.Actuator do
     {:ok, message} = Message.new(BeginMotion, state.joint_name, message_opts)
     PubSub.publish(state.bb.robot, [:actuator | state.bb.path], message)
 
-    %{state | current_position: clamped}
+    %{state | current_position: clamped, segment: profile.segment}
   end
+
+  # Returns the joint's actual current position, taking into account any
+  # in-flight motion segment.
+  defp position_at(%{segment: nil, current_position: pos}, _now), do: pos
+
+  defp position_at(%{segment: segment}, now) do
+    interpolate_segment(segment, now)
+  end
+
+  defp interpolate_segment(%{total_duration_ms: 0} = segment, _now), do: segment.target
+
+  defp interpolate_segment(%{accel_duration_ms: 0} = segment, now) do
+    # Rectangular profile fallback (no acceleration limit).
+    elapsed = now - segment.command_time
+    total = segment.total_duration_ms
+
+    cond do
+      elapsed <= 0 -> segment.initial
+      elapsed >= total -> segment.target
+      true -> segment.initial + (segment.target - segment.initial) * (elapsed / total)
+    end
+  end
+
+  defp interpolate_segment(segment, now) do
+    elapsed_ms = now - segment.command_time
+    total_ms = segment.total_duration_ms
+    accel_ms = segment.accel_duration_ms
+
+    cond do
+      elapsed_ms <= 0 ->
+        segment.initial
+
+      elapsed_ms >= total_ms ->
+        segment.target
+
+      elapsed_ms < accel_ms ->
+        # Accel phase: ½ a t²
+        t = elapsed_ms / 1000
+        segment.initial + 0.5 * segment.signed_accel * t * t
+
+      elapsed_ms > total_ms - accel_ms ->
+        # Decel phase: mirror of accel from the end.
+        t_remaining = (total_ms - elapsed_ms) / 1000
+        segment.target - 0.5 * segment.signed_accel * t_remaining * t_remaining
+
+      true ->
+        # Cruise: linear at peak velocity from the end of accel.
+        accel_s = accel_ms / 1000
+        cruise_elapsed_s = (elapsed_ms - accel_ms) / 1000
+        accel_distance = 0.5 * segment.signed_accel * accel_s * accel_s
+        segment.initial + accel_distance + segment.signed_peak_velocity * cruise_elapsed_s
+    end
+  end
+
+  defp build_profile(from, to, joint, now) do
+    velocity = velocity_limit(joint)
+    acceleration = acceleration_limit(joint)
+    distance = to - from
+    abs_distance = abs(distance)
+    direction = if distance >= 0, do: 1.0, else: -1.0
+
+    cond do
+      abs_distance == 0.0 ->
+        %{
+          expected_arrival: now,
+          acceleration: nil,
+          peak_velocity: nil,
+          segment: %{
+            initial: from,
+            target: to,
+            command_time: now,
+            total_duration_ms: 0,
+            accel_duration_ms: 0,
+            signed_accel: 0.0,
+            signed_peak_velocity: 0.0
+          }
+        }
+
+      velocity == nil ->
+        %{
+          expected_arrival: now,
+          acceleration: nil,
+          peak_velocity: nil,
+          segment: %{
+            initial: from,
+            target: to,
+            command_time: now,
+            total_duration_ms: 0,
+            accel_duration_ms: 0,
+            signed_accel: 0.0,
+            signed_peak_velocity: 0.0
+          }
+        }
+
+      acceleration == nil ->
+        # Rectangular profile (existing behaviour).
+        total_ms = round(abs_distance / velocity * 1000)
+
+        %{
+          expected_arrival: now + total_ms,
+          acceleration: nil,
+          peak_velocity: nil,
+          segment: %{
+            initial: from,
+            target: to,
+            command_time: now,
+            total_duration_ms: total_ms,
+            accel_duration_ms: 0,
+            signed_accel: 0.0,
+            signed_peak_velocity: direction * velocity
+          }
+        }
+
+      true ->
+        # Trapezoidal/triangular profile.
+        t_accel = velocity / acceleration
+        d_accel = 0.5 * acceleration * t_accel * t_accel
+
+        {accel_s, total_s, peak_v} =
+          if abs_distance >= 2 * d_accel do
+            # Trapezoid: accel ramp, cruise, decel ramp.
+            cruise_s = (abs_distance - 2 * d_accel) / velocity
+            {t_accel, 2 * t_accel + cruise_s, velocity}
+          else
+            # Triangle: never reach v_max.
+            peak_v = :math.sqrt(abs_distance * acceleration)
+            t = peak_v / acceleration
+            {t, 2 * t, peak_v}
+          end
+
+        total_ms = round(total_s * 1000)
+        accel_ms = round(accel_s * 1000)
+
+        %{
+          expected_arrival: now + total_ms,
+          acceleration: acceleration,
+          peak_velocity: peak_v,
+          segment: %{
+            initial: from,
+            target: to,
+            command_time: now,
+            total_duration_ms: total_ms,
+            accel_duration_ms: accel_ms,
+            signed_accel: direction * acceleration,
+            signed_peak_velocity: direction * peak_v
+          }
+        }
+    end
+  end
+
+  defp velocity_limit(nil), do: nil
+  defp velocity_limit(%{limits: nil}), do: nil
+  defp velocity_limit(%{limits: %{velocity: v}}), do: v
+
+  defp acceleration_limit(nil), do: nil
+  defp acceleration_limit(%{limits: nil}), do: nil
+  defp acceleration_limit(%{limits: limits}), do: Map.get(limits, :acceleration)
 
   defp calculate_initial_position(nil), do: 0.0
 
@@ -144,13 +316,4 @@ defmodule BB.Sim.Actuator do
 
   defp clamp_upper(position, nil), do: position
   defp clamp_upper(position, upper), do: min(position, upper)
-
-  defp calculate_travel_time(_from, _to, nil), do: 0
-  defp calculate_travel_time(_from, _to, %{limits: nil}), do: 0
-  defp calculate_travel_time(_from, _to, %{limits: %{velocity: nil}}), do: 0
-
-  defp calculate_travel_time(from, to, %{limits: %{velocity: velocity}}) do
-    distance = abs(to - from)
-    round(distance / velocity * 1000)
-  end
 end

--- a/test/bb/dsl/validate_limit_units_transformer_test.exs
+++ b/test/bb/dsl/validate_limit_units_transformer_test.exs
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Dsl.ValidateLimitUnitsTransformerTest do
+  use ExUnit.Case, async: true
+
+  describe "revolute joints" do
+    test "accepts angular units" do
+      defmodule RevoluteAngular do
+        use BB
+
+        topology do
+          link :base do
+            joint :j do
+              type :revolute
+
+              limit do
+                lower(~u(-90 degree))
+                upper(~u(90 degree))
+                effort(~u(10 newton_meter))
+                velocity(~u(180 degree_per_second))
+                acceleration(~u(360 degree_per_square_second))
+              end
+
+              link :child
+            end
+          end
+        end
+      end
+
+      assert RevoluteAngular.robot()
+    end
+
+    test "rejects linear velocity on a revolute joint (schema-level rejection)" do
+      # The schema already rejects this via `:or` validation before this
+      # transformer runs. Test verifies that bad unit/joint combinations are
+      # caught somewhere in the pipeline.
+      assert_raise Spark.Error.DslError, fn ->
+        defmodule RevoluteLinearVelocity do
+          use BB
+
+          topology do
+            link :base do
+              joint :j do
+                type :revolute
+
+                limit do
+                  effort(~u(10 newton_meter))
+                  velocity(~u(0.5 meter_per_second))
+                end
+
+                link :child
+              end
+            end
+          end
+        end
+      end
+    end
+
+    test "rejects linear acceleration on a revolute joint" do
+      assert_raise Spark.Error.DslError,
+                   ~r/`meter_per_square_second`.*not compatible with a `revolute`/sm,
+                   fn ->
+                     defmodule RevoluteLinearAccel do
+                       use BB
+
+                       topology do
+                         link :base do
+                           joint :j do
+                             type :revolute
+
+                             limit do
+                               effort(~u(10 newton_meter))
+                               velocity(~u(180 degree_per_second))
+                               acceleration(~u(1 meter_per_square_second))
+                             end
+
+                             link :child
+                           end
+                         end
+                       end
+                     end
+                   end
+    end
+  end
+
+  describe "prismatic joints" do
+    test "accepts linear units" do
+      defmodule PrismaticLinear do
+        use BB
+
+        topology do
+          link :base do
+            joint :j do
+              type :prismatic
+
+              limit do
+                lower(~u(0 meter))
+                upper(~u(1 meter))
+                effort(~u(10 newton))
+                velocity(~u(0.5 meter_per_second))
+                acceleration(~u(2 meter_per_square_second))
+              end
+
+              link :child
+            end
+          end
+        end
+      end
+
+      assert PrismaticLinear.robot()
+    end
+
+    test "rejects angular acceleration on a prismatic joint" do
+      assert_raise Spark.Error.DslError,
+                   ~r/`degree_per_square_second`.*not compatible with a `prismatic`/sm,
+                   fn ->
+                     defmodule PrismaticAngularAccel do
+                       use BB
+
+                       topology do
+                         link :base do
+                           joint :j do
+                             type :prismatic
+
+                             limit do
+                               effort(~u(10 newton))
+                               velocity(~u(0.5 meter_per_second))
+                               acceleration(~u(360 degree_per_square_second))
+                             end
+
+                             link :child
+                           end
+                         end
+                       end
+                     end
+                   end
+    end
+  end
+
+  describe "fixed joints" do
+    test "do not enforce unit compatibility (no limit block expected)" do
+      defmodule FixedJoint do
+        use BB
+
+        topology do
+          link :base do
+            joint :j do
+              type :fixed
+              link :child
+            end
+          end
+        end
+      end
+
+      assert FixedJoint.robot()
+    end
+  end
+end

--- a/test/bb/sim/actuator_test.exs
+++ b/test/bb/sim/actuator_test.exs
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Sim.ActuatorTest do
+  use ExUnit.Case, async: false
+
+  alias BB.Message
+  alias BB.Message.Actuator.BeginMotion
+  alias BB.PubSub
+
+  describe "trapezoidal profile" do
+    defmodule TrapRobot do
+      @moduledoc false
+      use BB
+
+      topology do
+        link :base do
+          joint :shoulder do
+            type :revolute
+
+            limit do
+              lower(~u(-180 degree))
+              upper(~u(180 degree))
+              effort(~u(10 newton_meter))
+              velocity(~u(60 degree_per_second))
+              acceleration(~u(120 degree_per_square_second))
+            end
+
+            actuator :motor, ServoMotor
+            sensor :estimator, {BB.Sensor.OpenLoopPositionEstimator, actuator: :motor}
+
+            link :arm
+          end
+        end
+      end
+    end
+
+    test "BeginMotion carries acceleration and peak_velocity when limits include acceleration" do
+      Process.flag(:trap_exit, true)
+      {:ok, pid} = TrapRobot.start_link(simulation: :kinematic)
+
+      PubSub.subscribe(TrapRobot, [:actuator, :base, :shoulder, :motor])
+      :ok = BB.Safety.arm(TrapRobot)
+
+      # Move from 0 to 1.0 rad. v=60°/s≈1.047 rad/s, a=120°/s²≈2.094 rad/s².
+      # 2 * d_accel = 2 * 0.5 * a * (v/a)² = v²/a ≈ 0.524 rad.
+      # 1.0 > 0.524, so trapezoid; peak_velocity should equal velocity limit.
+      BB.Actuator.set_position!(TrapRobot, :motor, 1.0)
+
+      assert_receive {:bb, _path,
+                      %Message{
+                        payload: %BeginMotion{
+                          acceleration: a,
+                          peak_velocity: v
+                        }
+                      }},
+                     1000
+
+      assert_in_delta a, :math.pi() * 120 / 180, 0.001
+      assert_in_delta v, :math.pi() * 60 / 180, 0.001
+
+      Supervisor.stop(pid)
+    end
+
+    test "BeginMotion uses triangular profile for short moves" do
+      Process.flag(:trap_exit, true)
+      {:ok, pid} = TrapRobot.start_link(simulation: :kinematic)
+
+      PubSub.subscribe(TrapRobot, [:actuator, :base, :shoulder, :motor])
+      :ok = BB.Safety.arm(TrapRobot)
+
+      # Move 0.1 rad — below the cruise threshold of ~0.524 rad. Should be
+      # triangular: peak_velocity < velocity limit, peak = sqrt(d * a).
+      BB.Actuator.set_position!(TrapRobot, :motor, 0.1)
+
+      assert_receive {:bb, _path,
+                      %Message{
+                        payload: %BeginMotion{
+                          acceleration: a,
+                          peak_velocity: v
+                        }
+                      }},
+                     1000
+
+      assert_in_delta a, :math.pi() * 120 / 180, 0.001
+      expected_peak = :math.sqrt(0.1 * a)
+      assert_in_delta v, expected_peak, 0.001
+      assert v < :math.pi() * 60 / 180
+      Supervisor.stop(pid)
+    end
+  end
+
+  describe "rectangular fallback when acceleration is omitted" do
+    defmodule RectRobot do
+      @moduledoc false
+      use BB
+
+      topology do
+        link :base do
+          joint :shoulder do
+            type :revolute
+
+            limit do
+              lower(~u(-180 degree))
+              upper(~u(180 degree))
+              effort(~u(10 newton_meter))
+              velocity(~u(60 degree_per_second))
+            end
+
+            actuator :motor, ServoMotor
+            sensor :estimator, {BB.Sensor.OpenLoopPositionEstimator, actuator: :motor}
+
+            link :arm
+          end
+        end
+      end
+    end
+
+    test "BeginMotion has nil acceleration/peak_velocity when no acceleration limit" do
+      Process.flag(:trap_exit, true)
+      {:ok, pid} = RectRobot.start_link(simulation: :kinematic)
+
+      PubSub.subscribe(RectRobot, [:actuator, :base, :shoulder, :motor])
+      :ok = BB.Safety.arm(RectRobot)
+
+      BB.Actuator.set_position!(RectRobot, :motor, 1.0)
+
+      assert_receive {:bb, _path,
+                      %Message{
+                        payload: %BeginMotion{acceleration: nil, peak_velocity: nil}
+                      }},
+                     1000
+
+      Supervisor.stop(pid)
+    end
+  end
+
+  describe "actual current position under rapid commanding (Bug A)" do
+    defmodule RapidRobot do
+      @moduledoc false
+      use BB
+
+      topology do
+        link :base do
+          joint :shoulder do
+            type :revolute
+
+            limit do
+              lower(~u(-180 degree))
+              upper(~u(180 degree))
+              effort(~u(10 newton_meter))
+              velocity(~u(10 degree_per_second))
+            end
+
+            actuator :motor, ServoMotor
+            sensor :estimator, {BB.Sensor.OpenLoopPositionEstimator, actuator: :motor}
+
+            link :arm
+          end
+        end
+      end
+    end
+
+    test "second command uses interpolated current position as initial_position" do
+      Process.flag(:trap_exit, true)
+      {:ok, pid} = RapidRobot.start_link(simulation: :kinematic)
+
+      PubSub.subscribe(RapidRobot, [:actuator, :base, :shoulder, :motor])
+      :ok = BB.Safety.arm(RapidRobot)
+
+      # First move: 0 → 1.0 rad. Velocity = 10°/s ≈ 0.175 rad/s, so travel
+      # time ≈ 5.7s. We deliberately interrupt long before arrival.
+      BB.Actuator.set_position!(RapidRobot, :motor, 1.0)
+
+      assert_receive {:bb, _path, %Message{payload: %BeginMotion{}}}, 1000
+
+      Process.sleep(50)
+      # Second command: should NOT report initial_position=1.0 (the previous
+      # commanded target); it should report a position partway between 0 and
+      # 1.0 reflecting elapsed interpolation.
+      BB.Actuator.set_position!(RapidRobot, :motor, 0.5)
+
+      assert_receive {:bb, _path,
+                      %Message{
+                        payload: %BeginMotion{initial_position: actual_initial}
+                      }},
+                     1000
+
+      assert actual_initial > 0.0,
+             "Expected the actuator to have moved away from 0, got #{actual_initial}"
+
+      assert actual_initial < 1.0,
+             "Expected the actuator NOT to have reached the previous target (1.0), got #{actual_initial}"
+
+      Supervisor.stop(pid)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes two bugs in `BB.Sim.Actuator` that made simulated motion unrealistic:

- **No acceleration model.** Travel time was `distance / velocity` — a rectangular profile. There was also no place in the DSL to declare an acceleration limit. Real motors ramp.
- **`current_position` snapped to the target instantly on every command.** When commands arrived faster than motion completed, each subsequent `BeginMotion` reported the *previous target* as its `initial_position`. The estimator interpolated from that lie, producing visible position jumps and effectively bypassing the declared velocity limit.

## What changed

- New optional `acceleration` field on `BB.Dsl.Limit` and the joint `limit` DSL entity. Accepts `degree_per_square_second` for rotational joints and `meter_per_square_second` for prismatic. Nil falls back to the legacy rectangular profile, so existing robots are unaffected.
- `BB.Robot.Builder` converts the new field to SI and adds it to the joint `limits` map.
- New `BB.Dsl.ValidateLimitUnitsTransformer` rejects unit/joint-type mismatches at compile time (e.g. angular acceleration on a prismatic joint) with a clear `DslError`. Runs after `TopologyTransformer` and before `RobotTransformer` so it pre-empts the existing unit-conversion crash. Also picks up pre-existing fields (`lower`/`upper`/`effort`/`velocity`) that the schema's `:or` already rejects, just less helpfully.
- `BB.Message.Actuator.BeginMotion` carries two new optional fields: `acceleration` and `peak_velocity` (both magnitudes, SI). Nil for both preserves the easing-based interpolation contract. Servo drivers that don't compute these continue publishing without the fields and are unaffected.
- `BB.Sim.Actuator` now stores the active motion segment (initial, target, command time, total/accel durations, signed velocity and acceleration) and computes the joint's actual current position on each new command before publishing the next `BeginMotion`. Travel time is trapezoidal when an acceleration limit is declared (triangular for short moves), rectangular otherwise.
- `BB.Sensor.OpenLoopPositionEstimator` adds a trapezoidal interpolation branch when `BeginMotion` carries `acceleration` and `peak_velocity`. Otherwise falls back to the configured easing function unchanged.

## Backwards compatibility

The `acceleration` field is optional everywhere. Robots that don't declare one keep their current rectangular-profile behaviour. The new `BeginMotion` fields default to nil; the estimator's nil-fallback path is the existing easing-based code untouched. The four real-hardware servo driver packages (`bb_servo_feetech`, `bb_servo_pca9685`, `bb_servo_pigpio`, `bb_servo_robotis`) need no changes.

## Test plan

- [x] 4 new tests in `test/bb/sim/actuator_test.exs` covering trapezoid, triangle, rectangular fallback, and the rapid-commanding `initial_position` correctness.
- [x] 6 new tests in `test/bb/dsl/validate_limit_units_transformer_test.exs` covering revolute/prismatic accept-correct, reject-wrong-units, and fixed-joint pass-through.
- [x] Full suite green: 848 tests + 21 doctests.
- [x] Exercised end-to-end against `bb_example_so101` (`SIMULATE=1`) — a 0.5 rad shoulder command produces a `BeginMotion` with `acceleration: 12.57 rad/s²`, `peak_velocity: 2.507 rad/s` (triangular, sub-limit), and a 399 ms duration of visibly ramped motion in the dashboard.