### PR TITLE
feat: add `mix bb.from_urdf` URDF importer

### DIFF
--- a/lib/bb/urdf/importer.ex
+++ b/lib/bb/urdf/importer.ex
@@ -50,6 +50,7 @@ if Code.ensure_loaded?(Sourceror) do
     @spec to_quoted(Parser.robot(), module) ::
             {:ok, Macro.t(), [String.t()]} | {:error, term}
     def to_quoted(robot, module_name) when is_atom(module_name) do
+      robot = dedupe_material_names(robot)
       links_by_name = Map.new(robot.links, &{&1.name, &1})
       joints_by_parent = Enum.group_by(robot.joints, & &1.parent)
       child_links = MapSet.new(robot.joints, & &1.child)
@@ -73,6 +74,31 @@ if Code.ensure_loaded?(Sourceror) do
 
         {:ok, ast, robot.warnings}
       end
+    end
+
+    # URDF lets many visuals reference a single named material; BB's DSL
+    # requires globally-unique entity names. Keep the URDF name on the first
+    # visual that uses each material and strip it on later occurrences (BB
+    # auto-generates a unique identifier when `name` is absent).
+    defp dedupe_material_names(robot) do
+      {links, _seen} = Enum.map_reduce(robot.links, MapSet.new(), &dedupe_link_material/2)
+      %{robot | links: links}
+    end
+
+    defp dedupe_link_material(%{visual: %{material: %{name: name}}} = link, seen)
+         when is_binary(name) do
+      if MapSet.member?(seen, name) do
+        {strip_material_name(link), seen}
+      else
+        {link, MapSet.put(seen, name)}
+      end
+    end
+
+    defp dedupe_link_material(link, seen), do: {link, seen}
+
+    defp strip_material_name(link) do
+      visual = %{link.visual | material: %{link.visual.material | name: nil}}
+      %{link | visual: visual}
     end
 
     defp validate_referenced_links(joints, links_by_name) do
@@ -186,11 +212,10 @@ if Code.ensure_loaded?(Sourceror) do
     end
 
     defp render_geometry({:mesh, %{filename: filename, scale: scale}}) do
-      children =
-        [call(:filename, [filename])] ++
-          if scale == 1.0, do: [], else: [call(:scale, [scale])]
-
-      call(:mesh, [], children)
+      call(:mesh, [], [
+        call(:filename, [filename]),
+        call(:scale, [scale * 1.0])
+      ])
     end
 
     defp render_material(material) do

--- a/lib/bb/urdf/importer.ex
+++ b/lib/bb/urdf/importer.ex
@@ -249,10 +249,30 @@ if Code.ensure_loaded?(Sourceror) do
           render_axis(joint) ++
           render_limit(joint) ++
           render_dynamics(joint.dynamics) ++
+          render_mimic(joint) ++
           [render_link(child_link, links_by_name, joints_by_parent)]
 
       call(:joint, [atom_name(joint.name)], body)
     end
+
+    defp render_mimic(%{mimic: nil}), do: []
+
+    defp render_mimic(%{name: joint_name, mimic: mimic}) do
+      sensor_name = String.to_atom("#{joint_name}_mimic")
+
+      opts =
+        [source: atom_name(mimic.joint)]
+        |> append_if(mimic.multiplier != 1.0, multiplier: mimic.multiplier)
+        |> append_if(mimic.offset != 0.0, offset: mimic.offset)
+
+      mimic_module = {:__aliases__, [], [:BB, :Sensor, :Mimic]}
+      child_spec = {mimic_module, opts}
+
+      [call(:sensor, [sensor_name, child_spec])]
+    end
+
+    defp append_if(list, false, _kv), do: list
+    defp append_if(list, true, kv), do: list ++ kv
 
     defp render_axis(%{type: :fixed}), do: []
     defp render_axis(%{axis: nil}), do: []
@@ -462,6 +482,8 @@ if Code.ensure_loaded?(Sourceror) do
         red: 1,
         roll: 1,
         scale: 1,
+        sensor: 2,
+        sensor: 3,
         settings: 1,
         sphere: 0,
         sphere: 1,

