### PR TITLE
feat: prompt for Nx backend during `mix igniter.install bb`

### DIFF
--- a/lib/mix/tasks/bb.add_nx_backend.ex
+++ b/lib/mix/tasks/bb.add_nx_backend.ex
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.Bb.AddNxBackend do
+    @shortdoc "Configures an Nx backend for the project"
+    @moduledoc """
+    #{@shortdoc}
+
+    BB uses Nx for kinematics and motion planning. Nx defaults to
+    `Nx.BinaryBackend` — a pure-Elixir reference implementation that is fine
+    for sanity checks but orders of magnitude slower than the native backends.
+    This task prompts the user to pick a backend and applies the dep + config
+    changes.
+
+    Skips itself entirely if `:nx` is already configured, or if `:exla` /
+    `:torchx` is already declared in `mix.exs`.
+
+    ## Examples
+
+    ```bash
+    # Interactive (prompts to choose a backend)
+    mix bb.add_nx_backend
+
+    # Non-interactive (defaults to exla)
+    mix bb.add_nx_backend --yes
+
+    # Explicit choice
+    mix bb.add_nx_backend --backend exla
+    mix bb.add_nx_backend --backend torchx
+    mix bb.add_nx_backend --backend binary
+    ```
+
+    ## Options
+
+    * `--backend` - One of `exla`, `torchx`, or `binary`. Skips the prompt.
+    """
+
+    use Igniter.Mix.Task
+
+    alias Igniter.Project.Config
+    alias Igniter.Project.Deps
+    alias Igniter.Util.IO, as: IgniterIO
+
+    @nx_version "~> 0.10"
+
+    @backends [
+      {"EXLA (recommended — JIT-compiled native CPU/GPU)", :exla},
+      {"Torchx (libtorch — useful if you'll integrate with PyTorch models)", :torchx},
+      {"Binary (pure Elixir, slow, no extra dependencies)", :binary}
+    ]
+
+    @impl Igniter.Mix.Task
+    def info(_argv, _parent) do
+      %Igniter.Mix.Task.Info{
+        schema: [backend: :string],
+        aliases: [b: :backend]
+      }
+    end
+
+    @impl Igniter.Mix.Task
+    def igniter(igniter) do
+      cond do
+        already_configured?(igniter) ->
+          igniter
+
+        backend = explicit_backend(igniter) ->
+          apply_backend(igniter, backend)
+
+        non_interactive?(igniter) ->
+          apply_backend(igniter, :exla)
+
+        true ->
+          apply_backend(igniter, prompt_backend())
+      end
+    end
+
+    defp non_interactive?(igniter) do
+      igniter.args.options[:yes] || igniter.assigns[:test_mode?]
+    end
+
+    defp already_configured?(igniter) do
+      Config.configures_root_key?(igniter, "config.exs", :nx) or
+        has_dep?(igniter, :exla) or
+        has_dep?(igniter, :torchx)
+    end
+
+    defp has_dep?(igniter, name) do
+      case Deps.get_dep(igniter, name) do
+        {:ok, nil} -> false
+        {:ok, _} -> true
+        {:error, _} -> false
+      end
+    end
+
+    defp explicit_backend(igniter) do
+      case Keyword.get(igniter.args.options, :backend) do
+        nil -> nil
+        value -> parse_backend(value)
+      end
+    end
+
+    defp parse_backend(value) do
+      case String.downcase(to_string(value)) do
+        "exla" ->
+          :exla
+
+        "torchx" ->
+          :torchx
+
+        "binary" ->
+          :binary
+
+        other ->
+          Mix.raise("Unknown Nx backend: #{inspect(other)}. Expected exla, torchx, or binary.")
+      end
+    end
+
+    defp prompt_backend do
+      IgniterIO.select(
+        "Which Nx backend would you like to use?",
+        @backends,
+        display: &elem(&1, 0),
+        default: List.first(@backends)
+      )
+      |> elem(1)
+    end
+
+    defp apply_backend(igniter, :exla) do
+      igniter
+      |> Deps.add_dep({:exla, @nx_version}, on_exists: :skip)
+      |> Config.configure(
+        "config.exs",
+        :nx,
+        [:default_backend],
+        {:code, Sourceror.parse_string!("EXLA.Backend")}
+      )
+    end
+
+    defp apply_backend(igniter, :torchx) do
+      igniter
+      |> Deps.add_dep({:torchx, @nx_version}, on_exists: :skip)
+      |> Config.configure(
+        "config.exs",
+        :nx,
+        [:default_backend],
+        {:code, Sourceror.parse_string!("Torchx.Backend")}
+      )
+    end
+
+    defp apply_backend(igniter, :binary) do
+      Igniter.add_notice(
+        igniter,
+        "Nx will use the default BinaryBackend (pure Elixir). Performance will be limited; switch to EXLA or Torchx for serious workloads."
+      )
+    end
+  end
+else
+  defmodule Mix.Tasks.Bb.AddNxBackend do
+    @shortdoc "Configures an Nx backend for the project"
+    @moduledoc false
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The bb.add_nx_backend task requires igniter.
+
+          mix deps.get
+          mix bb.add_nx_backend
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/lib/mix/tasks/bb.add_nx_backend.ex
+++ b/lib/mix/tasks/bb.add_nx_backend.ex
@@ -14,8 +14,13 @@ if Code.ensure_loaded?(Igniter) do
     This task prompts the user to pick a backend and applies the dep + config
     changes.
 
