### PR TITLE
improvement: add nx_eigen to bb.add_nx_backend choices

### DIFF
--- a/lib/mix/tasks/bb.add_nx_backend.ex
+++ b/lib/mix/tasks/bb.add_nx_backend.ex
@@ -20,7 +20,8 @@ if Code.ensure_loaded?(Igniter) do
     compilation — so a compile-time default crashes the robot module compile.
 
     Skips itself entirely if `:nx` is already configured in `runtime.exs` or
-    `config.exs`, or if `:exla` / `:torchx` is already declared in `mix.exs`.
+    `config.exs`, or if `:exla` / `:torchx` / `:nx_eigen` is already declared
+    in `mix.exs`.
 
     ## Examples
 
@@ -34,12 +35,13 @@ if Code.ensure_loaded?(Igniter) do
     # Explicit choice
     mix bb.add_nx_backend --backend exla
     mix bb.add_nx_backend --backend torchx
+    mix bb.add_nx_backend --backend eigen
     mix bb.add_nx_backend --backend binary
     ```
 
     ## Options
 
-    * `--backend` - One of `exla`, `torchx`, or `binary`. Skips the prompt.
+    * `--backend` - One of `exla`, `torchx`, `eigen`, or `binary`. Skips the prompt.
     """
 
     use Igniter.Mix.Task
@@ -48,13 +50,18 @@ if Code.ensure_loaded?(Igniter) do
     alias Igniter.Project.Deps
     alias Igniter.Util.IO, as: IgniterIO
 
-    @nx_version "~> 0.10"
-
     @backends [
       {"EXLA (recommended — JIT-compiled native CPU/GPU)", :exla},
       {"Torchx (libtorch — useful if you'll integrate with PyTorch models)", :torchx},
+      {"Eigen (Eigen C++ — great on embedded targets like the UNO Q or Raspberry Pi)", :eigen},
       {"Binary (pure Elixir, slow, no extra dependencies)", :binary}
     ]
+
+    @packages %{
+      exla: {"exla", "EXLA.Backend"},
+      torchx: {"torchx", "Torchx.Backend"},
+      eigen: {"nx_eigen", "NxEigen.Backend"}
+    }
 
     @impl Igniter.Mix.Task
     def info(_argv, _parent) do
@@ -89,7 +96,8 @@ if Code.ensure_loaded?(Igniter) do
       Config.configures_root_key?(igniter, "runtime.exs", :nx) or
         Config.configures_root_key?(igniter, "config.exs", :nx) or
         has_dep?(igniter, :exla) or
-        has_dep?(igniter, :torchx)
+        has_dep?(igniter, :torchx) or
+        has_dep?(igniter, :nx_eigen)
     end
 
     defp has_dep?(igniter, name) do
@@ -115,11 +123,16 @@ if Code.ensure_loaded?(Igniter) do
         "torchx" ->
           :torchx
 
+        "eigen" ->
+          :eigen
+
         "binary" ->
           :binary
 
         other ->
-          Mix.raise("Unknown Nx backend: #{inspect(other)}. Expected exla, torchx, or binary.")
+          Mix.raise(
+            "Unknown Nx backend: #{inspect(other)}. Expected exla, torchx, eigen, or binary."
+          )
       end
     end
 
@@ -133,23 +146,19 @@ if Code.ensure_loaded?(Igniter) do
       |> elem(1)
     end
 
-    defp apply_backend(igniter, :exla) do
-      igniter
-      |> Deps.add_dep({:exla, @nx_version}, on_exists: :skip)
-      |> set_default_backend("EXLA.Backend")
-    end
-
-    defp apply_backend(igniter, :torchx) do
-      igniter
-      |> Deps.add_dep({:torchx, @nx_version}, on_exists: :skip)
-      |> set_default_backend("Torchx.Backend")
-    end
-
     defp apply_backend(igniter, :binary) do
       Igniter.add_notice(
         igniter,
-        "Nx will use the default BinaryBackend (pure Elixir). Performance will be limited; switch to EXLA or Torchx for serious workloads."
+        "Nx will use the default BinaryBackend (pure Elixir). Performance will be limited; switch to EXLA, Torchx, or Eigen for serious workloads."
       )
+    end
+
+    defp apply_backend(igniter, backend) do
+      {package, backend_module} = Map.fetch!(@packages, backend)
+
+      igniter
+      |> Deps.add_dep(Deps.determine_dep_type_and_version!(package), on_exists: :skip)
+      |> set_default_backend(backend_module)
     end
 
     # Writes `config :nx, default_backend: <Backend>` to `config/runtime.exs`,

--- a/test/mix/tasks/bb.add_nx_backend_test.exs
+++ b/test/mix/tasks/bb.add_nx_backend_test.exs
@@ -8,13 +8,18 @@ defmodule Mix.Tasks.Bb.AddNxBackendTest do
 
   @moduletag :igniter
 
+  defp assert_dep_added(igniter, package) do
+    {_, source} = Rewrite.source(igniter.rewrite, "mix.exs")
+
+    assert source.content =~ ~r/\{:#{package}, "~> [0-9.]+"\}/,
+           "expected mix.exs to declare a :#{package} dependency, got:\n#{source.content}"
+  end
+
   describe "--backend exla" do
     test "adds the exla dep" do
       test_project()
       |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "exla"])
-      |> assert_has_patch("mix.exs", """
-      + |      {:exla, "~> 0.10"}
-      """)
+      |> assert_dep_added("exla")
     end
 
     test "writes the default_backend config to runtime.exs" do
@@ -42,9 +47,7 @@ defmodule Mix.Tasks.Bb.AddNxBackendTest do
     test "adds the torchx dep" do
       test_project()
       |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "torchx"])
-      |> assert_has_patch("mix.exs", """
-      + |      {:torchx, "~> 0.10"}
-      """)
+      |> assert_dep_added("torchx")
     end
 
     test "writes the default_backend config to runtime.exs" do
@@ -54,6 +57,23 @@ defmodule Mix.Tasks.Bb.AddNxBackendTest do
 
       {_, source} = Rewrite.source(igniter.rewrite, "config/runtime.exs")
       assert source.content =~ "config :nx, default_backend: Torchx.Backend"
+    end
+  end
+
+  describe "--backend eigen" do
+    test "adds the nx_eigen dep" do
+      test_project()
+      |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "eigen"])
+      |> assert_dep_added("nx_eigen")
+    end
+
+    test "writes the default_backend config to runtime.exs" do
+      igniter =
+        test_project()
+        |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "eigen"])
+
+      {_, source} = Rewrite.source(igniter.rewrite, "config/runtime.exs")
+      assert source.content =~ "config :nx, default_backend: NxEigen.Backend"
     end
   end
 
@@ -69,9 +89,7 @@ defmodule Mix.Tasks.Bb.AddNxBackendTest do
     test "with --yes defaults to exla" do
       test_project()
       |> Igniter.compose_task("bb.add_nx_backend", ["--yes"])
-      |> assert_has_patch("mix.exs", """
-      + |      {:exla, "~> 0.10"}
-      """)
+      |> assert_dep_added("exla")
     end
   end
 
@@ -131,6 +149,23 @@ defmodule Mix.Tasks.Bb.AddNxBackendTest do
         |> String.replace(
           ~r/(defp deps do\s*\n\s*\[)/,
           "\\1\n      {:torchx, \"~> 0.10\"},"
+        )
+
+      test_project(files: %{"mix.exs" => mix_exs})
+      |> Igniter.compose_task("bb.add_nx_backend", ["--backend", "exla"])
+      |> assert_unchanged()
+    end
+
+    test "skips when :nx_eigen is already a dep" do
+      project = test_project()
+
+      mix_exs =
+        project.rewrite
+        |> Rewrite.source!("mix.exs")
+        |> Rewrite.Source.get(:content)
+        |> String.replace(
+          ~r/(defp deps do\s*\n\s*\[)/,
+          "\\1\n      {:nx_eigen, \"~> 0.1\"},"
         )
 
       test_project(files: %{"mix.exs" => mix_exs})

--- a/test/mix/tasks/bb.install_test.exs
+++ b/test/mix/tasks/bb.install_test.exs
@@ -67,11 +67,10 @@ defmodule Mix.Tasks.Bb.InstallTest do
       test_project()
       |> Igniter.compose_task("bb.install", ["--backend", "exla"])
 
-    {_, source} = Rewrite.source(igniter.rewrite, "config/runtime.exs")
-    assert source.content =~ "config :nx, default_backend: EXLA.Backend"
+    {_, runtime} = Rewrite.source(igniter.rewrite, "config/runtime.exs")
+    assert runtime.content =~ "config :nx, default_backend: EXLA.Backend"
 
-    assert_has_patch(igniter, "mix.exs", """
-    + |      {:exla, "~> 0.10"}
-    """)
+    {_, mix} = Rewrite.source(igniter.rewrite, "mix.exs")
+    assert mix.content =~ ~r/\{:exla, "~> [0-9.]+"\}/
   end
 end


### PR DESCRIPTION
## Summary

- Adds `nx_eigen` as a fourth option in `mix bb.add_nx_backend` alongside `exla`, `torchx`, and `binary`. Eigen is particularly well suited to embedded targets like the Arduino UNO Q and Raspberry Pi.
- Switches dep version resolution over to Igniter's `Deps.determine_dep_type_and_version!/1`, so the installer always picks up the latest Hex release for each backend instead of carrying hard-coded `~> N.M` constants. This already caught one drifted assertion in `bb.install_test.exs` (`exla` is at `~> 0.12`, not `~> 0.10`).
- Updates the existing tests to assert on package name (regex) rather than literal version strings so they don't break the next time upstream cuts a release.

## Test plan

- [x] `mix check --no-retry` (compiler, credo, dialyzer, ex_doc, ex_unit, formatter, mix_audit, reuse, spark, unused_deps all green)
- [ ] Manually run `mix bb.add_nx_backend --backend eigen` in a sample project and confirm `{:nx_eigen, "~> 0.1"}` lands in `mix.exs` and `config :nx, default_backend: NxEigen.Backend` lands in `config/runtime.exs`