--- a/lib/bb/urdf/importer.ex
+++ b/lib/bb/urdf/importer.ex
@@ -1,0 +1,458 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if Code.ensure_loaded?(Sourceror) do
+  defmodule BB.Urdf.Importer do
+    @moduledoc """
+    Generate BB DSL source code from a parsed URDF document.
+
+    Consumes the intermediate representation produced by `BB.Urdf.Parser` and
+    emits an Elixir `defmodule` that `use BB`, with nested `link`/`joint` blocks
+    in topology order. The output is formatted source ready to be written into
+    a file.
+
+    ## Limitations
+
+    URDF features that don't have a direct BB analogue are skipped with a
+    warning rather than failing the import — see `BB.Urdf.Parser` for the
+    warnings collected during parsing. The importer adds its own warnings for
+    topology issues (cycles, missing parent/child links, multiple roots).
+    """
+
+    alias BB.Urdf.Parser
+
+    @cardinal_axes %{
+      {1.0, 0.0, 0.0} => [pitch: 90.0],
+      {-1.0, 0.0, 0.0} => [pitch: -90.0],
+      {0.0, 1.0, 0.0} => [roll: -90.0],
+      {0.0, -1.0, 0.0} => [roll: 90.0],
+      {0.0, 0.0, 1.0} => [],
+      {0.0, 0.0, -1.0} => [pitch: 180.0]
+    }
+
+    @doc """
+    Render a parsed URDF document to a formatted Elixir source string.
+
+    Returns `{:ok, source, warnings}` on success.
+    """
+    @spec to_source(Parser.robot(), module) :: {:ok, String.t(), [String.t()]} | {:error, term}
+    def to_source(robot, module_name) when is_atom(module_name) do
+      with {:ok, ast, warnings} <- to_quoted(robot, module_name) do
+        source = Sourceror.to_string(ast, locals_without_parens: locals_without_parens())
+        {:ok, source <> "\n", warnings}
+      end
+    end
+
+    @doc """
+    Build the quoted form of the generated module.
+    """
+    @spec to_quoted(Parser.robot(), module) ::
+            {:ok, Macro.t(), [String.t()]} | {:error, term}
+    def to_quoted(robot, module_name) when is_atom(module_name) do
+      links_by_name = Map.new(robot.links, &{&1.name, &1})
+      joints_by_parent = Enum.group_by(robot.joints, & &1.parent)
+      child_links = MapSet.new(robot.joints, & &1.child)
+
+      with :ok <- validate_referenced_links(robot.joints, links_by_name),
+           {:ok, root} <- roots(robot.links, child_links) do
+        topology = render_topology(root, links_by_name, joints_by_parent)
+        settings = render_settings(robot.name)
+
+        body =
+          block([
+            call(:use, [{:__aliases__, [], [:BB]}]),
+            settings,
+            topology
+          ])
+
+        module_alias =
+          {:__aliases__, [], Module.split(module_name) |> Enum.map(&String.to_atom/1)}
+
+        ast = {:defmodule, [], [module_alias, [do: body]]}
+
+        {:ok, ast, robot.warnings}
+      end
+    end
+
+    defp validate_referenced_links(joints, links_by_name) do
+      Enum.reduce_while(joints, :ok, fn joint, _acc ->
+        cond do
+          not Map.has_key?(links_by_name, joint.parent) ->
+            {:halt, {:error, {:undefined_link, joint.name, joint.parent}}}
+
+          not Map.has_key?(links_by_name, joint.child) ->
+            {:halt, {:error, {:undefined_link, joint.name, joint.child}}}
+
+          true ->
+            {:cont, :ok}
+        end
+      end)
+    end
+
+    defp roots(links, child_links) do
+      case Enum.reject(links, &MapSet.member?(child_links, &1.name)) do
+        [root] ->
+          {:ok, root}
+
+        [] ->
+          {:error, :no_root_link}
+
+        multiple ->
+          names = Enum.map(multiple, & &1.name)
+          {:error, {:multiple_root_links, names}}
+      end
+    end
+
+    defp render_settings(name) do
+      call(:settings, [], [call(:name, [atom_name(name)])])
+    end
+
+    defp render_topology(root, links_by_name, joints_by_parent) do
+      call(:topology, [], [render_link(root, links_by_name, joints_by_parent)])
+    end
+
+    defp render_link(link, links_by_name, joints_by_parent) do
+      children =
+        render_inertial(link.inertial) ++
+          render_visual(link.visual) ++
+          Enum.map(link.collisions, &render_collision/1) ++
+          Enum.flat_map(Map.get(joints_by_parent, link.name, []), fn joint ->
+            [render_joint(joint, links_by_name, joints_by_parent)]
+          end)
+
+      call(:link, [atom_name(link.name)], children)
+    end
+
+    defp render_inertial(nil), do: []
+
+    defp render_inertial(inertial) do
+      children =
+        maybe(inertial.mass, &call(:mass, [unit(&1, :kilogram)])) ++
+          maybe(inertial.inertia, &render_inertia/1) ++
+          maybe(inertial.origin, &render_origin/1)
+
+      [call(:inertial, [], children)]
+    end
+
+    defp render_inertia(inertia) do
+      call(:inertia, [], [
+        call(:ixx, [unit(inertia.ixx, :kilogram_square_meter)]),
+        call(:iyy, [unit(inertia.iyy, :kilogram_square_meter)]),
+        call(:izz, [unit(inertia.izz, :kilogram_square_meter)]),
+        call(:ixy, [unit(inertia.ixy, :kilogram_square_meter)]),
+        call(:ixz, [unit(inertia.ixz, :kilogram_square_meter)]),
+        call(:iyz, [unit(inertia.iyz, :kilogram_square_meter)])
+      ])
+    end
+
+    defp render_visual(nil), do: []
+
+    defp render_visual(visual) do
+      children =
+        maybe(visual.origin, &render_origin/1) ++
+          maybe(visual.geometry, &render_geometry/1) ++
+          maybe(visual.material, &render_material/1)
+
+      [call(:visual, [], children)]
+    end
+
+    defp render_collision(collision) do
+      children =
+        maybe(collision.origin, &render_origin/1) ++
+          maybe(collision.name, &call(:name, [atom_name(&1)])) ++
+          maybe(collision.geometry, &render_geometry/1)
+
+      call(:collision, [], children)
+    end
+
+    defp render_geometry({:box, %{size: {x, y, z}}}) do
+      call(:box, [], [
+        call(:x, [unit(x, :meter)]),
+        call(:y, [unit(y, :meter)]),
+        call(:z, [unit(z, :meter)])
+      ])
+    end
+
+    defp render_geometry({:cylinder, %{radius: r, length: l}}) do
+      call(:cylinder, [], [
+        call(:radius, [unit(r, :meter)]),
+        call(:height, [unit(l, :meter)])
+      ])
+    end
+
+    defp render_geometry({:sphere, %{radius: r}}) do
+      call(:sphere, [], [call(:radius, [unit(r, :meter)])])
+    end
+
+    defp render_geometry({:mesh, %{filename: filename, scale: scale}}) do
+      children =
+        [call(:filename, [filename])] ++
+          if scale == 1.0, do: [], else: [call(:scale, [scale])]
+
+      call(:mesh, [], children)
+    end
+
+    defp render_material(material) do
+      children =
+        maybe(material.name, &call(:name, [atom_name(&1)])) ++
+          maybe(material.color, &render_color/1) ++
+          maybe(material.texture, &render_texture/1)
+
+      call(:material, [], children)
+    end
+
+    defp render_color(%{red: r, green: g, blue: b, alpha: a}) do
+      call(:color, [], [
+        call(:red, [r]),
+        call(:green, [g]),
+        call(:blue, [b]),
+        call(:alpha, [a])
+      ])
+    end
+
+    defp render_texture(filename) when is_binary(filename) do
+      call(:texture, [], [call(:filename, [filename])])
+    end
+
+    defp render_joint(joint, links_by_name, joints_by_parent) do
+      child_link = Map.fetch!(links_by_name, joint.child)
+
+      body =
+        [call(:type, [joint.type])] ++
+          maybe(joint.origin, &render_origin/1) ++
+          render_axis(joint) ++
+          render_limit(joint) ++
+          render_dynamics(joint.dynamics) ++
+          [render_link(child_link, links_by_name, joints_by_parent)]
+
+      call(:joint, [atom_name(joint.name)], body)
+    end
+
+    defp render_axis(%{type: :fixed}), do: []
+    defp render_axis(%{axis: nil}), do: []
+
+    defp render_axis(%{axis: axis}) do
+      children =
+        case Map.get(@cardinal_axes, normalise_axis(axis)) do
+          nil ->
+            {roll, pitch} = axis_to_euler(axis)
+
+            [
+              call(:roll, [unit(roll, :degree)]),
+              call(:pitch, [unit(pitch, :degree)])
+            ]
+
+          angles ->
+            Enum.map(angles, fn {key, deg} -> call(key, [unit(deg, :degree)]) end)
+        end
+
+      [empty_block_call(:axis, [], children)]
+    end
+
+    defp render_limit(%{type: :fixed}), do: []
+    defp render_limit(%{limit: nil}), do: []
+
+    defp render_limit(%{type: :continuous, limit: limit}) do
+      children =
+        maybe(limit.effort, &call(:effort, [unit(&1, :newton_meter)])) ++
+          maybe(limit.velocity, &call(:velocity, [unit(&1, :radian_per_second)]))
+
+      if children == [], do: [], else: [call(:limit, [], children)]
+    end
+
+    defp render_limit(%{type: type, limit: limit}) do
+      {position_unit, velocity_unit, effort_unit} = limit_units_for_type(type)
+
+      children =
+        maybe(limit.lower, &call(:lower, [unit(&1, position_unit)])) ++
+          maybe(limit.upper, &call(:upper, [unit(&1, position_unit)])) ++
+          maybe(limit.effort, &call(:effort, [unit(&1, effort_unit)])) ++
+          maybe(limit.velocity, &call(:velocity, [unit(&1, velocity_unit)]))
+
+      if children == [], do: [], else: [call(:limit, [], children)]
+    end
+
+    defp limit_units_for_type(:prismatic), do: {:meter, :meter_per_second, :newton}
+    defp limit_units_for_type(_), do: {:radian, :radian_per_second, :newton_meter}
+
+    defp render_dynamics(nil), do: []
+
+    defp render_dynamics(%{damping: nil, friction: nil}), do: []
+
+    defp render_dynamics(dynamics) do
+      children =
+        maybe(dynamics.damping, &call(:damping, [unit(&1, :newton_meter_second_per_radian)])) ++
+          maybe(dynamics.friction, &call(:friction, [unit(&1, :newton_meter)]))
+
+      [call(:dynamics, [], children)]
+    end
+
+    defp render_origin(%{xyz: {x, y, z}, rpy: {roll, pitch, yaw}}) do
+      case drop_zero([
+             {:x, x, :meter},
+             {:y, y, :meter},
+             {:z, z, :meter},
+             {:roll, roll, :radian},
+             {:pitch, pitch, :radian},
+             {:yaw, yaw, :radian}
+           ]) do
+        [] -> []
+        children -> [call(:origin, [], children)]
+      end
+    end
+
+    defp drop_zero(fields) do
+      fields
+      |> Enum.reject(fn {_k, v, _u} -> v == 0.0 end)
+      |> Enum.map(fn {k, v, u} -> call(k, [unit(v, u)]) end)
+    end
+
+    defp normalise_axis({x, y, z}) do
+      {round_axis(x), round_axis(y), round_axis(z)}
+    end
+
+    defp round_axis(v) when v > 0.999 and v < 1.001, do: 1.0
+    defp round_axis(v) when v < -0.999 and v > -1.001, do: -1.0
+    defp round_axis(v) when v > -0.001 and v < 0.001, do: 0.0
+    defp round_axis(v), do: v
+
+    # For non-cardinal axis vectors, compute roll/pitch that rotate Z to the
+    # target. Yaw is redundant (rotation about Z) so we leave it at zero.
+    defp axis_to_euler({x, y, z}) do
+      pitch = :math.atan2(x, z)
+      roll = :math.atan2(-y, :math.sqrt(x * x + z * z))
+      {rad_to_deg(roll), rad_to_deg(pitch)}
+    end
+
+    defp rad_to_deg(r), do: r * 180.0 / :math.pi()
+
+    defp atom_name(name) when is_atom(name), do: name
+
+    defp atom_name(name) when is_binary(name) do
+      name
+      |> String.replace(~r/[^A-Za-z0-9_]/, "_")
+      |> then(fn
+        <<digit, _::binary>> = s when digit in ?0..?9 -> "_" <> s
+        s -> s
+      end)
+      |> String.to_atom()
+    end
+
+    defp unit(value, unit_name) when is_float(value) and is_atom(unit_name) do
+      text = "#{format_float(value)} #{unit_name}"
+      {:sigil_u, [delimiter: "("], [{:<<>>, [], [text]}, []]}
+    end
+
+    defp format_float(v) when is_float(v) do
+      v
+      |> :erlang.float_to_binary(decimals: 6)
+      |> String.trim_trailing("0")
+      |> String.trim_trailing(".")
+      |> case do
+        "" -> "0"
+        "-" -> "0"
+        other -> other
+      end
+    end
+
+    defp call(name, args, []), do: {name, [], args}
+
+    defp call(name, args, children) when is_list(children),
+      do: {name, [], args ++ [[do: block(children)]]}
+
+    defp call(name, args), do: {name, [], args}
+
+    defp empty_block_call(name, args, []),
+      do: {name, [], args ++ [[do: {:__block__, [], []}]]}
+
+    defp empty_block_call(name, args, children),
+      do: call(name, args, children)
+
+    defp block([single]), do: single
+    defp block(children), do: {:__block__, [], children}
+
+    defp maybe(nil, _fun), do: []
+
+    defp maybe(value, fun) do
+      case fun.(value) do
+        list when is_list(list) -> list
+        ast -> [ast]
+      end
+    end
+
+    # Mirrors the BB DSL entries in `.formatter.exs` for the entities emitted
+    # by this module, so generated source uses idiomatic DSL formatting without
+    # requiring the consumer to run `mix format` first.
+    defp locals_without_parens do
+      [
+        alpha: 1,
+        axis: 0,
+        axis: 1,
+        blue: 1,
+        box: 0,
+        box: 1,
+        collision: 0,
+        collision: 1,
+        color: 0,
+        color: 1,
+        cylinder: 0,
+        cylinder: 1,
+        damping: 1,
+        dynamics: 0,
+        dynamics: 1,
+        effort: 1,
+        filename: 1,
+        friction: 1,
+        green: 1,
+        height: 1,
+        inertia: 0,
+        inertia: 1,
+        inertial: 0,
+        inertial: 1,
+        ixx: 1,
+        ixy: 1,
+        ixz: 1,
+        iyy: 1,
+        iyz: 1,
+        izz: 1,
+        joint: 1,
+        joint: 2,
+        length: 1,
+        limit: 0,
+        limit: 1,
+        link: 1,
+        link: 2,
+        lower: 1,
+        mass: 1,
+        material: 0,
+        material: 1,
+        mesh: 0,
+        mesh: 1,
+        name: 1,
+        origin: 0,
+        origin: 1,
+        pitch: 1,
+        radius: 1,
+        red: 1,
+        roll: 1,
+        scale: 1,
+        settings: 1,
+        sphere: 0,
+        sphere: 1,
+        texture: 0,
+        texture: 1,
+        topology: 1,
+        type: 1,
+        upper: 1,
+        velocity: 1,
+        visual: 0,
+        visual: 1,
+        x: 1,
+        y: 1,
+        yaw: 1,
+        z: 1
+      ]
+    end
+  end
+end

