### PR TITLE
improvement!: store wall-clock time and originating node on `BB.Message` (#37)

### DIFF
--- a/documentation/reference/message-types.md
+++ b/documentation/reference/message-types.md
@@ -10,16 +10,18 @@ All message payloads in BB PubSub. Messages are wrapped in `BB.Message`:
 
 ```elixir
 %BB.Message{
-  timestamp: integer(),   # System.monotonic_time(:nanosecond)
-  frame_id: atom(),       # Coordinate frame (typically joint/link name)
-  payload: struct()       # One of the message types below
+  monotonic_time: integer(),  # System.monotonic_time(:nanosecond)
+  wall_time: integer(),       # System.system_time(:nanosecond)
+  node: node(),               # Node that produced the message
+  frame_id: atom(),           # Coordinate frame (typically joint/link name)
+  payload: struct()           # One of the message types below
 }
 ```
 
-**Note on timestamps:** The timestamp is monotonic time in nanoseconds (`System.monotonic_time(:nanosecond)`), not wall-clock time. This means:
-- Timestamps are suitable for ordering events and measuring durations
-- They cannot be converted to wall-clock/UTC time
-- They are only meaningful within a single BEAM VM instance
+**Note on timing fields:**
+- `monotonic_time` is monotonic nanoseconds from `System.monotonic_time/1`. Use it for ordering events and measuring durations within a single node. It is **not** comparable across nodes or BEAM restarts.
+- `wall_time` is system time in nanoseconds from `System.system_time/1`. Use it for correlation with real-world time, log alignment, and recording/playback. Subject to NTP jumps.
+- `node` is the originating BEAM node, useful for disambiguating messages in distributed deployments.
 
 ## Sensor Messages
 
@@ -358,8 +360,10 @@ Messages are wrapped in `BB.Message`:
 ```elixir
 %BB.Message{
   payload: %JointState{...},
-  timestamp: ~U[2025-01-18 12:00:00Z],
-  frame_id: "shoulder"
+  monotonic_time: -576_460_748_776_542,
+  wall_time: 1_737_201_600_000_000_000,
+  node: :nonode@nohost,
+  frame_id: :shoulder
 }
 ```
 

--- a/documentation/topics/pubsub-system.md
+++ b/documentation/topics/pubsub-system.md
@@ -72,8 +72,10 @@ All messages are wrapped in `BB.Message`:
 ```elixir
 %BB.Message{
   payload: %BB.Message.Sensor.JointState{...},
-  timestamp: ~U[2025-01-18 12:00:00Z],
-  frame_id: "shoulder"
+  monotonic_time: -576_460_748_776_542,
+  wall_time: 1_737_201_600_000_000_000,
+  node: :nonode@nohost,
+  frame_id: :shoulder
 }
 ```
 

--- a/documentation/tutorials/03-sensors-and-pubsub.md
+++ b/documentation/tutorials/03-sensors-and-pubsub.md
@@ -184,7 +184,9 @@ Messages have a standard envelope structure:
 
 ```elixir
 %BB.Message{
-  timestamp: -576460748776542,  # monotonic nanoseconds
+  monotonic_time: -576460748776542,         # monotonic nanoseconds
+  wall_time: 1_737_201_600_000_000_000,     # system nanoseconds (UTC epoch)
+  node: :nonode@nohost,
   frame_id: :imu,
   payload: %BB.Message.Sensor.Imu{
     orientation: {:quaternion, 0.0, 0.0, 0.0, 1.0},
@@ -194,9 +196,11 @@ Messages have a standard envelope structure:
 }
 ```
 
-- `timestamp` - Monotonic time in nanoseconds (from `System.monotonic_time/1`)
-- `frame_id` - Coordinate frame for the data (typically the sensor name)
-- `payload` - The actual sensor data struct (type depends on message type)
+- `monotonic_time` - Monotonic time in nanoseconds (from `System.monotonic_time/1`). Use for ordering and durations within a node.
+- `wall_time` - System time in nanoseconds (from `System.system_time/1`). Use for correlation with real-world time, logging, and recording/playback.
+- `node` - The BEAM node that produced the message. Useful in distributed deployments.
+- `frame_id` - Coordinate frame for the data (typically the sensor name).
+- `payload` - The actual sensor data struct (type depends on message type).
 
 ## Available Message Types
 

--- a/lib/bb/message.ex
+++ b/lib/bb/message.ex
@@ -38,10 +38,12 @@ defmodule BB.Message do
   Note: `defstruct` must be defined before `use BB.Message`.
   """
 
-  defstruct [:timestamp, :frame_id, :payload, :robot]
+  defstruct [:monotonic_time, :wall_time, :node, :frame_id, :payload, :robot]
 
   @type t :: %__MODULE__{
-          timestamp: integer(),
+          monotonic_time: integer(),
+          wall_time: integer(),
+          node: node(),
           frame_id: atom(),
           payload: struct(),
           robot: module() | nil
@@ -73,7 +75,9 @@ defmodule BB.Message do
   Create a new message with validated payload.
 
   Validates the attributes against the payload module's schema, then wraps
-  the resulting struct in a message envelope with a fresh timestamp.
+  the resulting struct in a message envelope. The envelope is stamped with
+  the current monotonic time, wall-clock time, and the local node name,
+  so messages remain interpretable across nodes and after recording.
 
   ## Examples
 
@@ -91,7 +95,9 @@ defmodule BB.Message do
       {:ok, validated} ->
         {:ok,
          %__MODULE__{
-           timestamp: System.monotonic_time(:nanosecond),
+           monotonic_time: System.monotonic_time(:nanosecond),
+           wall_time: System.system_time(:nanosecond),
+           node: Node.self(),
            frame_id: frame_id,
            payload: struct(payload_module, validated)
          }}

--- a/test/bb/controller/action_test.exs
+++ b/test/bb/controller/action_test.exs
@@ -57,7 +57,7 @@ defmodule BB.Controller.ActionTest do
     test "invokes command on robot module" do
       action = %Command{command: :disarm, args: []}
       context = %Context{robot_module: TestRobot}
-      message = %BB.Message{timestamp: 0, frame_id: :test, payload: %{}}
+      message = %BB.Message{monotonic_time: 0, frame_id: :test, payload: %{}}
 
       result = Action.execute(action, message, context)
 
@@ -68,7 +68,7 @@ defmodule BB.Controller.ActionTest do
     test "passes args as map to command" do
       action = %Command{command: :move_to, args: [target: :home]}
       context = %Context{robot_module: TestRobot}
-      message = %BB.Message{timestamp: 0, frame_id: :test, payload: %{}}
+      message = %BB.Message{monotonic_time: 0, frame_id: :test, payload: %{}}
 
       result = Action.execute(action, message, context)
 
@@ -88,7 +88,7 @@ defmodule BB.Controller.ActionTest do
 
       action = %Callback{handler: handler}
       context = %Context{robot_module: SomeRobot, controller_name: :test_controller}
-      message = %BB.Message{timestamp: 123, frame_id: :test, payload: %{value: 42}}
+      message = %BB.Message{monotonic_time: 123, frame_id: :test, payload: %{value: 42}}
 
       result = Action.execute(action, message, context)
 

--- a/test/bb/controller/pattern_match_test.exs
+++ b/test/bb/controller/pattern_match_test.exs
@@ -41,7 +41,9 @@ defmodule BB.Controller.PatternMatchTest do
 
   defp build_message(payload) do
     %BB.Message{
-      timestamp: System.monotonic_time(:nanosecond),
+      monotonic_time: System.monotonic_time(:nanosecond),
+      wall_time: System.system_time(:nanosecond),
+      node: Node.self(),
       frame_id: :sensor,
       payload: payload
     }

--- a/test/bb/controller/threshold_test.exs
+++ b/test/bb/controller/threshold_test.exs
@@ -72,7 +72,9 @@ defmodule BB.Controller.ThresholdTest do
 
     defp build_message(payload) do
       %BB.Message{
-        timestamp: System.monotonic_time(:nanosecond),
+        monotonic_time: System.monotonic_time(:nanosecond),
+        wall_time: System.system_time(:nanosecond),
+        node: Node.self(),
         frame_id: :sensor,
         payload: payload
       }

--- a/test/bb/message_test.exs
+++ b/test/bb/message_test.exs
@@ -11,11 +11,13 @@ defmodule BB.MessageTest do
   alias BB.Message.Geometry.Pose
 
   describe "Message envelope" do
-    test "new/3 creates a message with timestamp, frame_id, and payload" do
+    test "new/3 creates a message with timing, origin, frame_id, and payload" do
       {:ok, msg} = Pose.new(:base_link, Vec3.new(1, 2, 3), Quaternion.identity())
 
       assert %Message{} = msg
-      assert is_integer(msg.timestamp)
+      assert is_integer(msg.monotonic_time)
+      assert is_integer(msg.wall_time)
+      assert msg.node == Node.self()
       assert msg.frame_id == :base_link
       assert %Pose{} = msg.payload
     end

--- a/test/bb/sensor/mimic_test.exs
+++ b/test/bb/sensor/mimic_test.exs
@@ -185,7 +185,9 @@ defmodule BB.Sensor.MimicTest do
       test_pid = self()
 
       other_message = %Message{
-        timestamp: System.monotonic_time(:nanosecond),
+        monotonic_time: System.monotonic_time(:nanosecond),
+        wall_time: System.system_time(:nanosecond),
+        node: Node.self(),
         frame_id: :gripper,
         payload: %{__struct__: SomeOtherType, value: 42}
       }

--- a/test/support/test_parameter_bridge.ex
+++ b/test/support/test_parameter_bridge.ex
@@ -198,7 +198,9 @@ defmodule BB.Test.ParameterBridge do
       param_atom = if is_atom(param_id), do: param_id, else: String.to_atom(param_id)
 
       message = %BB.Message{
-        timestamp: System.monotonic_time(:nanosecond),
+        monotonic_time: System.monotonic_time(:nanosecond),
+        wall_time: System.system_time(:nanosecond),
+        node: Node.self(),
         frame_id: :remote,
         payload: %RemoteParamValue{value: value}
       }


### PR DESCRIPTION
## Summary

Closes #37.

- Renames `BB.Message.timestamp` → `monotonic_time` to make its semantics explicit.
- Adds `wall_time` (`System.system_time(:nanosecond)`) so messages remain interpretable for recording/playback, log correlation, and matching events to real-world time.
- Adds `node` (`Node.self()`) so messages carry their origin in distributed deployments, and applications can build their own cross-node ordering schemes on top.

`BB.Message.new/3` populates all three fields automatically. Direct struct constructions in the test suite were updated.

## Breaking change

Anything reading `message.timestamp` must switch to `message.monotonic_time`.

Known downstream impact in this workspace:

- `bb_mcp/lib/bb/mcp/event_buffer.ex:81` reads `message.timestamp` — will need a follow-up PR against `bb_mcp` once this lands.
- `bb_kino` already updated locally to use `message.wall_time` for event-stream display (separate PR to follow).

## Test plan

- [x] `mix check --no-retry` green locally (compiler, credo, dialyzer, ex_unit, formatter, reuse, mix_audit, unused_deps)
- [x] 874 tests + 21 doctests pass
- [ ] CI passes