### PR TITLE
improvement: add `BB.Igniter` helpers for add-on installers

### DIFF
--- a/lib/bb/igniter.ex
+++ b/lib/bb/igniter.ex
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if Code.ensure_loaded?(Igniter) do
+  defmodule BB.Igniter do
+    @moduledoc """
+    Helpers for writing Igniter installers for BB add-on packages.
+
+    Only available when `:igniter` is loaded.
+    """
+
+    alias Igniter.Code.Common
+    alias Igniter.Code.Function
+
+    @doc """
+    Returns the robot module to operate on.
+
+    Resolution order:
+
+      1. The `--robot` option from `igniter.args.options` (parsed module name)
+      2. `{AppPrefix}.Robot` (e.g. `MyApp.Robot`)
+
+    Add `robot: :string` (and ideally `aliases: [r: :robot]`) to your task's
+    schema to support the `--robot` flag.
+    """
+    @spec robot_module(Igniter.t()) :: module()
+    def robot_module(igniter) do
+      case Keyword.get(igniter.args.options, :robot) do
+        nil -> Igniter.Project.Module.module_name(igniter, "Robot")
+        name -> Igniter.Project.Module.parse(name)
+      end
+    end
+
+    @doc """
+    Adds a `controller` entry to the robot's `controllers do … end` section.
+
+    `code` is the full DSL call as a string, e.g.
+
+        controller :dynamixel, {BB.Servo.Robotis.Controller, port: ...}
+
+    The section is created if it doesn't already exist. Idempotent on `name`:
+    if a controller with the same name is already present, the igniter is
+    returned unchanged.
+    """
+    @spec add_controller(Igniter.t(), module(), atom(), String.t()) :: Igniter.t()
+    def add_controller(igniter, robot_module, name, code) do
+      add_named_dsl_entity(igniter, robot_module, :controllers, :controller, name, code)
+    end
+
+    @doc """
+    Adds a `bridge` entry to the robot's `parameters do … end` section.
+
+    `code` is the full DSL call as a string, e.g.
+
+        bridge :robotis_bridge, {BB.Servo.Robotis.Bridge, controller: :dynamixel}
+
+    The section is created if it doesn't already exist. Idempotent on `name`.
+    """
+    @spec add_parameter_bridge(Igniter.t(), module(), atom(), String.t()) :: Igniter.t()
+    def add_parameter_bridge(igniter, robot_module, name, code) do
+      add_named_dsl_entity(igniter, robot_module, :parameters, :bridge, name, code)
+    end
+
+    @doc """
+    Adds a nested `group` hierarchy to the robot's `parameters do … end` section.
+
+    `group_path` is a list of atoms describing the path of nested groups to
+    create, e.g. `[:config, :feetech]` produces:
+
+        group :config do
+          group :feetech do
+            <body_code>
+          end
+        end
+
+    `body_code` is the contents of the innermost group (typically one or more
+    `param ...` declarations) as a string.
+
+    The `parameters` section and intermediate groups are created as needed.
+    Idempotent: if the full group path already exists, the body is not added a
+    second time (so manually-edited param contents are preserved).
+    """
+    @spec add_param_group(Igniter.t(), module(), [atom(), ...], String.t()) :: Igniter.t()
+    def add_param_group(igniter, robot_module, group_path, body_code)
+        when is_list(group_path) and group_path != [] do
+      code = wrap_in_groups(group_path, body_code)
+
+      Spark.Igniter.update_dsl(igniter, robot_module, [{:section, :parameters}], nil, fn zipper ->
+        if group_path_exists?(zipper, group_path) do
+          {:ok, zipper}
+        else
+          {:ok, Common.add_code(zipper, code)}
+        end
+      end)
+    end
+
+    @doc """
+    Ensures the robot's child spec in the application module carries the given
+    opts.
+
+    For new robot children, the opts are inserted directly. For existing
+    children, the existing opts are replaced. This is a coarse operation; if
+    multiple installers need to set different keys, the last one to run wins.
+    """
+    @spec set_robot_opts(Igniter.t(), module(), keyword()) :: Igniter.t()
+    def set_robot_opts(igniter, robot_module, opts) do
+      Igniter.Project.Application.add_new_child(igniter, {robot_module, opts},
+        opts_updater: fn zipper -> {:ok, Sourceror.Zipper.replace(zipper, opts)} end
+      )
+    end
+
+    defp wrap_in_groups([leaf], body_code) do
+      "group :#{leaf} do\n#{indent(body_code)}\nend\n"
+    end
+
+    defp wrap_in_groups([name | rest], body_code) do
+      "group :#{name} do\n#{indent(wrap_in_groups(rest, body_code))}\nend\n"
+    end
+
+    defp indent(text) do
+      text
+      |> String.split("\n")
+      |> Enum.map_join("\n", fn
+        "" -> ""
+        line -> "  " <> line
+      end)
+    end
+
+    defp add_named_dsl_entity(igniter, robot_module, section, entity, name, code) do
+      Spark.Igniter.update_dsl(igniter, robot_module, [{:section, section}], nil, fn zipper ->
+        if entity_with_name_exists?(zipper, entity, name) do
+          {:ok, zipper}
+        else
+          {:ok, Common.add_code(zipper, code)}
+        end
+      end)
+    end
+
+    defp entity_with_name_exists?(zipper, entity, name) do
+      case Function.move_to_function_call_in_current_scope(
+             zipper,
+             entity,
+             [2, 3],
+             &Function.argument_equals?(&1, 0, name)
+           ) do
+        {:ok, _} -> true
+        _ -> false
+      end
+    end
+
+    defp group_path_exists?(_zipper, []), do: true
+
+    defp group_path_exists?(zipper, [name | rest]) do
+      with {:ok, group_zipper} <-
+             Function.move_to_function_call_in_current_scope(
+               zipper,
+               :group,
+               [2, 3],
+               &Function.argument_equals?(&1, 0, name)
+             ),
+           {:ok, group_body} <- Common.move_to_do_block(group_zipper) do
+        group_path_exists?(group_body, rest)
+      else
+        _ -> false
+      end
+    end
+  end
+end