--- a/lib/bb/urdf/importer.ex
+++ b/lib/bb/urdf/importer.ex
@@ -50,7 +50,12 @@ if Code.ensure_loaded?(Sourceror) do
     @spec to_quoted(Parser.robot(), module) ::
             {:ok, Macro.t(), [String.t()]} | {:error, term}
     def to_quoted(robot, module_name) when is_atom(module_name) do
-      robot = dedupe_material_names(robot)
+      robot =
+        robot
+        |> drop_world_anchor_joints()
+        |> dedupe_joint_names()
+        |> dedupe_material_names()
+
       links_by_name = Map.new(robot.links, &{&1.name, &1})
       joints_by_parent = Enum.group_by(robot.joints, & &1.parent)
       child_links = MapSet.new(robot.joints, & &1.child)
@@ -74,6 +79,76 @@ if Code.ensure_loaded?(Sourceror) do
 
         {:ok, ast, robot.warnings}
       end
+    end
+
+    # URDF commonly anchors a robot to the world with a fixed joint whose
+    # parent is a synthetic link (`world`, `map`, etc.) that's never defined
+    # in the file. BB has no concept of a world frame — the topology root is
+    # the robot. Drop joints whose parent link isn't defined; their child
+    # then becomes an unparented link, which the root-finder picks up
+    # naturally.
+    defp drop_world_anchor_joints(robot) do
+      link_names = MapSet.new(robot.links, & &1.name)
+
+      {joints, dropped} =
+        Enum.split_with(robot.joints, &MapSet.member?(link_names, &1.parent))
+
+      warnings =
+        Enum.map(dropped, fn joint ->
+          "dropped joint #{inspect(joint.name)}: parent link #{inspect(joint.parent)} is not defined (URDF world anchor?)"
+        end)
+
+      %{robot | joints: joints, warnings: robot.warnings ++ warnings}
+    end
+
+    # URDF has separate namespaces for link and joint names; BB requires
+    # global uniqueness across both. Rename any joint whose name collides
+    # with a link (or with another joint) and rewrite `<mimic>` source
+    # references to match.
+    defp dedupe_joint_names(robot) do
+      link_names = MapSet.new(robot.links, & &1.name)
+      {joints, _used, renames} = rename_colliding_joints(robot.joints, link_names)
+      joints = rewrite_mimic_sources(joints, renames)
+      %{robot | joints: joints}
+    end
+
+    defp rename_colliding_joints(joints, link_names) do
+      Enum.reduce(joints, {[], link_names, %{}}, fn joint, {acc, used, renames} ->
+        if MapSet.member?(used, joint.name) do
+          new_name = unique_name(joint.name <> "_joint", used)
+
+          {[%{joint | name: new_name} | acc], MapSet.put(used, new_name),
+           Map.put(renames, joint.name, new_name)}
+        else
+          {[joint | acc], MapSet.put(used, joint.name), renames}
+        end
+      end)
+      |> then(fn {joints, used, renames} -> {Enum.reverse(joints), used, renames} end)
+    end
+
+    defp unique_name(base, used) do
+      if MapSet.member?(used, base) do
+        Enum.find_value(Stream.iterate(2, &(&1 + 1)), &numbered_candidate(base, &1, used))
+      else
+        base
+      end
+    end
+
+    defp numbered_candidate(base, n, used) do
+      candidate = "#{base}_#{n}"
+      if MapSet.member?(used, candidate), do: nil, else: candidate
+    end
+
+    defp rewrite_mimic_sources(joints, renames) when map_size(renames) == 0, do: joints
+
+    defp rewrite_mimic_sources(joints, renames) do
+      Enum.map(joints, fn
+        %{mimic: %{joint: source} = mimic} = joint ->
+          %{joint | mimic: %{mimic | joint: Map.get(renames, source, source)}}
+
+        joint ->
+          joint
+      end)
     end
 
     # URDF lets many visuals reference a single named material; BB's DSL

