### PR TITLE
improvement: coerce command goal values to declared argument types

### DIFF
--- a/lib/bb/robot/runtime.ex
+++ b/lib/bb/robot/runtime.ex
@@ -783,6 +783,7 @@ defmodule BB.Robot.Runtime do
 
   defp handle_execute_command(command, goal, execution_id, state) do
     category = command.category || :default
+    goal = coerce_goal(goal, command.arguments)
 
     with :ok <- check_state_allowed(command, state),
          {:ok, state} <- check_category_or_cancel(command, category, state) do
@@ -1359,4 +1360,65 @@ defmodule BB.Robot.Runtime do
   defp implements_safety?(module) do
     Spark.implements_behaviour?(module, BB.Safety)
   end
+
+  # Coerce goal values to their declared types and fill in declared defaults.
+  #
+  # Callers that go through `Map.new(keyword)` from the generated robot
+  # functions get atom keys + native Elixir values for free. Callers like the
+  # LiveView dashboard arrive with string values from HTML form submissions —
+  # `"ee_link"` instead of `:ee_link`, `"0.03"` instead of `0.03`. This lets
+  # those values reach the handler with their declared types.
+  #
+  # Coercion is best-effort: if a string can't be parsed, the original value
+  # is left in place so the handler can decide how to handle it. Unknown atoms
+  # specifically use `String.to_existing_atom/1` to avoid uncontrolled atom
+  # table growth.
+  @doc false
+  @spec coerce_goal(map(), [BB.Dsl.Command.Argument.t()]) :: map()
+  def coerce_goal(goal, arguments) when is_map(goal) and is_list(arguments) do
+    Enum.reduce(arguments, goal, fn arg, acc ->
+      case Map.fetch(acc, arg.name) do
+        {:ok, value} ->
+          Map.put(acc, arg.name, coerce_value(value, arg.type))
+
+        :error ->
+          maybe_put_default(acc, arg)
+      end
+    end)
+  end
+
+  defp maybe_put_default(goal, %{default: nil}), do: goal
+  defp maybe_put_default(goal, %{name: name, default: default}), do: Map.put(goal, name, default)
+
+  defp coerce_value(value, _type) when not is_binary(value), do: value
+
+  defp coerce_value(value, :atom) do
+    String.to_existing_atom(value)
+  rescue
+    ArgumentError -> value
+  end
+
+  defp coerce_value(value, :integer) do
+    case Integer.parse(value) do
+      {int, ""} -> int
+      _ -> value
+    end
+  end
+
+  defp coerce_value(value, :float) do
+    case Float.parse(value) do
+      {float, ""} -> float
+      _ -> value
+    end
+  end
+
+  defp coerce_value("true", :boolean), do: true
+  defp coerce_value("false", :boolean), do: false
+
+  defp coerce_value(value, {:in, allowed}) do
+    coerced = coerce_value(value, :atom)
+    if coerced in allowed, do: coerced, else: value
+  end
+
+  defp coerce_value(value, _type), do: value
 end

--- a/test/bb/robot/runtime_test.exs
+++ b/test/bb/robot/runtime_test.exs
@@ -371,4 +371,79 @@ defmodule BB.Robot.RuntimeTest do
                       }}
     end
   end
