### PR TITLE
fix: stop publishing synthetic target `JointState` from `BB.Motion`

### DIFF
--- a/lib/bb/motion.ex
+++ b/lib/bb/motion.ex
@@ -137,7 +137,6 @@ defmodule BB.Motion do
           {:ok, positions, meta} ->
             RobotState.set_positions(robot_state, positions)
             send_positions_to_actuators(robot_module, robot, positions, delivery)
-            publish_joint_state(robot_module, positions)
 
             result = {:ok, meta}
 
@@ -264,7 +263,6 @@ defmodule BB.Motion do
         all_positions = merge_all_positions(results)
         RobotState.set_positions(robot_state, all_positions)
         send_positions_to_actuators(robot_module, robot, all_positions, delivery)
-        publish_joint_state(robot_module, all_positions)
 
         {:ok, results}
 
@@ -364,7 +362,6 @@ defmodule BB.Motion do
       fn ->
         RobotState.set_positions(robot_state, positions)
         send_positions_to_actuators(robot_module, robot, positions, delivery, actuator_opts)
-        publish_joint_state(robot_module, positions)
         {:ok, %{}}
       end
     )
@@ -442,21 +439,4 @@ defmodule BB.Motion do
         end
     end
   end
-
-  defp publish_joint_state(robot_module, positions) when map_size(positions) > 0 do
-    {names, values} = positions |> Enum.unzip()
-    count = length(names)
-
-    {:ok, msg} =
-      BB.Message.new(BB.Message.Sensor.JointState, :motion,
-        names: names,
-        positions: Enum.map(values, &(&1 * 1.0)),
-        velocities: List.duplicate(0.0, count),
-        efforts: List.duplicate(0.0, count)
-      )
-
-    BB.publish(robot_module, [:sensor, :motion], msg)
-  end
-
-  defp publish_joint_state(_robot_module, _positions), do: :ok
 end


### PR DESCRIPTION
## Summary

- `BB.Motion.move_to/4`, `move_to_multi/3`, and `send_positions/3` each published a synthetic `JointState` to `[:sensor, :motion]` carrying the *target* positions immediately after dispatching the actuator command. Removed — estimators and real sensors are the authoritative source of joint position.

## Why

The 3D visualisers in `bb_liveview` and `bb_kino` both subscribe to `[:sensor | _]` and forward every `JointState` to the scene. Per waypoint, the visible sequence was:

1. `Motion` publishes `[:sensor, :motion]` `JointState` → visualiser snaps to the **target**.
2. `Sim.Actuator` publishes `BeginMotion` → `OpenLoopPositionEstimator` emits interpolated `JointState`s beginning at the **actual current** position → visualiser jumps back to start and smoothly traverses to the target.

The snap was always present but invisible before the trapezoidal profile change in #85: with the old rectangular profile, `Sim.Actuator.current_position` snapped to the previous target on every command, so the estimator's interpolation segment was effectively degenerate and the jump-back was imperceptible. The smoothed profile makes the underlying bug obvious.

`RobotState.set_positions/2` is still called synchronously inside `Motion`, so callers that need post-command joint state can read `RobotState.get_all_positions/1`.

## Test plan

- [x] `mix check --no-retry` (compiler, credo, dialyzer, ex_doc, ex_unit (888 tests / 21 doctests), formatter, mix_audit, reuse, spark_cheat_sheets, spark_formatter, unused_deps — all green)
- [ ] Manual: run `BB.Example.SO101.Robot.demo_circle()` against `bb_liveview` in simulation mode and confirm the 3D visualiser tracks the trapezoidal motion without the jump-to-target/jump-back-to-start glitch.