--- a/lib/bb/urdf/parser.ex
+++ b/lib/bb/urdf/parser.ex
@@ -1,0 +1,490 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Urdf.Parser do
+  @moduledoc """
+  Parse a URDF XML document into a plain-map intermediate representation.
+
+  The result is intentionally close to the URDF wire format: link/joint
+  lists are flat (joints reference parent and child link names), values are
+  floats in SI base units, and unsupported URDF features are collected as
+  warnings rather than raised as errors. The `BB.Urdf.Importer` consumes this
+  representation and produces a BB DSL module.
+  """
+
+  require Record
+
+  Record.defrecordp(
+    :xml_element,
+    :xmlElement,
+    Record.extract(:xmlElement, from_lib: "xmerl/include/xmerl.hrl")
+  )
+
+  Record.defrecordp(
+    :xml_attribute,
+    :xmlAttribute,
+    Record.extract(:xmlAttribute, from_lib: "xmerl/include/xmerl.hrl")
+  )
+
+  @type origin :: %{xyz: {float, float, float}, rpy: {float, float, float}}
+  @type geometry ::
+          {:box, %{size: {float, float, float}}}
+          | {:cylinder, %{radius: float, length: float}}
+          | {:sphere, %{radius: float}}
+          | {:mesh, %{filename: String.t(), scale: float}}
+
+  @type robot :: %{
+          name: String.t(),
+          links: [link],
+          joints: [joint],
+          materials: %{optional(String.t()) => material},
+          warnings: [String.t()]
+        }
+  @type link :: %{
+          name: String.t(),
+          visual: visual | nil,
+          collisions: [collision],
+          inertial: inertial | nil
+        }
+  @type visual :: %{
+          name: String.t() | nil,
+          origin: origin | nil,
+          geometry: geometry | nil,
+          material: material | nil
+        }
+  @type collision :: %{
+          name: String.t() | nil,
+          origin: origin | nil,
+          geometry: geometry | nil
+        }
+  @type inertial :: %{
+          origin: origin | nil,
+          mass: float | nil,
+          inertia: %{
+            ixx: float,
+            iyy: float,
+            izz: float,
+            ixy: float,
+            ixz: float,
+            iyz: float
+          }
+        }
+  @type joint :: %{
+          name: String.t(),
+          type: atom,
+          parent: String.t(),
+          child: String.t(),
+          origin: origin | nil,
+          axis: {float, float, float} | nil,
+          limit:
+            %{
+              lower: float | nil,
+              upper: float | nil,
+              effort: float | nil,
+              velocity: float | nil
+            }
+            | nil,
+          dynamics: %{damping: float | nil, friction: float | nil} | nil,
+          mimic: %{joint: String.t(), multiplier: float, offset: float} | nil
+        }
+  @type material :: %{
+          name: String.t() | nil,
+          color: %{red: float, green: float, blue: float, alpha: float} | nil,
+          texture: String.t() | nil
+        }
+
+  @doc """
+  Parse a URDF XML file from disk.
+  """
+  @spec parse_file(Path.t()) :: {:ok, robot} | {:error, term}
+  def parse_file(path) do
+    with {:ok, content} <- File.read(path) do
+      parse_string(content)
+    end
+  end
+
+  @doc """
+  Parse a URDF XML string.
+  """
+  @spec parse_string(String.t()) :: {:ok, robot} | {:error, term}
+  def parse_string(xml) when is_binary(xml) do
+    {doc, _rest} = :xmerl_scan.string(String.to_charlist(xml), space: :normalize)
+    {:ok, parse_robot(doc)}
+  catch
+    :exit, reason -> {:error, {:xml_parse_error, reason}}
+  end
+
+  defp parse_robot(xml_element(name: :robot) = element) do
+    name = attr(element, :name, "robot")
+    children = children(element)
+    materials = parse_top_level_materials(children)
+
+    {links, link_warnings} =
+      children
+      |> filter_by_name(:link)
+      |> Enum.map_reduce([], fn link_el, acc ->
+        {link, warnings} = parse_link(link_el, materials)
+        {link, warnings ++ acc}
+      end)
+
+    {joints, joint_warnings} =
+      children
+      |> filter_by_name(:joint)
+      |> Enum.map_reduce([], fn joint_el, acc ->
+        {joint, warnings} = parse_joint(joint_el)
+        {joint, warnings ++ acc}
+      end)
+
+    other_warnings =
+      children
+      |> Enum.flat_map(fn
+        xml_element(name: :transmission, attributes: attrs) ->
+          ["skipping <transmission> #{attr_value(attrs, :name, "")}"]
+
+        xml_element(name: :gazebo) ->
+          ["skipping <gazebo> extension block"]
+
+        _ ->
+          []
+      end)
+
+    %{
+      name: to_string(name),
+      links: links,
+      joints: joints,
+      materials: materials,
+      warnings: Enum.reverse(link_warnings) ++ Enum.reverse(joint_warnings) ++ other_warnings
+    }
+  end
+
+  defp parse_top_level_materials(children) do
+    children
+    |> filter_by_name(:material)
+    |> Enum.reduce(%{}, fn material_el, acc ->
+      material = parse_material(material_el)
+
+      case material.name do
+        nil -> acc
+        name -> Map.put(acc, name, material)
+      end
+    end)
+  end
+
+  defp parse_link(xml_element(name: :link) = element, materials) do
+    name = attr(element, :name)
+    children = children(element)
+
+    {visual, visual_warnings} =
+      case first_by_name(children, :visual) do
+        nil -> {nil, []}
+        el -> parse_visual(el, materials)
+      end
+
+    collisions = children |> filter_by_name(:collision) |> Enum.map(&parse_collision/1)
+
+    inertial =
+      case first_by_name(children, :inertial) do
+        nil -> nil
+        el -> parse_inertial(el)
+      end
+
+    {%{
+       name: to_string(name),
+       visual: visual,
+       collisions: collisions,
+       inertial: inertial
+     }, visual_warnings}
+  end
+
+  defp parse_visual(xml_element(name: :visual) = element, materials) do
+    name = attr(element, :name, nil)
+    children = children(element)
+    origin = first_by_name(children, :origin) |> parse_origin()
+    geometry = first_by_name(children, :geometry) |> parse_geometry()
+
+    {material, warnings} =
+      case first_by_name(children, :material) do
+        nil ->
+          {nil, []}
+
+        material_el ->
+          parsed = parse_material(material_el)
+          resolve_material(parsed, materials)
+      end
+
+    {%{
+       name: name && to_string(name),
+       origin: origin,
+       geometry: geometry,
+       material: material
+     }, warnings}
+  end
+
+  defp resolve_material(%{color: nil, texture: nil, name: name} = parsed, materials)
+       when is_binary(name) do
+    case Map.get(materials, name) do
+      nil ->
+        {parsed, ["material #{inspect(name)} referenced by name but not defined at top level"]}
+
+      defined ->
+        {Map.merge(parsed, Map.take(defined, [:color, :texture])), []}
+    end
+  end
+
+  defp resolve_material(parsed, _materials), do: {parsed, []}
+
+  defp parse_collision(xml_element(name: :collision) = element) do
+    name = attr(element, :name, nil)
+    children = children(element)
+
+    %{
+      name: name && to_string(name),
+      origin: first_by_name(children, :origin) |> parse_origin(),
+      geometry: first_by_name(children, :geometry) |> parse_geometry()
+    }
+  end
+
+  defp parse_inertial(xml_element(name: :inertial) = element) do
+    children = children(element)
+
+    mass =
+      case first_by_name(children, :mass) do
+        nil -> nil
+        el -> el |> attr(:value, "0") |> parse_float()
+      end
+
+    inertia =
+      case first_by_name(children, :inertia) do
+        nil ->
+          nil
+
+        el ->
+          %{
+            ixx: el |> attr(:ixx, "0") |> parse_float(),
+            iyy: el |> attr(:iyy, "0") |> parse_float(),
+            izz: el |> attr(:izz, "0") |> parse_float(),
+            ixy: el |> attr(:ixy, "0") |> parse_float(),
+            ixz: el |> attr(:ixz, "0") |> parse_float(),
+            iyz: el |> attr(:iyz, "0") |> parse_float()
+          }
+      end
+
+    %{
+      origin: first_by_name(children, :origin) |> parse_origin(),
+      mass: mass,
+      inertia: inertia
+    }
+  end
+
+  defp parse_material(xml_element(name: :material) = element) do
+    name = attr(element, :name, nil)
+    children = children(element)
+
+    color =
+      case first_by_name(children, :color) do
+        nil ->
+          nil
+
+        el ->
+          [r, g, b, a] = el |> attr(:rgba, "0 0 0 1") |> parse_floats(4)
+          %{red: r, green: g, blue: b, alpha: a}
+      end
+
+    texture =
+      case first_by_name(children, :texture) do
+        nil -> nil
+        el -> el |> attr(:filename, nil) |> to_string_or_nil()
+      end
+
+    %{
+      name: name && to_string(name),
+      color: color,
+      texture: texture
+    }
+  end
+
+  defp parse_joint(xml_element(name: :joint) = element) do
+    name = attr(element, :name)
+    type = element |> attr(:type, "fixed") |> to_string() |> String.to_atom()
+    children = children(element)
+
+    parent =
+      case first_by_name(children, :parent) do
+        nil -> nil
+        el -> el |> attr(:link) |> to_string()
+      end
+
+    child =
+      case first_by_name(children, :child) do
+        nil -> nil
+        el -> el |> attr(:link) |> to_string()
+      end
+
+    origin = first_by_name(children, :origin) |> parse_origin()
+    axis = parse_axis(first_by_name(children, :axis))
+    limit = parse_limit(first_by_name(children, :limit))
+    dynamics = parse_dynamics(first_by_name(children, :dynamics))
+    {mimic, mimic_warnings} = parse_mimic(first_by_name(children, :mimic), to_string(name))
+
+    safety_warnings =
+      case first_by_name(children, :safety_controller) do
+        nil -> []
+        _ -> ["joint #{inspect(to_string(name))}: <safety_controller> is not supported"]
+      end
+
+    {%{
+       name: to_string(name),
+       type: type,
+       parent: parent,
+       child: child,
+       origin: origin,
+       axis: axis,
+       limit: limit,
+       dynamics: dynamics,
+       mimic: mimic
+     }, mimic_warnings ++ safety_warnings}
+  end
+
+  defp parse_origin(nil), do: nil
+
+  defp parse_origin(xml_element() = element) do
+    xyz = element |> attr(:xyz, "0 0 0") |> parse_floats(3) |> List.to_tuple()
+    rpy = element |> attr(:rpy, "0 0 0") |> parse_floats(3) |> List.to_tuple()
+    %{xyz: xyz, rpy: rpy}
+  end
+
+  defp parse_axis(nil), do: nil
+
+  defp parse_axis(xml_element() = element) do
+    element |> attr(:xyz, "1 0 0") |> parse_floats(3) |> List.to_tuple()
+  end
+
+  defp parse_limit(nil), do: nil
+
+  defp parse_limit(xml_element() = element) do
+    %{
+      lower: element |> attr(:lower, nil) |> maybe_float(),
+      upper: element |> attr(:upper, nil) |> maybe_float(),
+      effort: element |> attr(:effort, nil) |> maybe_float(),
+      velocity: element |> attr(:velocity, nil) |> maybe_float()
+    }
+  end
+
+  defp parse_dynamics(nil), do: nil
+
+  defp parse_dynamics(xml_element() = element) do
+    %{
+      damping: element |> attr(:damping, nil) |> maybe_float(),
+      friction: element |> attr(:friction, nil) |> maybe_float()
+    }
+  end
+
+  defp parse_mimic(nil, _joint_name), do: {nil, []}
+
+  defp parse_mimic(xml_element() = element, joint_name) do
+    mimic = %{
+      joint: element |> attr(:joint) |> to_string(),
+      multiplier: element |> attr(:multiplier, "1") |> parse_float(),
+      offset: element |> attr(:offset, "0") |> parse_float()
+    }
+
+    warning =
+      "joint #{inspect(joint_name)}: <mimic> is not supported by bb (mirrors #{inspect(mimic.joint)})"
+
+    {mimic, [warning]}
+  end
+
+  defp parse_geometry(nil), do: nil
+
+  defp parse_geometry(xml_element() = element) do
+    case children(element) do
+      [xml_element(name: :box) = el | _] ->
+        size = el |> attr(:size, "0 0 0") |> parse_floats(3) |> List.to_tuple()
+        {:box, %{size: size}}
+
+      [xml_element(name: :cylinder) = el | _] ->
+        {:cylinder,
+         %{
+           radius: el |> attr(:radius, "0") |> parse_float(),
+           length: el |> attr(:length, "0") |> parse_float()
+         }}
+
+      [xml_element(name: :sphere) = el | _] ->
+        {:sphere, %{radius: el |> attr(:radius, "0") |> parse_float()}}
+
+      [xml_element(name: :mesh) = el | _] ->
+        {:mesh,
+         %{
+           filename: el |> attr(:filename) |> to_string(),
+           scale: el |> attr(:scale, "1 1 1") |> parse_scale()
+         }}
+
+      _ ->
+        nil
+    end
+  end
+
+  defp parse_scale(value) do
+    case parse_floats(value, 3) do
+      [s, _, _] -> s
+      _ -> parse_float(value)
+    end
+  end
+
+  defp children(xml_element(content: content)) do
+    Enum.filter(content, fn
+      xml_element() -> true
+      _ -> false
+    end)
+  end
+
+  defp filter_by_name(elements, name) do
+    Enum.filter(elements, fn xml_element(name: n) -> n == name end)
+  end
+
+  defp first_by_name(elements, name) do
+    Enum.find(elements, fn xml_element(name: n) -> n == name end)
+  end
+
+  defp attr(xml_element(attributes: attrs), key, default \\ nil) do
+    attr_value(attrs, key, default)
+  end
+
+  defp attr_value(attrs, key, default) do
+    Enum.find_value(attrs, default, fn
+      xml_attribute(name: ^key, value: value) -> value
+      _ -> nil
+    end)
+  end
+
+  defp parse_float(value) when is_list(value), do: value |> List.to_string() |> parse_float()
+
+  defp parse_float(value) when is_binary(value) do
+    case Float.parse(value) do
+      {f, _} -> f
+      :error -> 0.0
+    end
+  end
+
+  defp maybe_float(nil), do: nil
+  defp maybe_float(value), do: parse_float(value)
+
+  defp parse_floats(value, count) when is_list(value),
+    do: value |> List.to_string() |> parse_floats(count)
+
+  defp parse_floats(value, count) when is_binary(value) do
+    value
+    |> String.split(~r/\s+/, trim: true)
+    |> Enum.map(&parse_float/1)
+    |> pad_or_trim(count)
+  end
+
+  defp pad_or_trim(list, count) do
+    list = Enum.take(list, count)
+    list ++ List.duplicate(0.0, max(0, count - length(list)))
+  end
+
+  defp to_string_or_nil(nil), do: nil
+  defp to_string_or_nil(value), do: to_string(value)
+end

