### PR TITLE
improvement: add `test-subprojects` CI workflow

### DIFF
--- a/.github/workflows/test-subprojects.yml
+++ b/.github/workflows/test-subprojects.yml
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Test Subprojects
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    name: Discover downstream packages
+    runs-on: ubuntu-latest
+    if: github.repository == 'beam-bots/bb'
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+      siblings: ${{ steps.discover.outputs.siblings }}
+    steps:
+      - id: discover
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ORG: beam-bots
+        run: |
+          set -euo pipefail
+          # Find every non-archived bb_* repo in the org. bb_workspace is the
+          # meta-workspace, not an Elixir package, so skip it.
+          repos=$(gh api -X GET "/orgs/${ORG}/repos" --paginate \
+            --jq '[.[]
+              | select(.archived == false)
+              | select(.name | startswith("bb_"))
+              | select(.name != "bb_workspace")
+              | .name]')
+
+          # Only include repos with a top-level mix.exs — bb_examples is a docs
+          # repo and would fail the test step.
+          mix_repos="[]"
+          for name in $(jq -r '.[]' <<<"$repos"); do
+            if gh api "/repos/${ORG}/${name}/contents/mix.exs" --silent >/dev/null 2>&1; then
+              mix_repos=$(jq --arg n "$name" '. + [$n]' <<<"$mix_repos")
+            else
+              echo "skip ${name} (no top-level mix.exs)"
+            fi
+          done
+
+          matrix=$(jq -c '{project: map({name: .})}' <<<"$mix_repos")
+          siblings=$(jq -c '.' <<<"$mix_repos")
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          echo "siblings=${siblings}" >> "$GITHUB_OUTPUT"
+          echo "Discovered $(jq 'length' <<<"$mix_repos") subprojects: ${siblings}"
+
+  test-subprojects:
+    name: ${{ matrix.project.name }}
+    needs: discover
+    runs-on: ubuntu-latest
+    if: needs.discover.outputs.matrix != '{"project":[]}'
+    # Downstream breakage shouldn't block a bb PR while this workflow is bedding
+    # in; surface the failure but don't fail the run. Tighten once we trust it.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    env:
+      BB_VERSION: local
+      MIX_ENV: test
+    steps:
+      - name: Check out bb at this ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: bb
+
+      - name: Check out ${{ matrix.project.name }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: beam-bots/${{ matrix.project.name }}
+          path: ${{ matrix.project.name }}
+
+      - name: Check out sibling bb_* packages
+        # `BB_VERSION=local` resolves every bb-family dep to `../<package>`, so
+        # any sibling a subproject depends on (e.g. bb_example_wx200 ->
+        # bb_liveview) needs to be checked out alongside.
+        env:
+          SIBLINGS: ${{ needs.discover.outputs.siblings }}
+          TARGET: ${{ matrix.project.name }}
+        run: |
+          set -euo pipefail
+          for name in $(jq -r '.[]' <<<"${SIBLINGS}"); do
+            if [ "${name}" = "${TARGET}" ]; then
+              continue
+            fi
+            git clone --depth 1 "https://github.com/beam-bots/${name}.git" "${name}"
+          done
+
+      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        with:
+          version-file: bb/.tool-versions
+          version-type: strict
+
+      - name: mix deps.get
+        working-directory: ${{ matrix.project.name }}
+        run: mix deps.get
+
+      - name: mix compile --force --warnings-as-errors
+        working-directory: ${{ matrix.project.name }}
+        run: mix compile --force --warnings-as-errors
+
+      - name: mix test
+        working-directory: ${{ matrix.project.name }}
+        run: mix test

--- a/.github/workflows/test-subprojects.yml
+++ b/.github/workflows/test-subprojects.yml
@@ -73,7 +73,6 @@ jobs:
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
     env:
       BB_VERSION: local
-      MIX_ENV: test
     steps:
       - name: Check out bb at this ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -111,10 +110,6 @@ jobs:
         working-directory: ${{ matrix.project.name }}
         run: mix deps.get
 
-      - name: mix compile --force --warnings-as-errors
+      - name: mix check --no-retry
         working-directory: ${{ matrix.project.name }}
-        run: mix compile --force --warnings-as-errors
-
-      - name: mix test
-        working-directory: ${{ matrix.project.name }}
-        run: mix test
+        run: mix check --no-retry

--- a/.github/workflows/test-subprojects.yml
+++ b/.github/workflows/test-subprojects.yml
@@ -101,10 +101,30 @@ jobs:
             git clone --depth 1 "https://github.com/beam-bots/${name}.git" "${name}"
           done
 
-      - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+      - id: beam
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           version-file: bb/.tool-versions
           version-type: strict
+
+      - name: Cache deps
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ matrix.project.name }}/deps
+          key: ${{ runner.os }}-otp${{ steps.beam.outputs.otp-version }}-elixir${{ steps.beam.outputs.elixir-version }}-${{ matrix.project.name }}-deps-${{ hashFiles(format('{0}/mix.lock', matrix.project.name)) }}
+          restore-keys: |
+            ${{ runner.os }}-otp${{ steps.beam.outputs.otp-version }}-elixir${{ steps.beam.outputs.elixir-version }}-${{ matrix.project.name }}-deps-
+
+      - name: Cache _build (compiled deps + PLT)
+        # Dialyxir's PLT lives in _build/<env>/, so this also caches the PLT
+        # across runs. Bust the cache when bb's mix.lock changes, since that
+        # reshuffles which bb transitive deps end up in _build.
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ matrix.project.name }}/_build
+          key: ${{ runner.os }}-otp${{ steps.beam.outputs.otp-version }}-elixir${{ steps.beam.outputs.elixir-version }}-${{ matrix.project.name }}-build-${{ hashFiles(format('{0}/mix.lock', matrix.project.name), 'bb/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-otp${{ steps.beam.outputs.otp-version }}-elixir${{ steps.beam.outputs.elixir-version }}-${{ matrix.project.name }}-build-
 
       - name: mix deps.get
         working-directory: ${{ matrix.project.name }}

--- a/.github/workflows/test-subprojects.yml
+++ b/.github/workflows/test-subprojects.yml
@@ -29,31 +29,36 @@ jobs:
           ORG: beam-bots
         run: |
           set -euo pipefail
-          # Find every non-archived bb_* repo in the org. bb_workspace is the
-          # meta-workspace, not an Elixir package, so skip it.
-          repos=$(gh api -X GET "/orgs/${ORG}/repos" --paginate \
+          # Every non-archived repo in the org, except bb itself (checked out
+          # separately) and bb_workspace (the meta-workspace, not a package).
+          candidates=$(gh api -X GET "/orgs/${ORG}/repos" --paginate \
             --jq '[.[]
               | select(.archived == false)
-              | select(.name | startswith("bb_"))
+              | select(.name != "bb")
               | select(.name != "bb_workspace")
               | .name]')
 
-          # Only include repos with a top-level mix.exs — bb_examples is a docs
-          # repo and would fail the test step.
-          mix_repos="[]"
-          for name in $(jq -r '.[]' <<<"$repos"); do
+          # Keep only repos with a top-level mix.exs. These are the "siblings"
+          # we clone alongside the project under test so cross-package deps
+          # resolve under BB_VERSION=local (e.g. bb_so101 -> feetech).
+          siblings_array="[]"
+          for name in $(jq -r '.[]' <<<"$candidates"); do
             if gh api "/repos/${ORG}/${name}/contents/mix.exs" --silent >/dev/null 2>&1; then
-              mix_repos=$(jq --arg n "$name" '. + [$n]' <<<"$mix_repos")
+              siblings_array=$(jq --arg n "$name" '. + [$n]' <<<"$siblings_array")
             else
               echo "skip ${name} (no top-level mix.exs)"
             fi
           done
 
-          matrix=$(jq -c '{project: map({name: .})}' <<<"$mix_repos")
-          siblings=$(jq -c '.' <<<"$mix_repos")
+          # The matrix (packages we actually test) is the bb_* subset. Non-bb_
+          # siblings like feetech are libraries we depend on, not bb subprojects.
+          matrix=$(jq -c '{project: [.[] | select(startswith("bb_")) | {name: .}]}' \
+            <<<"$siblings_array")
+          siblings=$(jq -c '.' <<<"$siblings_array")
           echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
           echo "siblings=${siblings}" >> "$GITHUB_OUTPUT"
-          echo "Discovered $(jq 'length' <<<"$mix_repos") subprojects: ${siblings}"
+          echo "Siblings: ${siblings}"
+          echo "Matrix:   ${matrix}"
 
   test-subprojects:
     name: ${{ matrix.project.name }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/test-subprojects.yml` to test every `beam-bots/bb_*` downstream package against the candidate `bb` source.
- The matrix is built **dynamically** from the GitHub API at workflow start — a new downstream package is picked up automatically, no edits to this workflow required.
- All sibling `bb_*` repos are checked out alongside the target so cross-package deps (e.g. `bb_example_wx200` → `bb_liveview`, `bb_servo_robotis`, …) resolve under `BB_VERSION=local`.
- `continue-on-error: true` while this beds in, per the issue: a red downstream shouldn't block a bb PR yet. Tighten once we trust the signal.

Closes #99.

## Discovery rules

The `discover` job lists `beam-bots/*` repos, then keeps the ones that are:

- non-archived
- name starts with `bb_`
- not `bb_workspace` (meta workspace, not a package)
- have a top-level `mix.exs` (filters out doc repos like `bb_examples`)

That yields the same 15 packages listed in the issue today, dynamically.

## Test plan

- [ ] Workflow parses and runs on this PR (the workflow itself runs on `pull_request`).
- [ ] `discover` job emits a non-empty matrix and the `test-subprojects` matrix expands.
- [ ] At least one subproject job goes green end-to-end (deps.get → compile → test) under `BB_VERSION=local`.
- [ ] Red subprojects surface as yellow on the PR rather than blocking it (verifies `continue-on-error: true`).

## Open questions deferred from the issue

- Whether to keep `continue-on-error: true` or tighten — defer until we've seen the steady-state pass rate.
- Phoenix asset compilation for `bb_example_*` — leave as-is; if `mix test` fails due to missing assets we'll add a per-project `setup` step then.