-    Skips itself entirely if `:nx` is already configured, or if `:exla` /
-    `:torchx` is already declared in `mix.exs`.
+    The `config :nx, default_backend: …` line is written to `config/runtime.exs`,
+    not `config/config.exs`. BB performs compile-time tensor operations in
+    its Spark transformer chain, and EXLA/Torchx aren't started during
+    compilation — so a compile-time default crashes the robot module compile.
+
+    Skips itself entirely if `:nx` is already configured in `runtime.exs` or
+    `config.exs`, or if `:exla` / `:torchx` is already declared in `mix.exs`.
 
     ## Examples
 
@@ -81,7 +86,8 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     defp already_configured?(igniter) do
-      Config.configures_root_key?(igniter, "config.exs", :nx) or
+      Config.configures_root_key?(igniter, "runtime.exs", :nx) or
+        Config.configures_root_key?(igniter, "config.exs", :nx) or
         has_dep?(igniter, :exla) or
         has_dep?(igniter, :torchx)
     end
@@ -130,29 +136,35 @@ if Code.ensure_loaded?(Igniter) do
     defp apply_backend(igniter, :exla) do
       igniter
       |> Deps.add_dep({:exla, @nx_version}, on_exists: :skip)
-      |> Config.configure(
-        "config.exs",
-        :nx,
-        [:default_backend],
-        {:code, Sourceror.parse_string!("EXLA.Backend")}
-      )
+      |> set_default_backend("EXLA.Backend")
     end
 
     defp apply_backend(igniter, :torchx) do
       igniter
       |> Deps.add_dep({:torchx, @nx_version}, on_exists: :skip)
-      |> Config.configure(
-        "config.exs",
-        :nx,
-        [:default_backend],
-        {:code, Sourceror.parse_string!("Torchx.Backend")}
-      )
+      |> set_default_backend("Torchx.Backend")
     end
 
     defp apply_backend(igniter, :binary) do
       Igniter.add_notice(
         igniter,
         "Nx will use the default BinaryBackend (pure Elixir). Performance will be limited; switch to EXLA or Torchx for serious workloads."
+      )
+    end
+
+    # Writes `config :nx, default_backend: <Backend>` to `config/runtime.exs`,
+    # not `config/config.exs`. BB performs compile-time tensor operations in
+    # its Spark transformer chain (BB.Robot.Builder); the EXLA/Torchx backend
+    # processes aren't started during compilation, so a compile-time default
+    # crashes the user's robot-module compile with a `no process: EXLA.Client`
+    # error.
+    defp set_default_backend(igniter, backend_module) do
+      Config.configure(
+        igniter,
+        "runtime.exs",
+        :nx,
+        [:default_backend],
+        {:code, Sourceror.parse_string!(backend_module)}
       )
     end
   end

--- a/lib/mix/tasks/bb.add_robot.ex
+++ b/lib/mix/tasks/bb.add_robot.ex
@@ -42,7 +42,17 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     defp create_robot_module(igniter, module) do
-      contents = """
+      case Module.module_exists(igniter, module) do
+        {true, igniter} ->
+          igniter
+
+        {false, igniter} ->
+          Module.create_module(igniter, module, robot_module_contents())
+      end
+    end
+
+    defp robot_module_contents do
+      """
       use BB
 
       commands do