--- a/lib/bb/urdf/parser.ex
+++ b/lib/bb/urdf/parser.ex
@@ -325,7 +325,7 @@ defmodule BB.Urdf.Parser do
     axis = parse_axis(first_by_name(children, :axis))
     limit = parse_limit(first_by_name(children, :limit))
     dynamics = parse_dynamics(first_by_name(children, :dynamics))
-    {mimic, mimic_warnings} = parse_mimic(first_by_name(children, :mimic), to_string(name))
+    mimic = parse_mimic(first_by_name(children, :mimic))
 
     safety_warnings =
       case first_by_name(children, :safety_controller) do
@@ -343,7 +343,7 @@ defmodule BB.Urdf.Parser do
        limit: limit,
        dynamics: dynamics,
        mimic: mimic
-     }, mimic_warnings ++ safety_warnings}
+     }, safety_warnings}
   end
 
   defp parse_origin(nil), do: nil
@@ -380,19 +380,14 @@ defmodule BB.Urdf.Parser do
     }
   end
 
-  defp parse_mimic(nil, _joint_name), do: {nil, []}
+  defp parse_mimic(nil), do: nil
 
-  defp parse_mimic(xml_element() = element, joint_name) do
-    mimic = %{
+  defp parse_mimic(xml_element() = element) do
+    %{
       joint: element |> attr(:joint) |> to_string(),
       multiplier: element |> attr(:multiplier, "1") |> parse_float(),
       offset: element |> attr(:offset, "0") |> parse_float()
     }
-
-    warning =
-      "joint #{inspect(joint_name)}: <mimic> is not supported by bb (mirrors #{inspect(mimic.joint)})"
-
-    {mimic, [warning]}
   end
 
   defp parse_geometry(nil), do: nil

--- a/lib/mix/tasks/bb.from_urdf.ex
+++ b/lib/mix/tasks/bb.from_urdf.ex
@@ -23,12 +23,15 @@ if Code.ensure_loaded?(Igniter) do
       * `--module`, `-m` - The module name for the generated robot.
         Defaults to `{AppPrefix}.Robot`.
 
-    ## Limitations
+    ## URDF feature support
 
-    Some URDF features have no direct BB equivalent and are skipped with a
+    `<mimic>` joints are emitted as a `BB.Sensor.Mimic` attached to the
+    mimicking joint — BB's sensor implements the same
+    `position * multiplier + offset` semantics as URDF.
+
+    These URDF features have no direct BB equivalent and are skipped with a
     warning rather than failing the import:
 
-      * `<mimic>` joints
       * `<safety_controller>` blocks
       * `<transmission>` blocks
       * `<gazebo>` extensions

--- a/lib/mix/tasks/bb.from_urdf.ex
+++ b/lib/mix/tasks/bb.from_urdf.ex
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.Bb.FromUrdf do
+    @shortdoc "Generate a BB robot module from a URDF file"
+
+    @moduledoc """
+    #{@shortdoc}
+
+    Reads a URDF XML file and writes a `defmodule` that uses `BB` with an
+    equivalent topology to your project.
+
+    ## Example
+
+    ```bash
+    mix bb.from_urdf path/to/robot.urdf --module MyApp.Robot
+    ```
+
+    ## Options
+
+      * `--module`, `-m` - The module name for the generated robot.
+        Defaults to `{AppPrefix}.Robot`.
+
+    ## Limitations
+
+    Some URDF features have no direct BB equivalent and are skipped with a
+    warning rather than failing the import:
+
+      * `<mimic>` joints
+      * `<safety_controller>` blocks
+      * `<transmission>` blocks
+      * `<gazebo>` extensions
+
+    Mesh files are referenced as-is — `package://` URIs from ROS are not
+    rewritten, so you may need to copy meshes into the project and adjust
+    paths by hand.
+    """
+
+    use Igniter.Mix.Task
+
+    alias BB.Urdf.{Importer, Parser}
+
+    @impl Igniter.Mix.Task
+    def info(_argv, _parent) do
+      %Igniter.Mix.Task.Info{
+        positional: [:urdf_path],
+        schema: [module: :string],
+        aliases: [m: :module]
+      }
+    end
+
+    @impl Igniter.Mix.Task
+    def igniter(igniter) do
+      %{urdf_path: urdf_path} = igniter.args.positional
+      module_name = resolve_module(igniter)
+
+      case Parser.parse_file(urdf_path) do
+        {:ok, parsed} ->
+          generate(igniter, parsed, module_name)
+
+        {:error, reason} ->
+          Igniter.add_issue(igniter, "Could not parse URDF #{urdf_path}: #{inspect(reason)}")
+      end
+    end
+
+    defp resolve_module(igniter) do
+      case Keyword.get(igniter.args.options, :module) do
+        nil -> Igniter.Project.Module.module_name(igniter, "Robot")
+        name -> Igniter.Project.Module.parse(name)
+      end
+    end
+
+    defp generate(igniter, parsed, module_name) do
+      case Importer.to_source(parsed, module_name) do
+        {:ok, source, warnings} ->
+          igniter
+          |> create_or_replace_module(module_name, source)
+          |> add_warnings(warnings)
+
+        {:error, reason} ->
+          Igniter.add_issue(igniter, "Could not generate BB module: #{inspect(reason)}")
+      end
+    end
+
+    defp create_or_replace_module(igniter, module_name, source) do
+      body = strip_defmodule(source, module_name)
+
+      Igniter.Project.Module.create_module(
+        igniter,
+        module_name,
+        body,
+        on_exists: :overwrite
+      )
+    end
+
+    defp strip_defmodule(source, module_name) do
+      module_string = Macro.inspect_atom(:literal, module_name)
+
+      source
+      |> String.replace(~r/\Adefmodule\s+#{Regex.escape(module_string)}\s+do\n?/, "")
+      |> String.replace(~r/\nend\s*\z/, "")
+      |> String.trim_trailing()
+    end
+
+    defp add_warnings(igniter, warnings) do
+      Enum.reduce(warnings, igniter, fn warning, acc ->
+        Igniter.add_warning(acc, warning)
+      end)
+    end
+  end
+else
+  defmodule Mix.Tasks.Bb.FromUrdf do
+    @shortdoc "Generate a BB robot module from a URDF file"
+    @moduledoc false
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The bb.from_urdf task requires igniter.
+
+          mix deps.get
+          mix bb.from_urdf path/to/robot.urdf --module MyApp.Robot
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end

--- a/test/bb/urdf/importer_test.exs
+++ b/test/bb/urdf/importer_test.exs
@@ -155,6 +155,26 @@ defmodule BB.Urdf.ImporterTest do
       assert source =~ ~r/mesh do\s*filename "package:\/\/meshes\/arm\.stl"\s*scale 1\.0/
     end
 
+    test "drops joints whose parent link is undefined (URDF world anchor)" do
+      {source, warnings} = import_fixture("world_anchor.urdf", MyApp.WorldGen)
+
+      refute source =~ "joint :world_anchor"
+      assert source =~ "joint :shoulder"
+      assert Enum.any?(warnings, &(&1 =~ "dropped joint \"world_anchor\""))
+      assert [{MyApp.WorldGen, _}] = Code.compile_string(source)
+    end
+
+    test "renames joints that collide with link names and rewrites mimic refs" do
+      {source, _warnings} = import_fixture("name_collision.urdf", MyApp.CollideGen)
+
+      # `gripper` is a link; the homonymous joint gets renamed.
+      assert source =~ "link :gripper"
+      assert source =~ "joint :gripper_joint"
+      # The mimic source on `finger_joint` points to the renamed joint.
+      assert source =~ "source: :gripper_joint"
+      assert [{MyApp.CollideGen, _}] = Code.compile_string(source)
+    end
+
     test "errors out on multiple root links" do
       xml = """
       <?xml version="1.0"?>

--- a/test/bb/urdf/importer_test.exs
+++ b/test/bb/urdf/importer_test.exs
@@ -95,6 +95,26 @@ defmodule BB.Urdf.ImporterTest do
       assert Enum.any?(warnings, &(&1 =~ "<transmission>"))
     end
 
+    test "dedupes named materials so multiple visuals can share a URDF material" do
+      {source, _warnings} = import_fixture("shared_materials.urdf", MyApp.SharedGen)
+
+      # First visual keeps the URDF material name…
+      assert Regex.match?(
+               ~r/link :base_link do.*?material do\s*name :grey/s,
+               source
+             )
+
+      # …and the resulting module compiles (would fail if the name leaked
+      # into later visuals — the DSL rejects duplicate entity names).
+      assert [{MyApp.SharedGen, _}] = Code.compile_string(source)
+    end
+
+    test "emits mesh scale as a float (the default integer trips the URDF exporter)" do
+      {source, _warnings} = import_fixture("shared_materials.urdf")
+
+      assert source =~ ~r/mesh do\s*filename "package:\/\/meshes\/arm\.stl"\s*scale 1\.0/
+    end
+
     test "errors out on multiple root links" do
       xml = """
       <?xml version="1.0"?>

--- a/test/bb/urdf/importer_test.exs
+++ b/test/bb/urdf/importer_test.exs
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Urdf.ImporterTest do
+  use ExUnit.Case, async: true
+
+  alias BB.Urdf.{Importer, Parser}
+
+  @fixture_dir Path.join([__DIR__, "..", "..", "fixtures", "urdf"])
+
+  defp import_fixture(name, module \\ MyApp.Generated) do
+    {:ok, parsed} = Parser.parse_file(Path.join(@fixture_dir, name))
+    {:ok, source, warnings} = Importer.to_source(parsed, module)
+    {source, warnings}
+  end
+
+  describe "to_source/2" do
+    test "wraps output in defmodule that uses BB" do
+      {source, _warnings} = import_fixture("minimal.urdf")
+
+      assert source =~ "defmodule MyApp.Generated do"
+      assert source =~ "use BB"
+      assert source =~ "settings do"
+      assert source =~ "name :minimal_bot"
+      assert source =~ "topology do"
+      assert source =~ "link :base_link"
+    end
+
+    test "generated source compiles" do
+      {source, _warnings} = import_fixture("minimal.urdf", MyApp.MinimalGen)
+      assert [{MyApp.MinimalGen, _}] = Code.compile_string(source)
+    end
+
+    test "nests joints under their parent link in topology order" do
+      {source, _warnings} = import_fixture("two_link_arm.urdf", MyApp.TwoLinkGen)
+
+      # base_link contains shoulder joint, which contains upper_arm, etc.
+      assert Regex.match?(
+               ~r/link :base_link do.*joint :shoulder do.*link :upper_arm/s,
+               source
+             )
+
+      assert Regex.match?(
+               ~r/link :upper_arm do.*joint :elbow do.*link :forearm/s,
+               source
+             )
+
+      assert [{MyApp.TwoLinkGen, _}] = Code.compile_string(source)
+    end
+
+    test "emits ~u sigil literals for unit-bearing values" do
+      {source, _warnings} = import_fixture("two_link_arm.urdf")
+
+      assert source =~ ~r/~u\(0\.\d+ meter\)/
+      assert source =~ ~r/~u\([\d.]+ kilogram\)/
+      assert source =~ ~r/~u\([\d.]+ kilogram_square_meter\)/
+      assert source =~ ~r/~u\([-\d.]+ radian\)/
+    end
+
+    test "maps URDF y-axis to bb's axis rotation" do
+      {source, _warnings} = import_fixture("two_link_arm.urdf")
+
+      assert source =~ ~r/axis do\s*roll ~u\(-90 degree\)\s*end/
+    end
+
+    test "emits limit with effort/velocity only for continuous joints" do
+      {source, _warnings} = import_fixture("two_link_arm.urdf")
+
+      assert Regex.match?(
+               ~r/joint :elbow do.*type :continuous.*limit do(?:(?!lower|upper).)*end/s,
+               source
+             )
+    end
+
+    test "omits axis, limit, and dynamics for fixed joints" do
+      {source, _warnings} = import_fixture("two_link_arm.urdf")
+
+      assert Regex.match?(
+               ~r/joint :wrist do\s*type :fixed.*?link :gripper/s,
+               source
+             )
+
+      refute Regex.match?(
+               ~r/joint :wrist do(?:(?!end).)*axis/s,
+               source
+             )
+    end
+
+    test "passes through parser warnings" do
+      {_source, warnings} = import_fixture("mimic_and_transmission.urdf")
+
+      assert Enum.any?(warnings, &(&1 =~ "<mimic>"))
+      assert Enum.any?(warnings, &(&1 =~ "<safety_controller>"))
+      assert Enum.any?(warnings, &(&1 =~ "<transmission>"))
+    end
+
+    test "errors out on multiple root links" do
+      xml = """
+      <?xml version="1.0"?>
+      <robot name="t">
+        <link name="a"/>
+        <link name="b"/>
+      </robot>
+      """
+
+      {:ok, parsed} = Parser.parse_string(xml)
+      assert {:error, {:multiple_root_links, _}} = Importer.to_source(parsed, X)
+    end
+
+    test "errors out when a joint references an undefined link" do
+      xml = """
+      <?xml version="1.0"?>
+      <robot name="t">
+        <link name="a"/>
+        <joint name="bad" type="fixed">
+          <parent link="a"/>
+          <child link="nope"/>
+        </joint>
+      </robot>
+      """
+
+      {:ok, parsed} = Parser.parse_string(xml)
+      assert {:error, {:undefined_link, "bad", "nope"}} = Importer.to_source(parsed, X)
+    end
+  end
+end

--- a/test/bb/urdf/importer_test.exs
+++ b/test/bb/urdf/importer_test.exs
@@ -90,9 +90,49 @@ defmodule BB.Urdf.ImporterTest do
     test "passes through parser warnings" do
       {_source, warnings} = import_fixture("mimic_and_transmission.urdf")
 
-      assert Enum.any?(warnings, &(&1 =~ "<mimic>"))
       assert Enum.any?(warnings, &(&1 =~ "<safety_controller>"))
       assert Enum.any?(warnings, &(&1 =~ "<transmission>"))
+    end
+
+    test "emits a BB.Sensor.Mimic for URDF <mimic> joints" do
+      {source, _warnings} = import_fixture("mimic_and_transmission.urdf", MyApp.MimicGen)
+
+      assert source =~ "sensor :right_finger_joint_mimic"
+      assert source =~ "BB.Sensor.Mimic"
+      assert source =~ "source: :left_finger_joint"
+      assert source =~ "multiplier: -1.0"
+      assert [{MyApp.MimicGen, _}] = Code.compile_string(source)
+    end
+
+    test "omits default multiplier and offset on emitted mimic sensors" do
+      xml = """
+      <?xml version="1.0"?>
+      <robot name="t">
+        <link name="a"/>
+        <link name="b"/>
+        <link name="c"/>
+        <joint name="j1" type="prismatic">
+          <parent link="a"/>
+          <child link="b"/>
+          <axis xyz="1 0 0"/>
+          <limit lower="0" upper="1" effort="1" velocity="1"/>
+        </joint>
+        <joint name="j2" type="prismatic">
+          <parent link="b"/>
+          <child link="c"/>
+          <axis xyz="1 0 0"/>
+          <limit lower="0" upper="1" effort="1" velocity="1"/>
+          <mimic joint="j1"/>
+        </joint>
+      </robot>
+      """
+
+      {:ok, parsed} = Parser.parse_string(xml)
+      {:ok, source, _} = Importer.to_source(parsed, MyApp.DefaultMimic)
+
+      assert source =~ ~r/source: :j1[^,}]*\}/
+      refute source =~ "multiplier:"
+      refute source =~ "offset:"
     end
 
     test "dedupes named materials so multiple visuals can share a URDF material" do

