### PR TITLE
improvement: identify the publishing robot in pubsub deliveries (#91)

### DIFF
--- a/lib/bb/message.ex
+++ b/lib/bb/message.ex
@@ -9,6 +9,12 @@ defmodule BB.Message do
   Messages in BB are wrapped in a standard envelope containing timing,
   coordinate frame, and payload data.
 
+  The `:robot` field identifies the publishing robot module and is filled
+  in automatically by `BB.PubSub.publish/3` just before dispatch. It is
+  `nil` on freshly-constructed messages that have not yet been published,
+  and lets subscribers that listen to more than one robot attribute each
+  delivered message to its source.
+
   ## Usage
 
   Use the `use BB.Message` macro to define a payload type:
@@ -32,12 +38,13 @@ defmodule BB.Message do
   Note: `defstruct` must be defined before `use BB.Message`.
   """
 
-  defstruct [:timestamp, :frame_id, :payload]
+  defstruct [:timestamp, :frame_id, :payload, :robot]
 
   @type t :: %__MODULE__{
           timestamp: integer(),
           frame_id: atom(),
-          payload: struct()
+          payload: struct(),
+          robot: module() | nil
         }
 
   @doc "Returns a compiled Spark.Options schema for this payload type"

--- a/lib/bb/pub_sub.ex
+++ b/lib/bb/pub_sub.ex
@@ -33,9 +33,12 @@ defmodule BB.PubSub do
 
   Subscribers receive messages as:
 
-      {:bb, source_path, %BB.Message{}}
+      {:bb, source_path, %BB.Message{robot: robot_module}}
 
-  Where `source_path` is the full path of the publisher.
+  Where `source_path` is the full path of the publisher and the
+  `:robot` field on the message identifies which robot published it
+  (filled in by `publish/3`). This lets a process subscribed to more
+  than one robot attribute each incoming message correctly.
 
   ## Message Type Filtering
 
@@ -111,6 +114,7 @@ defmodule BB.PubSub do
     settings = Info.settings(robot)
     registry_module = settings.registry_module
     registry = registry_name(robot)
+    message = %{message | robot: robot}
     message_module = message.payload.__struct__
 
     path

--- a/test/bb/pub_sub_test.exs
+++ b/test/bb/pub_sub_test.exs
@@ -31,6 +31,27 @@ defmodule BB.PubSubTest do
     end
   end
 
+  defmodule OtherRobot do
+    @moduledoc false
+    use BB
+
+    topology do
+      link :base_link do
+        joint :shoulder do
+          type :revolute
+
+          limit do
+            effort(~u(10 newton_meter))
+            velocity(~u(100 degree_per_second))
+          end
+
+          link :arm do
+          end
+        end
+      end
+    end
+  end
+
   describe "ancestor_paths/1" do
     test "generates all ancestor paths including self and root" do
       paths = PubSub.ancestor_paths([:sensor, :base_link, :joint1, :imu])
@@ -72,6 +93,7 @@ defmodule BB.PubSubTest do
           linear_acceleration: Vec3.new(0, 0, 9.81)
         )
 
+      message = %{message | robot: TestRobot}
       PubSub.publish(TestRobot, path, message)
 
       assert_receive {:bb, ^path, ^message}
@@ -91,6 +113,7 @@ defmodule BB.PubSubTest do
           linear_acceleration: Vec3.new(0, 0, 9.81)
         )
 
+      message = %{message | robot: TestRobot}
       PubSub.publish(TestRobot, child_path, message)
 
       assert_receive {:bb, ^child_path, ^message}
@@ -109,6 +132,7 @@ defmodule BB.PubSubTest do
           linear_acceleration: Vec3.zero()
         )
 
+      message = %{message | robot: TestRobot}
       PubSub.publish(TestRobot, path, message)
 
       assert_receive {:bb, ^path, ^message}
@@ -130,6 +154,8 @@ defmodule BB.PubSubTest do
 
       {:ok, actuator_msg} = Pose.new(:motor, Vec3.zero(), Quaternion.identity())
 
+      sensor_msg = %{sensor_msg | robot: TestRobot}
+      actuator_msg = %{actuator_msg | robot: TestRobot}
       PubSub.publish(TestRobot, sensor_path, sensor_msg)
       PubSub.publish(TestRobot, actuator_path, actuator_msg)
 
@@ -171,10 +197,65 @@ defmodule BB.PubSubTest do
           linear_acceleration: Vec3.zero()
         )
 
+      message = %{message | robot: TestRobot}
       PubSub.publish(TestRobot, path, message)
 
       assert_receive {:subscriber1, ^message}
       assert_receive {:subscriber2, ^message}
+    end
+  end
+
+  describe "robot attribution" do
+    test "publish/3 stamps the message with the publishing robot" do
+      start_supervised!(TestRobot)
+      path = [:sensor, :base_link, :imu]
+      {:ok, _} = PubSub.subscribe(TestRobot, path)
+
+      {:ok, message} =
+        Imu.new(:imu,
+          orientation: Quaternion.identity(),
+          angular_velocity: Vec3.zero(),
+          linear_acceleration: Vec3.zero()
+        )
+
+      assert message.robot == nil
+      PubSub.publish(TestRobot, path, message)
+
+      assert_receive {:bb, ^path, delivered}
+      assert delivered.robot == TestRobot
+      assert delivered.payload == message.payload
+    end
+
+    test "subscriber to multiple robots can attribute each message" do
+      start_supervised!(TestRobot)
+      start_supervised!(OtherRobot)
+
+      path = [:sensor, :base_link, :imu]
+      {:ok, _} = PubSub.subscribe(TestRobot, path)
+      {:ok, _} = PubSub.subscribe(OtherRobot, path)
+
+      {:ok, from_test} =
+        Imu.new(:imu,
+          orientation: Quaternion.identity(),
+          angular_velocity: Vec3.zero(),
+          linear_acceleration: Vec3.new(0, 0, 9.81)
+        )
+
+      {:ok, from_other} =
+        Imu.new(:imu,
+          orientation: Quaternion.identity(),
+          angular_velocity: Vec3.new(1, 0, 0),
+          linear_acceleration: Vec3.zero()
+        )
+
+      PubSub.publish(TestRobot, path, from_test)
+      PubSub.publish(OtherRobot, path, from_other)
+
+      assert_receive {:bb, ^path, %{robot: TestRobot} = delivered_test}
+      assert_receive {:bb, ^path, %{robot: OtherRobot} = delivered_other}
+
+      assert delivered_test.payload == from_test.payload
+      assert delivered_other.payload == from_other.payload
     end
   end
 
@@ -196,6 +277,7 @@ defmodule BB.PubSubTest do
 
       {:ok, pose_msg} = Pose.new(:camera, Vec3.zero(), Quaternion.identity())
 
+      imu_msg = %{imu_msg | robot: TestRobot}
       PubSub.publish(TestRobot, imu_path, imu_msg)
       PubSub.publish(TestRobot, pose_path, pose_msg)
 
@@ -220,6 +302,8 @@ defmodule BB.PubSubTest do
 
       {:ok, pose_msg} = Pose.new(:camera, Vec3.zero(), Quaternion.identity())
 
+      imu_msg = %{imu_msg | robot: TestRobot}
+      pose_msg = %{pose_msg | robot: TestRobot}
       PubSub.publish(TestRobot, imu_path, imu_msg)
       PubSub.publish(TestRobot, pose_path, pose_msg)
 
@@ -241,6 +325,7 @@ defmodule BB.PubSubTest do
           linear_acceleration: Vec3.zero()
         )
 
+      imu_msg = %{imu_msg | robot: TestRobot}
       PubSub.publish(TestRobot, imu_path, imu_msg)
 
       assert_receive {:bb, ^imu_path, ^imu_msg}
@@ -263,6 +348,8 @@ defmodule BB.PubSubTest do
 
       {:ok, pose_msg} = Pose.new(:camera, Vec3.zero(), Quaternion.identity())
 
+      imu_msg = %{imu_msg | robot: TestRobot}
+      pose_msg = %{pose_msg | robot: TestRobot}
       PubSub.publish(TestRobot, imu_path, imu_msg)
       PubSub.publish(TestRobot, pose_path, pose_msg)
 
@@ -284,6 +371,7 @@ defmodule BB.PubSubTest do
           linear_acceleration: Vec3.zero()
         )
 
+      message1 = %{message1 | robot: TestRobot}
       PubSub.publish(TestRobot, path, message1)
       assert_receive {:bb, ^path, ^message1}
 


### PR DESCRIPTION
## Summary

- Adds a `:robot` field to `BB.Message`; `BB.PubSub.publish/3` stamps it onto the message just before dispatch.
- Subscribers that listen to messages from more than one robot can now attribute each delivered message to its source by reading `message.robot` — no more guessing from the path.
- The delivery tuple shape (`{:bb, path, %BB.Message{}}`) is unchanged, so every existing `handle_info({:bb, _path, %BB.Message{}}, _)` clause across the workspace keeps compiling and running.

The concrete consumer is `bb_mcp`, whose `query_events` event buffer currently mis-attributes events when more than one robot is configured on the same MCP server. The companion fix lives in beam-bots/bb_mcp.

Closes #91.

## Test plan

- [x] `mix check --no-retry` passes in `bb/`.
- [x] New regression tests in `test/bb/pub_sub_test.exs` cover the single-robot stamp and the multi-robot disambiguation cases.
- [x] Existing pinned-message tests updated to expect the stamped `:robot` field.
- [x] Spot-checked sibling consumers (`bb_kino`, `bb_liveview`, `bb_example_wx200`) — all compile cleanly against the new struct with no changes.
- [x] `bb_mcp` (companion PR) compiles and `mix check` passes with `BB_VERSION=local`.