@@ -62,8 +72,6 @@ if Code.ensure_loaded?(Igniter) do
         end
       end
       """
-
-      Module.create_module(igniter, module, contents)
     end
 
     defp add_to_supervision_tree(igniter, robot_module) do

--- a/lib/mix/tasks/bb.install.ex
+++ b/lib/mix/tasks/bb.install.ex
@@ -8,11 +8,22 @@ if Code.ensure_loaded?(Igniter) do
     @moduledoc """
     #{@shortdoc}
 
+    Composes `bb.add_robot` (scaffolds a robot module) and `bb.add_nx_backend`
+    (prompts to configure an Nx backend — defaults to EXLA).
+
     ## Example
 
     ```bash
     mix igniter.install bb
+    mix igniter.install bb --robot MyApp.Robot --backend exla
     ```
+
+    ## Options
+
+    * `--robot` - The module name for the robot (defaults to `{AppPrefix}.Robot`).
+    * `--backend` - Nx backend to install: `exla`, `torchx`, or `binary`.
+      If omitted, the user is prompted (defaults to `exla` in non-interactive
+      runs).
     """
 
     use Igniter.Mix.Task
@@ -22,9 +33,9 @@ if Code.ensure_loaded?(Igniter) do
     @impl Igniter.Mix.Task
     def info(_argv, _parent) do
       %Igniter.Mix.Task.Info{
-        composes: ["bb.add_robot"],
-        schema: [robot: :string],
-        aliases: [r: :robot]
+        composes: ["bb.add_robot", "bb.add_nx_backend"],
+        schema: [robot: :string, backend: :string],
+        aliases: [r: :robot, b: :backend]
       }
     end
 
@@ -35,6 +46,14 @@ if Code.ensure_loaded?(Igniter) do
       igniter
       |> Formatter.import_dep(:bb)
       |> Igniter.compose_task("bb.add_robot", ["--robot", inspect(robot_module)])
+      |> Igniter.compose_task("bb.add_nx_backend", nx_backend_argv(igniter))
+    end
+
+    defp nx_backend_argv(igniter) do
+      case Keyword.get(igniter.args.options, :backend) do
+        nil -> []
+        backend -> ["--backend", backend]
+      end
     end
   end
 else

--- a/test/mix/tasks/bb.add_nx_backend_test.exs
+++ b/test/mix/tasks/bb.add_nx_backend_test.exs
@@ -17,13 +17,24 @@ defmodule Mix.Tasks.Bb.AddNxBackendTest do
       """)
     end
 
-    test "writes the default_backend config" do
+    test "writes the default_backend config to runtime.exs" do
       igniter =
         test_project()
         |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "exla"])
 
-      {_, source} = Rewrite.source(igniter.rewrite, "config/config.exs")
+      {_, source} = Rewrite.source(igniter.rewrite, "config/runtime.exs")
       assert source.content =~ "config :nx, default_backend: EXLA.Backend"
+    end
+
+    test "does not write to config.exs (compile-time backend would crash BB transformers)" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "exla"])
+
+      case Rewrite.source(igniter.rewrite, "config/config.exs") do
+        {:ok, source} -> refute source.content =~ "default_backend"
+        {:error, _} -> :ok
+      end
     end
   end
 
@@ -36,12 +47,12 @@ defmodule Mix.Tasks.Bb.AddNxBackendTest do
       """)
     end
 
-    test "writes the default_backend config" do
+    test "writes the default_backend config to runtime.exs" do
       igniter =
         test_project()
         |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "torchx"])
 
-      {_, source} = Rewrite.source(igniter.rewrite, "config/config.exs")
+      {_, source} = Rewrite.source(igniter.rewrite, "config/runtime.exs")
       assert source.content =~ "config :nx, default_backend: Torchx.Backend"
     end
   end
@@ -65,7 +76,21 @@ defmodule Mix.Tasks.Bb.AddNxBackendTest do
   end
 
   describe "skipping" do
-    test "skips when :nx is already configured" do
+    test "skips when :nx is already configured in runtime.exs" do
+      test_project(
+        files: %{
+          "config/runtime.exs" => """
+          import Config
+
+          config :nx, default_backend: Some.Other.Backend
+          """
+        }
+      )
+      |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "exla"])
+      |> assert_unchanged()
+    end
+
+    test "skips when :nx is already configured in config.exs" do
       test_project(
         files: %{
           "config/config.exs" => """