--- a/test/bb/urdf/parser_test.exs
+++ b/test/bb/urdf/parser_test.exs
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Urdf.ParserTest do
+  use ExUnit.Case, async: true
+
+  alias BB.Urdf.Parser
+
+  @fixture_dir Path.join([__DIR__, "..", "..", "fixtures", "urdf"])
+
+  describe "parse_file/1" do
+    test "parses a minimal robot with no joints" do
+      {:ok, robot} = Parser.parse_file(Path.join(@fixture_dir, "minimal.urdf"))
+
+      assert robot.name == "minimal_bot"
+      assert [%{name: "base_link"}] = robot.links
+      assert robot.joints == []
+      assert robot.warnings == []
+    end
+
+    test "parses links, joints, visuals, materials and inertials" do
+      {:ok, robot} = Parser.parse_file(Path.join(@fixture_dir, "two_link_arm.urdf"))
+
+      assert robot.name == "two_link_arm"
+      assert length(robot.links) == 4
+      assert length(robot.joints) == 3
+
+      base = Enum.find(robot.links, &(&1.name == "base_link"))
+      assert base.visual.geometry == {:box, %{size: {0.2, 0.2, 0.05}}}
+      assert base.visual.origin == %{xyz: {0.0, 0.0, 0.1}, rpy: {0.0, 0.0, 0.0}}
+      assert base.visual.material.color == %{red: 1.0, green: 0.0, blue: 0.0, alpha: 1.0}
+      assert [%{name: "base_col", geometry: {:sphere, %{radius: 0.1}}}] = base.collisions
+      assert base.inertial.mass == 1.5
+
+      shoulder = Enum.find(robot.joints, &(&1.name == "shoulder"))
+      assert shoulder.type == :revolute
+      assert shoulder.parent == "base_link"
+      assert shoulder.child == "upper_arm"
+      assert shoulder.axis == {0.0, 1.0, 0.0}
+      assert shoulder.limit.lower == -1.57
+      assert shoulder.dynamics == %{damping: 0.5, friction: 0.1}
+    end
+
+    test "collects warnings for unsupported features" do
+      {:ok, robot} = Parser.parse_file(Path.join(@fixture_dir, "mimic_and_transmission.urdf"))
+
+      assert Enum.any?(robot.warnings, &(&1 =~ "<mimic>"))
+      assert Enum.any?(robot.warnings, &(&1 =~ "<safety_controller>"))
+      assert Enum.any?(robot.warnings, &(&1 =~ "<transmission>"))
+      assert Enum.any?(robot.warnings, &(&1 =~ "<gazebo>"))
+    end
+
+    test "resolves top-level material references inside visuals" do
+      {:ok, robot} = Parser.parse_file(Path.join(@fixture_dir, "two_link_arm.urdf"))
+
+      base = Enum.find(robot.links, &(&1.name == "base_link"))
+      assert base.visual.material.name == "red"
+      assert base.visual.material.color == %{red: 1.0, green: 0.0, blue: 0.0, alpha: 1.0}
+    end
+
+    test "returns an error for missing files" do
+      assert {:error, :enoent} = Parser.parse_file("/no/such/file.urdf")
+    end
+  end
+
+  describe "parse_string/1" do
+    test "returns an error for malformed XML" do
+      assert {:error, {:xml_parse_error, _}} = Parser.parse_string("<robot><link></robot>")
+    end
+
+    test "parses cylinder geometry with radius and length" do
+      xml = """
+      <?xml version="1.0"?>
+      <robot name="t"><link name="a">
+        <collision><geometry><cylinder radius="0.1" length="0.5"/></geometry></collision>
+      </link></robot>
+      """
+
+      {:ok, robot} = Parser.parse_string(xml)
+      [link] = robot.links
+      [collision] = link.collisions
+      assert collision.geometry == {:cylinder, %{radius: 0.1, length: 0.5}}
+    end
+
+    test "parses mesh geometry with filename and scale" do
+      xml = """
+      <?xml version="1.0"?>
+      <robot name="t"><link name="a">
+        <visual><geometry><mesh filename="package://thing/mesh.stl" scale="0.5 0.5 0.5"/></geometry></visual>
+      </link></robot>
+      """
+
+      {:ok, robot} = Parser.parse_string(xml)
+      [link] = robot.links
+      assert link.visual.geometry == {:mesh, %{filename: "package://thing/mesh.stl", scale: 0.5}}
+    end
+  end
+end

