### PR TITLE
improvement: add `bb.upgrade` Igniter task for 0.16

### DIFF
--- a/documentation/how-to/upgrade-to-0.16.md
+++ b/documentation/how-to/upgrade-to-0.16.md
@@ -1,0 +1,103 @@
+<!--
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Upgrading to bb 0.16
+
+bb 0.16 introduces two breaking changes. The fastest path forwards is:
+
+```bash
+mix igniter.upgrade bb
+```
+
+That runs the `bb.upgrade` Igniter task, which applies the mechanical migrations and prints a notice listing the remaining manual follow-ups. The sections below describe each change so you can audit the diff or migrate by hand if you don't use Igniter.
+
+## 1. `auto_disarm_on_error` removed; topology supervisor escalates instead
+
+The old `auto_disarm_on_error: true` default disarmed the whole robot whenever any component called `BB.Safety.report_error/3`. That contradicted the fault-isolation philosophy of the supervision tree — a single overheating servo would stop everything.
+
+0.16 replaces that with supervisor-driven escalation:
+
+* All hardware-facing subsystems now run under a new `BB.TopologySupervisor` with its own restart budget.
+* If failures cascade up and exhaust that budget, the topology supervisor stops and `BB.Safety.Controller` force-disarms the robot.
+* `BB.Safety.report_error/3` is now notification-only — it publishes a `BB.Safety.HardwareError` event on `[:safety, :error]` and returns. It does **not** change safety state.
+
+### Removed
+
+```elixir
+settings do
+  auto_disarm_on_error false   # ← delete this line
+end
+```
+
+The upgrader removes the line for you. If the `settings do … end` block ends up empty after the removal, you can delete the whole block.
+
+### New tunables
+
+If you want to tune how much failure your robot will absorb before force-disarm, set them in the robot DSL:
+
+```elixir
+settings do
+  topology_max_restarts 3   # default
+  topology_max_seconds 5    # default
+end
+```
+
+### Migrating code that called `report_error/3` expecting disarm
+
+If you had components calling `BB.Safety.report_error/3` and relying on the side-effect of auto-disarm, two options:
+
+1. **Crash to escalate (preferred).** Raise or exit when you detect an unrecoverable fault — the supervisor will restart you, and repeated restarts naturally hit the topology supervisor's budget. The escalation is then automatic and observable.
+
+   ```elixir
+   # In an actuator on persistent communication failure:
+   BB.Safety.report_error(robot, path, :servo_unreachable)
+   raise BB.Error.Hardware.Unreachable, path: path
+   ```
+
+2. **Subscribe and disarm explicitly.** If you want a softer response in certain situations, subscribe to `[:safety, :error]` and call `BB.Safety.disarm/1` from your own logic when appropriate.
+
+## 2. `ex_cldr_units` replaced with `localize`
+
+bb's unit handling now uses Kip Cole's [`localize`](https://hex.pm/packages/localize) package, which consolidates the `ex_cldr_*` family into a single dependency with no compile-time backend module.
+
+### What the upgrader rewrites automatically
+
+In any module that uses a BB DSL macro (`use BB`, `use BB.Actuator`, `use BB.Sensor`, `use BB.Controller`, `use BB.Bridge`, `use BB.Command`) or implements the `BB.Safety` behaviour:
+
+| Before | After |
+|---|---|
+| `Cldr.Unit.new!(:meter, 5)` | `Localize.Unit.new!(5, "meter")` |
+| `Cldr.Unit.new!(5, :meter)` | `Localize.Unit.new!(5, "meter")` |
+| `Cldr.Unit.convert!(unit, :radian)` | `Localize.Unit.convert!(unit, "radian")` |
+| `Cldr.Unit.compatible?(u, :meter)` | `Localize.Unit.compatible?(u, "meter")` |
+| `Cldr.Unit.compare(a, b)` | `Localize.Unit.compare(a, b)` |
+| `Cldr.Unit.to_string!(unit)` | `Localize.Unit.to_string!(unit)` |
+| `%Cldr.Unit{unit: :meter, value: 1}` | `%Localize.Unit{name: "meter", value: 1}` |
+
+It also rewrites `alias BB.Cldr.Unit` to `alias BB.Unit` across the codebase (the `BB.Cldr` backend module no longer exists).
+
+### What the upgrader can't safely automate
+
+* **`.unit` field access on bare variables.** Code like `do_something(my_unit.unit)` needs to become `my_unit.name` and the value is now a string, not an atom. The upgrader doesn't rewrite this because there's no reliable way to know which `.unit` accesses are on unit structs.
+* **Custom Cldr backend modules.** If you defined your own `MyApp.Cldr` backend with `Cldr.Unit` as a provider, the upgrader doesn't touch it. Whether you keep it (because your app uses `ex_cldr_units` for its own reasons) or remove it is your call.
+* **`BB.Safety.report_error/3` callers** — the function still exists and the call sites still compile. The behaviour change (no longer auto-disarms) is described above and needs to be addressed by hand.
+
+### Unit name format
+
+bb's `~u(...)` sigil keeps accepting atom-style names with underscores (`~u(10 newton_meter)`); they're translated to CLDR canonical dash form (`"newton-meter"`) inside `BB.Unit`. So existing DSL definitions and most sigil call sites need no change.
+
+When you write CLDR unit identifiers directly (e.g. in a `Localize.Unit.new!/2` call), use the dash form: `"newton-meter"`, not `"newton_meter"`.
+
+## Verifying the upgrade
+
+After running the upgrader (or doing the migration by hand):
+
+```bash
+mix compile --warnings-as-errors
+mix test
+```
+
+If you have downstream bb packages (servo drivers, custom sensors, etc.), bump their `bb` constraint to `~> 0.16` and re-run their checks too.

--- a/lib/bb/igniter/upgrade/v0_16.ex
+++ b/lib/bb/igniter/upgrade/v0_16.ex
@@ -1,0 +1,339 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if Code.ensure_loaded?(Igniter) do
+  # credo:disable-for-next-line Credo.Check.Readability.ModuleNames
+  defmodule BB.Igniter.Upgrade.V0_16 do
+    @moduledoc """
+    Migration steps for the 0.15 → 0.16 jump.
+
+    Run via `mix igniter.upgrade bb`. The two breaking changes covered:
+
+      * `auto_disarm_on_error` setting was removed from the robot DSL — safety
+        escalation now happens via the topology supervisor's restart budget.
+      * `ex_cldr_units` replaced with `localize`; `BB.Cldr` deleted; unit struct
+        is now `%Localize.Unit{}` with a `name` (string) field instead of
+        `%Cldr.Unit{}` with `unit` (atom).
+    """
+
+    alias Igniter.Code.Common
+    alias Igniter.Code.Function
+    alias Igniter.Code.Module
+    alias Igniter.Project.Module, as: ProjectModule
+    alias Sourceror.Zipper
+
+    @bb_use_macros [BB, BB.Actuator, BB.Sensor, BB.Controller, BB.Bridge, BB.Command]
+    @bb_behaviours [BB.Safety]
+
+    @doc """
+    Removes any `auto_disarm_on_error <bool>` line from `settings do … end`
+    blocks in modules that `use BB`.
+    """
+    @spec remove_auto_disarm_on_error(Igniter.t(), keyword()) :: Igniter.t()
+    def remove_auto_disarm_on_error(igniter, _opts) do
+      {igniter, modules} = find_modules_using(igniter, [BB])
+      Enum.reduce(modules, igniter, &remove_auto_disarm_from_module/2)
+    end
+
+    defp remove_auto_disarm_from_module(module, igniter) do
+      ProjectModule.find_and_update_module!(igniter, module, &remove_auto_disarm_zipper/1)
+    end
+
+    defp remove_auto_disarm_zipper(zipper) do
+      with {:ok, settings_zipper} <-
+             Function.move_to_function_call(zipper, :settings, 1, &has_do_block?/1),
+           {:ok, do_zipper} <- Common.move_to_do_block(settings_zipper) do
+        do_zipper =
+          do_zipper
+          |> Common.maybe_move_to_block()
+          |> remove_auto_disarm_line()
+
+        {:ok, do_zipper}
+      else
+        _ -> {:ok, zipper}
+      end
+    end
+
+    defp remove_auto_disarm_line(zipper) do
+      Common.remove(zipper, fn z ->
+        Function.function_call?(z, :auto_disarm_on_error, 1)
+      end)
+    end
+
+    @doc """
+    Rewrites `alias BB.Cldr.Unit` to `alias BB.Unit` (preserving any `as:`
+    clause) wherever it appears.
+    """
+    @spec rename_bb_cldr_unit_alias(Igniter.t(), keyword()) :: Igniter.t()
+    def rename_bb_cldr_unit_alias(igniter, _opts) do
+      {igniter, modules} =
+        ProjectModule.find_all_matching_modules(igniter, fn _module, zipper ->
+          alias_bb_cldr_unit?(zipper)
+        end)
+
+      Enum.reduce(modules, igniter, &rename_alias_in_module/2)
+    end
+
+    defp rename_alias_in_module(module, igniter) do
+      ProjectModule.find_and_update_module!(igniter, module, fn zipper ->
+        Common.update_all_matches(zipper, &alias_bb_cldr_unit_node?/1, &rewrite_alias_match/1)
+      end)
+    end
+
+    defp rewrite_alias_match(z), do: {:code, rewrite_alias_node(z.node)}
+
+    defp alias_bb_cldr_unit?(zipper) do
+      match?({:ok, _}, Common.move_to(zipper, &alias_bb_cldr_unit_node?/1))
+    end
+
+    defp alias_bb_cldr_unit_node?(%Zipper{node: node}) do
+      case node do
+        {:alias, _, [{:__aliases__, _, [:BB, :Cldr, :Unit]}]} -> true
+        {:alias, _, [{:__aliases__, _, [:BB, :Cldr, :Unit]}, _opts]} -> true
+        _ -> false
+      end
+    end
+
+    defp rewrite_alias_node({:alias, meta, [{:__aliases__, am, [:BB, :Cldr, :Unit]}]}) do
+      {:alias, meta, [{:__aliases__, am, [:BB, :Unit]}]}
+    end
+
+    defp rewrite_alias_node({:alias, meta, [{:__aliases__, am, [:BB, :Cldr, :Unit]}, opts]}) do
+      {:alias, meta, [{:__aliases__, am, [:BB, :Unit]}, opts]}
+    end
+
+    @doc """
+    Rewrites `Cldr.Unit.foo(...)` calls to `Localize.Unit.foo(...)` inside
+    modules that use a BB DSL macro or implement `BB.Safety`. Atom unit
+    identifiers (`:newton_meter`) are converted to CLDR canonical dash form
+    (`"newton-meter"`) and `Localize.Unit.new!/2` has its arguments reversed
+    so the value comes first.
+    """
+    @spec rewrite_cldr_unit_calls(Igniter.t(), keyword()) :: Igniter.t()
+    def rewrite_cldr_unit_calls(igniter, _opts) do
+      {igniter, modules} = find_bb_user_modules(igniter)
+
+      Enum.reduce(modules, igniter, fn module, igniter ->
+        ProjectModule.find_and_update_module!(igniter, module, fn zipper ->
+          {:ok,
+           zipper
+           |> rewrite_calls_of({Cldr.Unit, :new!}, 2, &rewrite_new_call/1)
+           |> rewrite_calls_of({Cldr.Unit, :convert!}, 2, &rewrite_convert_call/1)
+           |> rewrite_calls_of({Cldr.Unit, :convert}, 2, &rewrite_convert_call/1)
+           |> rewrite_calls_of({Cldr.Unit, :compatible?}, 2, &rewrite_compatible_call/1)
+           |> rewrite_calls_of({Cldr.Unit, :compare}, 2, &rewrite_module_only/1)
+           |> rewrite_calls_of({Cldr.Unit, :to_string!}, [1, 2], &rewrite_module_only/1)
+           |> rewrite_calls_of({Cldr.Unit, :to_string}, [1, 2], &rewrite_module_only/1)}
+        end)
+      end)
+    end
+
+    defp rewrite_calls_of(zipper, {module, fun}, arities, rewriter) do
+      arities = List.wrap(arities)
+      pred = fn z -> matches_any_arity?(z, module, fun, arities) end
+      replace = fn z -> {:code, rewriter.(z.node)} end
+
+      case Common.update_all_matches(zipper, pred, replace) do
+        {:ok, z} -> z
+        _ -> zipper
+      end
+    end
+
+    defp matches_any_arity?(z, module, fun, arities) do
+      Enum.any?(arities, fn a -> Function.function_call?(z, {module, fun}, a) end)
+    end
+
+    # Pipe form delegates to the unwrapped call form.
+    defp rewrite_new_call({:|>, pm, [piped, call]}),
+      do: {:|>, pm, [piped, rewrite_new_call(call)]}
+
+    # Two-arg call: Cldr.Unit.new!(:atom, value) or Cldr.Unit.new!(value, :atom)
+    defp rewrite_new_call({{:., dm, [_old_mod, :new!]}, m, [arg1, arg2]}) do
+      {value, unit} = pick_value_and_unit(arg1, arg2)
+      {{:., dm, [localize_unit_alias(dm), :new!]}, m, [value, unit_to_string_node(unit)]}
+    end
+
+    # Single-arg call (from pipe): Cldr.Unit.new!(:atom)
+    defp rewrite_new_call({{:., dm, [_old_mod, :new!]}, m, [arg]}) do
+      {{:., dm, [localize_unit_alias(dm), :new!]}, m, [unit_to_string_node(arg)]}
+    end
+
+    defp rewrite_convert_call({:|>, pm, [piped, call]}),
+      do: {:|>, pm, [piped, rewrite_convert_call(call)]}
+
+    defp rewrite_convert_call({{:., dm, [_old_mod, fun]}, m, [unit, target]}) do
+      {{:., dm, [localize_unit_alias(dm), fun]}, m, [unit, unit_to_string_node(target)]}
+    end
+
+    defp rewrite_convert_call({{:., dm, [_old_mod, fun]}, m, [target]}) do
+      {{:., dm, [localize_unit_alias(dm), fun]}, m, [unit_to_string_node(target)]}
+    end
+
+    defp rewrite_compatible_call({:|>, pm, [piped, call]}),
+      do: {:|>, pm, [piped, rewrite_compatible_call(call)]}
+
+    defp rewrite_compatible_call({{:., dm, [_old_mod, :compatible?]}, m, [a, b]}) do
+      {{:., dm, [localize_unit_alias(dm), :compatible?]}, m, [a, unit_to_string_node(b)]}
+    end
+
+    defp rewrite_compatible_call({{:., dm, [_old_mod, :compatible?]}, m, [b]}) do
+      {{:., dm, [localize_unit_alias(dm), :compatible?]}, m, [unit_to_string_node(b)]}
+    end
+
+    defp rewrite_module_only({:|>, pm, [piped, call]}),
+      do: {:|>, pm, [piped, rewrite_module_only(call)]}
+
+    # Cldr.Unit.compare(a, b) → Localize.Unit.compare(a, b) (module-only swap)
+    defp rewrite_module_only({{:., dm, [_old_mod, fun]}, m, args}) do
+      {{:., dm, [localize_unit_alias(dm), fun]}, m, args}
+    end
+
+    defp localize_unit_alias(meta) do
+      {:__aliases__, meta, [:Localize, :Unit]}
+    end
+
+    defp pick_value_and_unit(arg1, arg2) do
+      if atom_literal?(arg1), do: {arg2, arg1}, else: {arg1, arg2}
+    end
+
+    defp atom_literal?(node) when is_atom(node) and not is_nil(node), do: true
+    defp atom_literal?({:__block__, _, [name]}) when is_atom(name) and not is_nil(name), do: true
+    defp atom_literal?(_), do: false
+
+    defp unit_to_string_node(name) when is_atom(name) and not is_nil(name) do
+      {:__block__, [], [to_dash_string(name)]}
+    end
+
+    defp unit_to_string_node(binary) when is_binary(binary) do
+      {:__block__, [], [binary]}
+    end
+
+    defp unit_to_string_node({:__block__, m, [name]}) when is_atom(name) and not is_nil(name) do
+      {:__block__, m, [to_dash_string(name)]}
+    end
+
+    defp unit_to_string_node({:__block__, _, [binary]} = node) when is_binary(binary), do: node
+
+    # Leave unrecognised shapes untouched — the user will see the result.
+    defp unit_to_string_node(other), do: other
+
+    defp to_dash_string(name) when is_atom(name) do
+      name |> Atom.to_string() |> String.replace("_", "-")
+    end
+
+    @doc """
+    Rewrites `%Cldr.Unit{...}` literal/pattern uses to `%Localize.Unit{...}`
+    and translates field renames (`unit: :foo` → `name: "foo"`). Limited to
+    modules that use a BB DSL macro or implement `BB.Safety`.
+    """
+    @spec rewrite_cldr_unit_struct_patterns(Igniter.t(), keyword()) :: Igniter.t()
+    def rewrite_cldr_unit_struct_patterns(igniter, _opts) do
+      {igniter, modules} = find_bb_user_modules(igniter)
+      Enum.reduce(modules, igniter, &rewrite_struct_in_module/2)
+    end
+
+    defp rewrite_struct_in_module(module, igniter) do
+      ProjectModule.find_and_update_module!(igniter, module, fn zipper ->
+        Common.update_all_matches(zipper, &cldr_unit_struct?/1, &rewrite_struct_match/1)
+      end)
+    end
+
+    defp rewrite_struct_match(z), do: {:code, rewrite_struct_node(z.node)}
+
+    defp cldr_unit_struct?(%Zipper{node: {:%, _, [{:__aliases__, _, [:Cldr, :Unit]}, _fields]}}),
+      do: true
+
+    defp cldr_unit_struct?(_), do: false
+
+    defp rewrite_struct_node({:%, m, [{:__aliases__, am, [:Cldr, :Unit]}, {:%{}, mm, fields}]}) do
+      new_fields =
+        Enum.map(fields, fn
+          {{:__block__, fm, [:unit]}, value} ->
+            {{:__block__, fm, [:name]}, value_to_string(value)}
+
+          {:unit, value} ->
+            {:name, value_to_string(value)}
+
+          other ->
+            other
+        end)
+
+      {:%, m, [{:__aliases__, am, [:Localize, :Unit]}, {:%{}, mm, new_fields}]}
+    end
+
+    defp value_to_string({:__block__, m, [atom]}) when is_atom(atom) do
+      {:__block__, m, [to_dash_string(atom)]}
+    end
+
+    defp value_to_string(other), do: other
+
+    @doc """
+    Emits a notice telling the user where to read the rest of the 0.16
+    migration story, including the parts that can't be safely auto-rewritten
+    (`.unit` field accesses on bare variables, `BB.Safety.report_error/3`
+    semantic changes).
+    """
+    @spec add_release_notice(Igniter.t(), keyword()) :: Igniter.t()
+    def add_release_notice(igniter, _opts) do
+      Igniter.add_notice(igniter, """
+      bb 0.16 introduces two breaking changes. The upgrader has applied the
+      mechanical migrations; a few manual follow-ups may still be needed.
+
+      Read documentation/how-to/upgrade-to-0.16.md (or the corresponding
+      hexdocs page) for the full migration guide. Key things the upgrader
+      cannot safely automate:
+
+        * `value.unit` field accesses now need to be `value.name` and the
+          value is a string, not an atom. We don't rewrite bare `.unit`
+          accesses because we can't be sure of the receiver's type.
+
+        * `BB.Safety.report_error/3` no longer disarms the robot — it just
+          publishes a `[:safety, :error]` event. If you relied on the old
+          auto-disarm behaviour, escalate via crashing (raise/exit) so the
+          topology supervisor's restart budget can trigger force-disarm.
+      """)
+    end
+
+    # --- internal helpers ----------------------------------------------------
+
+    defp find_bb_user_modules(igniter) do
+      ProjectModule.find_all_matching_modules(igniter, fn _mod, zipper ->
+        uses_any?(zipper, @bb_use_macros) or implements_any_behaviour?(zipper, @bb_behaviours)
+      end)
+    end
+
+    defp find_modules_using(igniter, modules) do
+      ProjectModule.find_all_matching_modules(igniter, fn _mod, zipper ->
+        uses_any?(zipper, modules)
+      end)
+    end
+
+    defp uses_any?(zipper, modules) do
+      Enum.any?(modules, fn module ->
+        match?({:ok, _}, Module.move_to_use(zipper, module))
+      end)
+    end
+
+    defp implements_any_behaviour?(zipper, modules) do
+      Enum.any?(modules, fn module ->
+        match?({:ok, _}, Common.move_to(zipper, &behaviour_node?(&1, module)))
+      end)
+    end
+
+    defp behaviour_node?(%Zipper{node: node}, module) do
+      target = module |> Elixir.Module.split() |> Enum.map(&String.to_atom/1)
+
+      case node do
+        {:@, _, [{:behaviour, _, [{:__aliases__, _, ^target}]}]} -> true
+        _ -> false
+      end
+    rescue
+      _ -> false
+    end
+
+    defp has_do_block?(zipper) do
+      match?({:ok, _}, Common.move_to_do_block(zipper))
+    end
+  end
+end

--- a/lib/mix/tasks/bb.upgrade.ex
+++ b/lib/mix/tasks/bb.upgrade.ex
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.Bb.Upgrade do
+    @shortdoc "Run upgrade tasks for `bb` between two versions"
+    @moduledoc """
+    #{@shortdoc}
+
+    Usually invoked indirectly via `mix igniter.upgrade bb`.
+
+    ## Example
+
+    ```bash
+    mix igniter.upgrade bb
+    ```
+    """
+
+    use Igniter.Mix.Task
+
+    alias BB.Igniter.Upgrade.V0_16
+
+    @impl Igniter.Mix.Task
+    def info(_argv, _source) do
+      %Igniter.Mix.Task.Info{
+        group: :bb,
+        positional: [:from, :to]
+      }
+    end
+
+    @impl Igniter.Mix.Task
+    def igniter(igniter) do
+      positional = igniter.args.positional
+
+      upgrades = %{
+        "0.16.0" => [
+          &V0_16.remove_auto_disarm_on_error/2,
+          &V0_16.rename_bb_cldr_unit_alias/2,
+          &V0_16.rewrite_cldr_unit_calls/2,
+          &V0_16.rewrite_cldr_unit_struct_patterns/2,
+          &V0_16.add_release_notice/2
+        ]
+      }
+
+      Igniter.Upgrades.run(igniter, positional.from, positional.to, upgrades,
+        custom_opts: igniter.args.options
+      )
+    end
+  end
+else
+  defmodule Mix.Tasks.Bb.Upgrade do
+    @moduledoc false
+
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The task `bb.upgrade` requires `:igniter`. Add it to your dependencies and try again.
+
+      For more information, see: https://hexdocs.pm/igniter/readme.html#installation
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/test/bb/igniter/upgrade/v0_16_test.exs
+++ b/test/bb/igniter/upgrade/v0_16_test.exs
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# credo:disable-for-next-line Credo.Check.Readability.ModuleNames
+defmodule BB.Igniter.Upgrade.V0_16Test do
+  use ExUnit.Case, async: true
+
+  import Igniter.Test
+
+  alias BB.Igniter.Upgrade.V0_16
+
+  describe "remove_auto_disarm_on_error/2" do
+    test "removes the setting from a robot module" do
+      [
+        files: %{
+          "lib/my_app/robot.ex" => """
+          defmodule MyApp.Robot do
+            use BB
+
+            settings do
+              auto_disarm_on_error false
+            end
+
+            topology do
+              link :base
+            end
+          end
+          """
+        }
+      ]
+      |> test_project()
+      |> V0_16.remove_auto_disarm_on_error([])
+      |> assert_has_patch("lib/my_app/robot.ex", """
+      |    settings do
+      -|      auto_disarm_on_error false
+      |    end
+      """)
+    end
+
+    test "leaves modules that don't use BB untouched" do
+      [
+        files: %{
+          "lib/some_other.ex" => """
+          defmodule SomeOther do
+            def auto_disarm_on_error(_), do: :ok
+          end
+          """
+        }
+      ]
+      |> test_project()
+      |> V0_16.remove_auto_disarm_on_error([])
+      |> assert_unchanged("lib/some_other.ex")
+    end
+  end
+
+  describe "rename_bb_cldr_unit_alias/2" do
+    test "rewrites a bare alias" do
+      [
+        files: %{
+          "lib/my_app/foo.ex" => """
+          defmodule MyApp.Foo do
+            alias BB.Cldr.Unit
+
+            def compat?(u), do: Unit.compatible?(u, "meter")
+          end
+          """
+        }
+      ]
+      |> test_project()
+      |> V0_16.rename_bb_cldr_unit_alias([])
+      |> assert_has_patch("lib/my_app/foo.ex", """
+      -|  alias BB.Cldr.Unit
+      +|  alias BB.Unit
+      """)
+    end
+
+    test "preserves the `as:` clause" do
+      [
+        files: %{
+          "lib/my_app/bar.ex" => """
+          defmodule MyApp.Bar do
+            alias BB.Cldr.Unit, as: CldrUnit
+
+            def name(u), do: u.name
+          end
+          """
+        }
+      ]
+      |> test_project()
+      |> V0_16.rename_bb_cldr_unit_alias([])
+      |> assert_has_patch("lib/my_app/bar.ex", """
+      -|  alias BB.Cldr.Unit, as: CldrUnit
+      +|  alias BB.Unit, as: CldrUnit
+      """)
+    end
+  end
+
+  describe "rewrite_cldr_unit_calls/2" do
+    test "rewrites `Cldr.Unit.new!` in a BB.Actuator module, reversing args and dashing the atom" do
+      [
+        files: %{
+          "lib/my_app/servo.ex" => """
+          defmodule MyApp.Servo do
+            use BB.Actuator
+
+            def disarm(_), do: :ok
+
+            def init(_) do
+              {:ok, %{torque: Cldr.Unit.new!(:newton_meter, 5)}}
+            end
+          end
+          """
+        }
+      ]
+      |> test_project()
+      |> V0_16.rewrite_cldr_unit_calls([])
+      |> assert_has_patch("lib/my_app/servo.ex", """
+      -|      {:ok, %{torque: Cldr.Unit.new!(:newton_meter, 5)}}
+      +|      {:ok, %{torque: Localize.Unit.new!(5, "newton-meter")}}
+      """)
+    end
+
+    test "rewrites `Cldr.Unit.convert!` in a BB.Sensor module" do
+      [
+        files: %{
+          "lib/my_app/sensor.ex" => """
+          defmodule MyApp.Sensor do
+            use BB.Sensor
+
+            def init(_) do
+              v = some_unit() |> Cldr.Unit.convert!(:radian_per_second)
+              {:ok, v}
+            end
+
+            defp some_unit, do: nil
+          end
+          """
+        }
+      ]
+      |> test_project()
+      |> V0_16.rewrite_cldr_unit_calls([])
+      |> assert_has_patch("lib/my_app/sensor.ex", """
+      -|      v = some_unit() |> Cldr.Unit.convert!(:radian_per_second)
+      +|      v = some_unit() |> Localize.Unit.convert!("radian-per-second")
+      """)
+    end
+
+    test "leaves non-BB modules untouched" do
+      [
+        files: %{
+          "lib/random.ex" => """
+          defmodule Random do
+            def thing, do: Cldr.Unit.new!(:meter, 5)
+          end
+          """
+        }
+      ]
+      |> test_project()
+      |> V0_16.rewrite_cldr_unit_calls([])
+      |> assert_unchanged("lib/random.ex")
+    end
+  end
+
+  describe "rewrite_cldr_unit_struct_patterns/2" do
+    test "rewrites `%Cldr.Unit{}` to `%Localize.Unit{}` with name field rename" do
+      [
+        files: %{
+          "lib/my_app/sensor.ex" => """
+          defmodule MyApp.Sensor do
+            use BB.Sensor
+
+            def init(_) do
+              {:ok, %Cldr.Unit{unit: :meter, value: 1}}
+            end
+          end
+          """
+        }
+      ]
+      |> test_project()
+      |> V0_16.rewrite_cldr_unit_struct_patterns([])
+      |> assert_has_patch("lib/my_app/sensor.ex", """
+      -|      {:ok, %Cldr.Unit{unit: :meter, value: 1}}
+      +|      {:ok, %Localize.Unit{name: "meter", value: 1}}
+      """)
+    end
+  end
+
+  describe "add_release_notice/2" do
+    test "adds the migration notice" do
+      igniter =
+        []
+        |> test_project()
+        |> V0_16.add_release_notice([])
+
+      assert Enum.any?(igniter.notices, fn n ->
+               String.contains?(n, "documentation/how-to/upgrade-to-0.16.md")
+             end)
+    end
+  end
+end


### PR DESCRIPTION
Adds `mix igniter.upgrade bb` support so users on bb 0.15.x can be carried across the two breaking changes in 0.16 (topology supervisor escalation + localize migration) automatically.

Branches off #96 (localize migration) so the upgrader can reference the new types/aliases. Should merge after #96.

## What the upgrader does

* Removes `auto_disarm_on_error` lines from robot `settings do … end` blocks
* Renames `alias BB.Cldr.Unit` to `alias BB.Unit` (preserving any `as:` clause)
* Inside modules that use a BB DSL macro (`use BB`/`BB.Actuator`/`BB.Sensor`/`BB.Controller`/`BB.Bridge`/`BB.Command`) or implement `@behaviour BB.Safety`:
  * Rewrites `Cldr.Unit.{new!,convert!,convert,compatible?,compare,to_string,to_string!}` to `Localize.Unit.*` equivalents, translating atom unit names (`:newton_meter`) to CLDR canonical dash form (`\"newton-meter\"`) and reversing the arg order of `new!/2`
  * Rewrites `%Cldr.Unit{unit: :foo, ...}` to `%Localize.Unit{name: \"foo\", ...}` (struct rename + field rename + value translation)
* Prints a notice pointing the user at the upgrade-to-0.16 how-to for the manual follow-ups

## What it can't (and won't try to) automate

* `value.unit` field access on bare variables — no reliable way to tell whether the receiver is a unit struct vs anything else that has a `:unit` field
* `BB.Safety.report_error/3` semantic change — the call still compiles, only the behaviour differs

The how-to doc spells out both of these so users know what to look for.

## Scope

Following the AskUserQuestion confirmation, unit-API rewrites are gated on the file being a BB-using module. Random Elixir files that happen to call `Cldr.Unit.new!` (e.g. an app that has its own `ex_cldr_units` dep alongside bb) are left untouched.

## Test plan

- [x] 9 unit tests covering each migration function via Igniter's test mode, exercising both happy paths and the \"leave non-BB modules alone\" guarantee
- [x] `mix check --no-retry` clean (882 tests, dialyzer, credo, formatter, ex_doc, spark_cheat_sheets)
- [ ] Manual smoke test: run `mix igniter.upgrade bb` against a sample 0.15 project (deferred — needs a published 0.16)