--- a/test/mix/tasks/bb.add_nx_backend_test.exs
+++ b/test/mix/tasks/bb.add_nx_backend_test.exs
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Mix.Tasks.Bb.AddNxBackendTest do
+  use ExUnit.Case
+  import Igniter.Test
+
+  @moduletag :igniter
+
+  describe "--backend exla" do
+    test "adds the exla dep" do
+      test_project()
+      |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "exla"])
+      |> assert_has_patch("mix.exs", """
+      + |      {:exla, "~> 0.10"}
+      """)
+    end
+
+    test "writes the default_backend config" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "exla"])
+
+      {_, source} = Rewrite.source(igniter.rewrite, "config/config.exs")
+      assert source.content =~ "config :nx, default_backend: EXLA.Backend"
+    end
+  end
+
+  describe "--backend torchx" do
+    test "adds the torchx dep" do
+      test_project()
+      |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "torchx"])
+      |> assert_has_patch("mix.exs", """
+      + |      {:torchx, "~> 0.10"}
+      """)
+    end
+
+    test "writes the default_backend config" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "torchx"])
+
+      {_, source} = Rewrite.source(igniter.rewrite, "config/config.exs")
+      assert source.content =~ "config :nx, default_backend: Torchx.Backend"
+    end
+  end
+
+  describe "--backend binary" do
+    test "does not add any dep or config" do
+      test_project()
+      |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "binary"])
+      |> assert_unchanged()
+    end
+  end
+
+  describe "non-interactive default" do
+    test "with --yes defaults to exla" do
+      test_project()
+      |> Igniter.compose_task("bb.add_nx_backend", ["--yes"])
+      |> assert_has_patch("mix.exs", """
+      + |      {:exla, "~> 0.10"}
+      """)
+    end
+  end
+
+  describe "skipping" do
+    test "skips when :nx is already configured" do
+      test_project(
+        files: %{
+          "config/config.exs" => """
+          import Config
+
+          config :nx, default_backend: Some.Other.Backend
+          """
+        }
+      )
+      |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "exla"])
+      |> assert_unchanged()
+    end
+
+    test "skips when :exla is already a dep" do
+      project = test_project()
+
+      mix_exs =
+        project.rewrite
+        |> Rewrite.source!("mix.exs")
+        |> Rewrite.Source.get(:content)
+        |> String.replace(
+          ~r/(defp deps do\s*\n\s*\[)/,
+          "\\1\n      {:exla, \"~> 0.10\"},"
+        )
+
+      test_project(files: %{"mix.exs" => mix_exs})
+      |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "torchx"])
+      |> assert_unchanged()
+    end
+
+    test "skips when :torchx is already a dep" do
+      project = test_project()
+
+      mix_exs =
+        project.rewrite
+        |> Rewrite.source!("mix.exs")
+        |> Rewrite.Source.get(:content)
+        |> String.replace(
+          ~r/(defp deps do\s*\n\s*\[)/,
+          "\\1\n      {:torchx, \"~> 0.10\"},"
+        )
+
+      test_project(files: %{"mix.exs" => mix_exs})
+      |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "exla"])
+      |> assert_unchanged()
+    end
+  end
+
+  describe "idempotency" do
+    test "running twice does not duplicate the dep or config" do
+      test_project()
+      |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "exla"])
+      |> apply_igniter!()
+      |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "exla"])
+      |> assert_unchanged()
+    end
+  end
+
+  describe "invalid input" do
+    test "raises on unknown backend value" do
+      assert_raise Mix.Error, ~r/Unknown Nx backend/, fn ->
+        test_project()
+        |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "tensorflow"])
+      end
+    end
+  end
+end

--- a/test/mix/tasks/bb.add_robot_test.exs
+++ b/test/mix/tasks/bb.add_robot_test.exs
@@ -59,4 +59,17 @@ defmodule Mix.Tasks.Bb.AddRobotTest do
     |> Igniter.compose_task("bb.add_robot", ["--robot", "Test.Robot2"])
     |> assert_creates("lib/test/robot2.ex")
   end