--- a/test/bb/urdf/parser_test.exs
+++ b/test/bb/urdf/parser_test.exs
@@ -45,10 +45,16 @@ defmodule BB.Urdf.ParserTest do
     test "collects warnings for unsupported features" do
       {:ok, robot} = Parser.parse_file(Path.join(@fixture_dir, "mimic_and_transmission.urdf"))
 
-      assert Enum.any?(robot.warnings, &(&1 =~ "<mimic>"))
       assert Enum.any?(robot.warnings, &(&1 =~ "<safety_controller>"))
       assert Enum.any?(robot.warnings, &(&1 =~ "<transmission>"))
       assert Enum.any?(robot.warnings, &(&1 =~ "<gazebo>"))
+    end
+
+    test "parses <mimic> into a per-joint mimic struct" do
+      {:ok, robot} = Parser.parse_file(Path.join(@fixture_dir, "mimic_and_transmission.urdf"))
+
+      right = Enum.find(robot.joints, &(&1.name == "right_finger_joint"))
+      assert right.mimic == %{joint: "left_finger_joint", multiplier: -1.0, offset: 0.0}
     end
 
     test "resolves top-level material references inside visuals" do

--- a/test/fixtures/urdf/mimic_and_transmission.urdf
+++ b/test/fixtures/urdf/mimic_and_transmission.urdf
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<robot name="gripper_bot">
+  <link name="base_link"/>
+  <link name="left_finger"/>
+  <link name="right_finger"/>
+
+  <joint name="left_finger_joint" type="prismatic">
+    <parent link="base_link"/>
+    <child link="left_finger"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="0" upper="0.05" effort="10" velocity="0.1"/>
+    <safety_controller k_velocity="1.0"/>
+  </joint>
+
+  <joint name="right_finger_joint" type="prismatic">
+    <parent link="base_link"/>
+    <child link="right_finger"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="0" upper="0.05" effort="10" velocity="0.1"/>
+    <mimic joint="left_finger_joint" multiplier="-1" offset="0"/>
+  </joint>
+
+  <transmission name="left_finger_trans">
+    <type>transmission_interface/SimpleTransmission</type>
+  </transmission>
+
+  <gazebo reference="base_link">
+    <material>Gazebo/Grey</material>
+  </gazebo>
+</robot>

--- a/test/fixtures/urdf/mimic_and_transmission.urdf.license
+++ b/test/fixtures/urdf/mimic_and_transmission.urdf.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0

--- a/test/fixtures/urdf/minimal.urdf
+++ b/test/fixtures/urdf/minimal.urdf
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<robot name="minimal_bot">
+  <link name="base_link"/>
+</robot>

--- a/test/fixtures/urdf/minimal.urdf.license
+++ b/test/fixtures/urdf/minimal.urdf.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0

--- a/test/fixtures/urdf/name_collision.urdf
+++ b/test/fixtures/urdf/name_collision.urdf
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<robot name="collision_bot">
+  <link name="base"/>
+  <link name="gripper"/>
+  <link name="finger"/>
+
+  <joint name="gripper" type="revolute">
+    <parent link="base"/>
+    <child link="gripper"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1" upper="1" effort="1" velocity="1"/>
+  </joint>
+
+  <joint name="finger_joint" type="prismatic">
+    <parent link="gripper"/>
+    <child link="finger"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="0" upper="0.05" effort="1" velocity="0.1"/>
+    <mimic joint="gripper" multiplier="0.5"/>
+  </joint>
+</robot>

--- a/test/fixtures/urdf/name_collision.urdf.license
+++ b/test/fixtures/urdf/name_collision.urdf.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0