--- a/lib/mix/tasks/bb.add_robot.ex
+++ b/lib/mix/tasks/bb.add_robot.ex
@@ -34,13 +34,7 @@ if Code.ensure_loaded?(Igniter) do
 
     @impl Igniter.Mix.Task
     def igniter(igniter) do
-      options = igniter.args.options
-
-      robot_module =
-        case Keyword.get(options, :robot) do
-          nil -> Module.module_name(igniter, "Robot")
-          name -> Module.parse(name)
-        end
+      robot_module = BB.Igniter.robot_module(igniter)
 
       igniter
       |> create_robot_module(robot_module)

--- a/lib/mix/tasks/bb.install.ex
+++ b/lib/mix/tasks/bb.install.ex
@@ -18,18 +18,19 @@ if Code.ensure_loaded?(Igniter) do
     use Igniter.Mix.Task
 
     alias Igniter.Project.Formatter
-    alias Igniter.Project.Module
 
     @impl Igniter.Mix.Task
     def info(_argv, _parent) do
       %Igniter.Mix.Task.Info{
-        composes: ["bb.add_robot"]
+        composes: ["bb.add_robot"],
+        schema: [robot: :string],
+        aliases: [r: :robot]
       }
     end
 
     @impl Igniter.Mix.Task
     def igniter(igniter) do
-      robot_module = Module.module_name(igniter, "Robot")
+      robot_module = BB.Igniter.robot_module(igniter)
 
       igniter
       |> Formatter.import_dep(:bb)