+
+  describe "coerce_goal/2" do
+    alias BB.Dsl.Command.Argument
+
+    test "passes through values that are already the declared type" do
+      args = [%Argument{name: :ee_link, type: :atom}, %Argument{name: :radius, type: :float}]
+      goal = %{ee_link: :gripper, radius: 0.5}
+
+      assert Runtime.coerce_goal(goal, args) == goal
+    end
+
+    test "coerces string atoms via to_existing_atom" do
+      _ = :pre_existing_atom
+      args = [%Argument{name: :name, type: :atom}]
+
+      assert Runtime.coerce_goal(%{name: "pre_existing_atom"}, args) == %{
+               name: :pre_existing_atom
+             }
+    end
+
+    test "leaves unknown atom strings alone rather than blowing up" do
+      args = [%Argument{name: :name, type: :atom}]
+      goal = %{name: "this_definitely_does_not_exist_as_an_atom_anywhere"}
+
+      assert Runtime.coerce_goal(goal, args) == goal
+    end
+
+    test "parses integer and float strings from form submissions" do
+      args = [
+        %Argument{name: :points, type: :integer},
+        %Argument{name: :radius, type: :float}
+      ]
+
+      assert Runtime.coerce_goal(%{points: "16", radius: "0.03"}, args) ==
+               %{points: 16, radius: 0.03}
+    end
+
+    test "leaves unparseable numeric strings alone" do
+      args = [%Argument{name: :n, type: :integer}]
+      goal = %{n: "not a number"}
+
+      assert Runtime.coerce_goal(goal, args) == goal
+    end
+
+    test "coerces boolean strings" do
+      args = [%Argument{name: :flag, type: :boolean}]
+
+      assert Runtime.coerce_goal(%{flag: "true"}, args) == %{flag: true}
+      assert Runtime.coerce_goal(%{flag: "false"}, args) == %{flag: false}
+    end
+
+    test "coerces {:in, …} enum values to atom and validates membership" do
+      args = [%Argument{name: :plane, type: {:in, [:xy, :xz, :yz]}}]
+
+      assert Runtime.coerce_goal(%{plane: "xz"}, args) == %{plane: :xz}
+      # A value outside the enum is passed through unchanged
+      assert Runtime.coerce_goal(%{plane: "diagonal"}, args) == %{plane: "diagonal"}
+    end
+
+    test "fills declared defaults when keys are missing" do
+      args = [
+        %Argument{name: :radius, type: :float, default: 0.03},
+        %Argument{name: :no_default, type: :integer}
+      ]
+
+      assert Runtime.coerce_goal(%{}, args) == %{radius: 0.03}
+    end
+
+    test "leaves keys that aren't declared in arguments alone" do
+      args = [%Argument{name: :declared, type: :integer}]
+
+      assert Runtime.coerce_goal(%{declared: "5", undeclared: "hello"}, args) ==
+               %{declared: 5, undeclared: "hello"}
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`BB.Robot.Runtime.execute/3` now coerces each value in the goal map to the
type declared on the corresponding DSL `argument`, and fills in declared
defaults for keys the caller omitted. Callers that already pass native Elixir
values (atoms, numbers, booleans) see no change — coercion is a no-op for
non-strings.

## Motivation

The bb_liveview dashboard renders command argument forms based on each
command's DSL `argument` declarations. When the user clicks Execute, the
form values arrive as strings — `\"ee_link\"`, `\"0.03\"`, `\"16\"`. Before
this change, a handler declared as `argument :ee_link, :atom` and
pattern-matching `when is_atom(ee_link)` would fail because the string
never got cast back to an atom.

After this change the same dashboard submission lands at the handler with
`%{ee_link: :ee_link, radius: 0.03, points: 16}` — types match the DSL
declarations.

## Coercion rules

| DSL type | Coercion |
|---|---|
| `:atom` | `String.to_existing_atom/1`, rescuing `ArgumentError` so unknown-atom strings pass through rather than blow up the atom table |
| `:integer` / `:float` | `Integer.parse/1` / `Float.parse/1` with full-match on trailing empty string |
| `:boolean` | accepts `\"true\"` / `\"false\"` strings |
| `{:in, allowed}` | coerce to atom first, then validate membership |
| anything else | passed through |

Undeclared keys in the goal map are left alone. Defaults only fill when
the key is missing entirely — never overwriting a present value.

## Test plan

- [x] `mix check --no-retry` passes locally
- [x] 9 new unit tests in `test/bb/robot/runtime_test.exs` covering each
      rule, the `to_existing_atom` rescue path, default fill-in, and
      unparseable-string fallback
- [x] End-to-end verified in a downstream consumer: gabba's
      `demo_circle` command declared with `argument :plane, {:in, [:xy,
      :xz, :yz]}, default: :xz` now executes correctly from the
      bb_liveview dashboard form.