--- a/test/fixtures/urdf/shared_materials.urdf
+++ b/test/fixtures/urdf/shared_materials.urdf
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<robot name="shared_materials_bot">
+  <material name="grey">
+    <color rgba="0.5 0.5 0.5 1"/>
+  </material>
+
+  <link name="base_link">
+    <visual>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+      <material name="grey"/>
+    </visual>
+  </link>
+
+  <link name="arm1">
+    <visual>
+      <geometry>
+        <mesh filename="package://meshes/arm.stl"/>
+      </geometry>
+      <material name="grey"/>
+    </visual>
+  </link>
+
+  <link name="arm2">
+    <visual>
+      <geometry>
+        <cylinder radius="0.02" length="0.1"/>
+      </geometry>
+      <material name="grey"/>
+    </visual>
+  </link>
+
+  <joint name="j1" type="revolute">
+    <parent link="base_link"/>
+    <child link="arm1"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1" upper="1" effort="5" velocity="1"/>
+  </joint>
+
+  <joint name="j2" type="prismatic">
+    <parent link="arm1"/>
+    <child link="arm2"/>
+    <axis xyz="1 0 0"/>
+    <limit lower="0" upper="0.1" effort="10" velocity="0.5"/>
+  </joint>
+</robot>

--- a/test/fixtures/urdf/shared_materials.urdf.license
+++ b/test/fixtures/urdf/shared_materials.urdf.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0

--- a/test/fixtures/urdf/two_link_arm.urdf
+++ b/test/fixtures/urdf/two_link_arm.urdf
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<robot name="two_link_arm">
+  <material name="red">
+    <color rgba="1 0 0 1"/>
+  </material>
+
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.2 0.2 0.05"/>
+      </geometry>
+      <material name="red"/>
+    </visual>
+    <collision name="base_col">
+      <geometry>
+        <sphere radius="0.1"/>
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="1.5"/>
+      <inertia ixx="0.01" iyy="0.01" izz="0.02" ixy="0" ixz="0" iyz="0"/>
+    </inertial>
+  </link>
+
+  <link name="upper_arm">
+    <visual>
+      <geometry>
+        <cylinder radius="0.05" length="0.3"/>
+      </geometry>
+    </visual>
+  </link>
+
+  <link name="forearm"/>
+
+  <joint name="shoulder" type="revolute">
+    <parent link="base_link"/>
+    <child link="upper_arm"/>
+    <origin xyz="0 0 0.05" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <limit lower="-1.57" upper="1.57" effort="50" velocity="2"/>
+    <dynamics damping="0.5" friction="0.1"/>
+  </joint>
+
+  <joint name="elbow" type="continuous">
+    <parent link="upper_arm"/>
+    <child link="forearm"/>
+    <origin xyz="0 0 0.3" rpy="0 0 0"/>
+    <axis xyz="0 1 0"/>
+    <limit effort="20" velocity="3"/>
+  </joint>
+
+  <link name="gripper"/>
+
+  <joint name="wrist" type="fixed">
+    <parent link="forearm"/>
+    <child link="gripper"/>
+    <origin xyz="0 0 0.25" rpy="0 0 0"/>
+  </joint>
+</robot>

--- a/test/fixtures/urdf/two_link_arm.urdf.license
+++ b/test/fixtures/urdf/two_link_arm.urdf.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0

--- a/test/fixtures/urdf/world_anchor.urdf
+++ b/test/fixtures/urdf/world_anchor.urdf
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<robot name="anchored_bot">
+  <link name="base_link"/>
+  <link name="arm"/>
+
+  <joint name="world_anchor" type="fixed">
+    <parent link="world"/>
+    <child link="base_link"/>
+  </joint>
+
+  <joint name="shoulder" type="revolute">
+    <parent link="base_link"/>
+    <child link="arm"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-1" upper="1" effort="1" velocity="1"/>
+  </joint>
+</robot>

--- a/test/fixtures/urdf/world_anchor.urdf.license
+++ b/test/fixtures/urdf/world_anchor.urdf.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0

--- a/test/mix/tasks/bb.from_urdf_test.exs
+++ b/test/mix/tasks/bb.from_urdf_test.exs
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Mix.Tasks.Bb.FromUrdfTest do
+  use ExUnit.Case
+  import Igniter.Test
+
+  @moduletag :igniter
+
+  @fixture_dir Path.join([__DIR__, "..", "..", "fixtures", "urdf"])
+
+  test "generates a robot module from a minimal URDF" do
+    urdf = Path.join(@fixture_dir, "minimal.urdf")
+
+    test_project()
+    |> Igniter.compose_task("bb.from_urdf", [urdf, "--module", "Test.Robot"])
+    |> assert_creates("lib/test/robot.ex")
+  end
+
+  test "generated module uses BB and emits the URDF robot name" do
+    urdf = Path.join(@fixture_dir, "minimal.urdf")
+
+    igniter =
+      test_project()
+      |> Igniter.compose_task("bb.from_urdf", [urdf, "--module", "Test.Robot"])
+
+    {_, source} = Rewrite.source(igniter.rewrite, "lib/test/robot.ex")
+    assert source.content =~ "use BB"
+    assert source.content =~ ~r/name[ (]:minimal_bot/
+    assert source.content =~ ~r/link[ (]:base_link/
+  end
+
+  test "produces a warning for unsupported URDF features" do
+    urdf = Path.join(@fixture_dir, "mimic_and_transmission.urdf")
+
+    igniter =
+      test_project()
+      |> Igniter.compose_task("bb.from_urdf", [urdf, "--module", "Test.Robot"])
+
+    assert Enum.any?(igniter.warnings, &(&1 =~ "<mimic>"))
+    assert Enum.any?(igniter.warnings, &(&1 =~ "<transmission>"))
+  end
+
+  test "records an issue when the URDF file is missing" do
+    igniter =
+      test_project()
+      |> Igniter.compose_task("bb.from_urdf", ["/no/such/file.urdf", "--module", "Test.Robot"])
+
+    assert Enum.any?(igniter.issues, &(&1 =~ "Could not parse URDF"))
+  end
+end

--- a/test/mix/tasks/bb.from_urdf_test.exs
+++ b/test/mix/tasks/bb.from_urdf_test.exs
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Bb.FromUrdfTest do
       test_project()
       |> Igniter.compose_task("bb.from_urdf", [urdf, "--module", "Test.Robot"])
 
-    assert Enum.any?(igniter.warnings, &(&1 =~ "<mimic>"))
+    assert Enum.any?(igniter.warnings, &(&1 =~ "<safety_controller>"))
     assert Enum.any?(igniter.warnings, &(&1 =~ "<transmission>"))
   end
 


### PR DESCRIPTION
Closes #101.

## Summary

Adds a `mix bb.from_urdf` Igniter task that reads a URDF XML file and generates an equivalent BB DSL module:

```bash
mix bb.from_urdf path/to/robot.urdf --module MyApp.Robot
```

Three pieces:

- **`BB.Urdf.Parser`** — parses URDF XML into a plain-map representation via `:xmerl_scan` (no extra deps). Collects warnings for `<mimic>`, `<safety_controller>`, `<transmission>`, and `<gazebo>` blocks rather than failing the import, so partial fidelity is preferred over rejecting real-world URDFs.
- **`BB.Urdf.Importer`** — converts parsed URDF into a quoted BB DSL module and formats it via Sourceror with `~u` sigil literals for unit-bearing values. Joints are nested under their parent links in topology order; the root link is identified as the one never appearing as a `<child>`. Cardinal axis vectors map to BB's `axis do roll/pitch end` Euler form (`0 1 0` → `roll ~u(-90 degree)`, etc.); arbitrary vectors get rotated to Z via computed Euler angles.
- **`mix bb.from_urdf`** — Igniter task that wraps the two, writes the module via `Igniter.Project.Module.create_module`, and surfaces parser warnings via `Igniter.add_warning/2`.

## What's deliberately not in this PR

- **Mesh file management.** Mesh `filename` attributes (including `package://` URIs) are passed through verbatim. The user copies meshes and rewrites paths themselves; that felt like a separate concern from generation.
- **`<mimic>` / `<safety_controller>` / `<transmission>` translation.** No clean BB analogue — surfaced as warnings instead.
- **Tutorial doc.** `07-urdf-import.md` from the issue's "Related" section. The existing `07-parameters.md` makes the numbering awkward; happy to add this as a follow-up once we decide on a slot (e.g. renumber, or move to `documentation/how-to/`).
- **Regenerating `bb_example_wx200`'s definition** from a vendor URDF as a smoke test, per the issue's open question. Round-trip works on the test fixture (URDF → DSL → compile → URDF), but adding the example regen feels like a separate PR.

## Test plan

- [x] `mix test test/bb/urdf/parser_test.exs` (8 tests)
- [x] `mix test test/bb/urdf/importer_test.exs` (10 tests, including a generated-source-compiles check)
- [x] `mix test test/mix/tasks/bb.from_urdf_test.exs` (4 Igniter tests)
- [x] `mix test` (938 tests, no regressions)
- [x] `mix format --check-formatted`
- [x] `mix credo --strict`
- [x] `mix dialyzer` (clean)
- [x] Manual round-trip on `two_link_arm.urdf`: parse → generate DSL → compile → export → same structure