+
+  test "running twice for the same robot is a no-op (no `File already exists` issue)" do
+    igniter =
+      test_project()
+      |> Igniter.compose_task("bb.add_robot")
+      |> apply_igniter!()
+      |> Igniter.compose_task("bb.add_robot")
+
+    assert igniter.issues == [],
+           "expected no issues on a re-run, got: #{inspect(igniter.issues)}"
+
+    assert_unchanged(igniter)
+  end
 end

--- a/test/mix/tasks/bb.install_test.exs
+++ b/test/mix/tasks/bb.install_test.exs
@@ -62,12 +62,12 @@ defmodule Mix.Tasks.Bb.InstallTest do
     |> assert_unchanged()
   end
 
-  test "configures the chosen Nx backend" do
+  test "configures the chosen Nx backend in runtime.exs" do
     igniter =
       test_project()
       |> Igniter.compose_task("bb.install", ["--backend", "exla"])
 
-    {_, source} = Rewrite.source(igniter.rewrite, "config/config.exs")
+    {_, source} = Rewrite.source(igniter.rewrite, "config/runtime.exs")
     assert source.content =~ "config :nx, default_backend: EXLA.Backend"
 
     assert_has_patch(igniter, "mix.exs", """

--- a/test/mix/tasks/bb.install_test.exs
+++ b/test/mix/tasks/bb.install_test.exs
@@ -61,4 +61,17 @@ defmodule Mix.Tasks.Bb.InstallTest do
     |> Igniter.compose_task("bb.install")
     |> assert_unchanged()
   end
+
+  test "configures the chosen Nx backend" do
+    igniter =
+      test_project()
+      |> Igniter.compose_task("bb.install", ["--backend", "exla"])
+
+    {_, source} = Rewrite.source(igniter.rewrite, "config/config.exs")
+    assert source.content =~ "config :nx, default_backend: EXLA.Backend"
+
+    assert_has_patch(igniter, "mix.exs", """
+    + |      {:exla, "~> 0.10"}
+    """)
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `bb.add_nx_backend`, composed into `bb.install`, which prompts for an Nx backend (EXLA / Torchx / Binary) and writes the matching dep + `config :nx, default_backend: ...`.
- Non-interactive runs default to EXLA; an explicit `--backend exla|torchx|binary` flag bypasses the prompt.
- Skips itself entirely if `:nx` is already configured in `config/config.exs`, or if `:exla` / `:torchx` already appears in `mix.exs` — keeps the install idempotent and respects existing user choices.

## Behaviour

```
$ mix igniter.install bb
Which Nx backend would you like to use?
0. EXLA (recommended — JIT-compiled native CPU/GPU) (Default)
1. Torchx (libtorch — useful if you'll integrate with PyTorch models)
2. Binary (pure Elixir, slow, no extra dependencies)
Input number ❯
```

- EXLA → adds `{:exla, "~> 0.10"}`, sets `config :nx, default_backend: EXLA.Backend`.
- Torchx → adds `{:torchx, "~> 0.10"}`, sets `config :nx, default_backend: Torchx.Backend`.
- Binary → leaves Nx on its default backend and emits a notice that performance will be limited.

The `~> 0.10` constraint follows bb's existing `{:nx, "~> 0.10"}` constraint so versions line up.

## Test plan

- [x] `mix test test/mix/tasks/bb.add_nx_backend_test.exs` — 11 tests covering each backend, `--yes` default, skip paths (existing `:nx` config, existing `:exla` / `:torchx` dep), idempotency, and invalid input.
- [x] `mix test test/mix/tasks/bb.install_test.exs` — existing install tests still pass, plus one new test that confirms `bb.install --backend exla` writes the expected config and dep.
- [x] `mix check --no-retry` — compiler, credo, dialyzer, ex_doc, formatter, mix_audit, reuse, spark_formatter, spark_cheat_sheets all green.
- [ ] Manual smoke test via `mix igniter.install bb` in a fresh project — out of scope for this PR (open-questions in the issue around precompiled EXLA / Nerves / CUDA are deliberately deferred).

Closes #100.