### PR TITLE
fix: cover tuple argument types in typespec and `:map` example

### DIFF
--- a/lib/bb/dsl.ex
+++ b/lib/bb/dsl.ex
@@ -727,7 +727,7 @@ defmodule BB.Dsl do
 
     - Simple types: `:float`, `:integer`, `:boolean`, `:atom`, `:string`
     - Enums: `{:in, [:value1, :value2]}`
-    - Maps: `{:map, [x: :float, y: :float, z: :float]}`
+    - Maps: `{:map, [x: [type: :float, required: true]]}`
     - Modules: `MyModule`
     """,
     schema: [

--- a/lib/bb/dsl/command/argument.ex
+++ b/lib/bb/dsl/command/argument.ex
@@ -23,7 +23,7 @@ defmodule BB.Dsl.Command.Argument do
           __identifier__: any,
           __spark_metadata__: Entity.spark_meta(),
           name: atom,
-          type: atom | module,
+          type: atom | module | tuple,
           required: boolean,
           default: any,
           doc: String.t() | nil


### PR DESCRIPTION
## Summary

Two small follow-ups to #88:

- `lib/bb/dsl/command/argument.ex`: extend the `:type` field's typespec from `atom | module` to `atom | module | tuple`. Command argument coercion (`BB.Robot.Runtime.coerce_value/2`) already accepts tuple types like `{:in, [...]}` and `{:map, [...]}` at runtime; the typespec was lagging and dialyzer would have complained on a tuple-typed argument.
- `lib/bb/dsl.ex`: fix the `:map` example in the argument-type docs to use the nested-keyword shape Spark.Options actually expects: `{:map, [x: [type: :float, required: true]]}`. The previous flat form (`{:map, [x: :float, y: :float, z: :float]}`) is rejected by Spark.Options.

## Test plan

- [x] `mix check --no-retry` passes.