--- a/test/bb/igniter_test.exs
+++ b/test/bb/igniter_test.exs
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.IgniterTest do
+  use ExUnit.Case
+  import Igniter.Test
+
+  @moduletag :igniter
+
+  defp project_with_robot do
+    test_project()
+    |> Igniter.compose_task("bb.install")
+    |> apply_igniter!()
+  end
+
+  describe "robot_module/1" do
+    test "defaults to {AppPrefix}.Robot when --robot is not given" do
+      igniter = put_options(test_project(), [])
+      assert BB.Igniter.robot_module(igniter) == Test.Robot
+    end
+
+    test "parses --robot when provided" do
+      igniter = put_options(test_project(), robot: "MyApp.Arms.Left")
+      assert BB.Igniter.robot_module(igniter) == MyApp.Arms.Left
+    end
+  end
+
+  describe "add_controller/4" do
+    test "adds a controller entry to the controllers section" do
+      controller = "controller :my_controller, {SomeApp.Controller, port: \"/dev/ttyUSB0\"}\n"
+
+      project_with_robot()
+      |> BB.Igniter.add_controller(Test.Robot, :my_controller, controller)
+      |> assert_has_patch("lib/test/robot.ex", """
+      + |  controllers do
+      + |    controller(:my_controller, {SomeApp.Controller, port: "/dev/ttyUSB0"})
+      + |  end
+      """)
+    end
+
+    test "is idempotent on controller name" do
+      controller = "controller :my_controller, {SomeApp.Controller, port: \"/dev/ttyUSB0\"}\n"
+
+      project_with_robot()
+      |> BB.Igniter.add_controller(Test.Robot, :my_controller, controller)
+      |> apply_igniter!()
+      |> BB.Igniter.add_controller(Test.Robot, :my_controller, controller)
+      |> assert_unchanged()
+    end
+  end
+
+  describe "add_parameter_bridge/4" do
+    test "adds a bridge entry to the parameters section" do
+      bridge = "bridge :my_bridge, {SomeApp.Bridge, controller: :my_controller}\n"
+
+      project_with_robot()
+      |> BB.Igniter.add_parameter_bridge(Test.Robot, :my_bridge, bridge)
+      |> assert_has_patch("lib/test/robot.ex", """
+      + |  parameters do
+      + |    bridge(:my_bridge, {SomeApp.Bridge, controller: :my_controller})
+      + |  end
+      """)
+    end
+
+    test "is idempotent on bridge name" do
+      bridge = "bridge :my_bridge, {SomeApp.Bridge, controller: :my_controller}\n"
+
+      project_with_robot()
+      |> BB.Igniter.add_parameter_bridge(Test.Robot, :my_bridge, bridge)
+      |> apply_igniter!()
+      |> BB.Igniter.add_parameter_bridge(Test.Robot, :my_bridge, bridge)
+      |> assert_unchanged()
+    end
+  end
+
+  describe "add_param_group/4" do
+    test "wraps the body in the requested nested groups" do
+      project_with_robot()
+      |> BB.Igniter.add_param_group(
+        Test.Robot,
+        [:config, :widget],
+        "param :speed, type: :integer, default: 100\n"
+      )
+      |> assert_has_patch("lib/test/robot.ex", """
+      + |  parameters do
+      + |    group :config do
+      + |      group :widget do
+      + |        param(:speed, type: :integer, default: 100)
+      + |      end
+      + |    end
+      + |  end
+      """)
+    end
+
+    test "is idempotent on the full group path" do
+      body = "param :speed, type: :integer, default: 100\n"
+
+      project_with_robot()
+      |> BB.Igniter.add_param_group(Test.Robot, [:config, :widget], body)
+      |> apply_igniter!()
+      |> BB.Igniter.add_param_group(Test.Robot, [:config, :widget], body)
+      |> assert_unchanged()
+    end
+  end
+
+  describe "set_robot_opts/3" do
+    test "sets opts on the robot's child spec in the application module" do
+      project_with_robot()
+      |> BB.Igniter.set_robot_opts(Test.Robot, params: [config: [widget: [speed: 100]]])
+      |> assert_has_patch("lib/test/application.ex", ~s'''
+      + |    children = [{Test.Robot, [params: [config: [widget: [speed: 100]]]]}]
+      ''')
+    end
+
+    test "replaces existing opts on subsequent calls" do
+      project_with_robot()
+      |> BB.Igniter.set_robot_opts(Test.Robot, params: [config: [widget: [speed: 100]]])
+      |> apply_igniter!()
+      |> BB.Igniter.set_robot_opts(Test.Robot, params: [config: [widget: [speed: 100]]])
+      |> assert_unchanged()
+    end
+  end
+
+  defp put_options(igniter, options) do
+    %{igniter | args: %{igniter.args | options: options}}
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `BB.Igniter` module exposing helpers that BB add-on packages can use to write Igniter installers without each one re-implementing AST manipulation of the robot DSL.

The motivation is the upcoming wave of installers (`bb_servo_robotis`, `bb_servo_feetech`, `bb_servo_pca9685`, `bb_servo_pigpio`, `bb_pid_controller`, `bb_liveview`): each one needs the same handful of operations against the user's robot module, and pushing them in here means each downstream installer becomes a thin call-site rather than a Spark-DSL surgery.

### New helpers

- `robot_module/1` – resolves the robot module from `--robot` or falls back to `{AppPrefix}.Robot`. Extracted from `bb.install`/`bb.add_robot` so add-on installers share the default.
- `add_controller/4` – adds an entry to `controllers do … end`, creating the section if missing, idempotent on controller name.
- `add_parameter_bridge/4` – same shape for `bridge` entries in `parameters do … end`.
- `add_param_group/4` – wraps a body of `param` calls in a nested `group …` hierarchy and is idempotent on the full path.
- `set_robot_opts/3` – ensures the robot's child spec in the application module carries a given keyword list.

### Existing-task changes

`bb.install` and `bb.add_robot` now use `BB.Igniter.robot_module/1`. `bb.install` gained `--robot`/`-r` so the override flows through to the composed `bb.add_robot` cleanly.

### Notes

- All helpers gated behind `Code.ensure_loaded?(Igniter)` — `:igniter` stays an optional dep.
- 10 new unit tests cover each helper directly (idempotency, section creation, group nesting, app child spec patching).
- The existing `bb.add_robot`/`bb.install` tests continue to exercise `robot_module/1` indirectly.

## Test plan

- [x] `mix check --no-retry` passes (compiler, credo, dialyzer, ex_doc, ex_unit, formatter, mix_audit, reuse, spark_cheat_sheets, spark_formatter, unused_deps)
- [x] All 858 existing tests + 10 new tests pass
- [ ] Follow-up PRs land in `bb_servo_robotis`, `bb_servo_feetech`, `bb_servo_pca9685`, `bb_servo_pigpio`, `bb_pid_controller`, `bb_liveview` once this is released