### PR TITLE
improvement: merge `mix bb.from_urdf` output into existing modules

### DIFF
--- a/lib/bb/urdf/importer.ex
+++ b/lib/bb/urdf/importer.ex
@@ -50,20 +50,11 @@ if Code.ensure_loaded?(Sourceror) do
     @spec to_quoted(Parser.robot(), module) ::
             {:ok, Macro.t(), [String.t()]} | {:error, term}
     def to_quoted(robot, module_name) when is_atom(module_name) do
-      robot =
-        robot
-        |> drop_world_anchor_joints()
-        |> dedupe_joint_names()
-        |> dedupe_material_names()
+      with {:ok, prepared} <- prepare(robot) do
+        topology =
+          render_topology(prepared.root, prepared.links_by_name, prepared.joints_by_parent)
 
-      links_by_name = Map.new(robot.links, &{&1.name, &1})
-      joints_by_parent = Enum.group_by(robot.joints, & &1.parent)
-      child_links = MapSet.new(robot.joints, & &1.child)
-
-      with :ok <- validate_referenced_links(robot.joints, links_by_name),
-           {:ok, root} <- roots(robot.links, child_links) do
-        topology = render_topology(root, links_by_name, joints_by_parent)
-        settings = render_settings(robot.name)
+        settings = render_settings(prepared.name)
 
         body =
           block([
@@ -77,7 +68,49 @@ if Code.ensure_loaded?(Sourceror) do
 
         ast = {:defmodule, [], [module_alias, [do: body]]}
 
-        {:ok, ast, robot.warnings}
+        {:ok, ast, prepared.warnings}
+      end
+    end
+
+    @doc """
+    Build the quoted form of just the `topology do ... end` block.
+
+    Used when merging an imported URDF into an existing BB module — only the
+    topology gets replaced, leaving `settings`, sensors, controllers, commands
+    and other hand-written content alone.
+    """
+    @spec to_topology_quoted(Parser.robot()) ::
+            {:ok, Macro.t(), [String.t()]} | {:error, term}
+    def to_topology_quoted(robot) do
+      with {:ok, prepared} <- prepare(robot) do
+        topology =
+          render_topology(prepared.root, prepared.links_by_name, prepared.joints_by_parent)
+
+        {:ok, topology, prepared.warnings}
+      end
+    end
+
+    defp prepare(robot) do
+      robot =
+        robot
+        |> drop_world_anchor_joints()
+        |> dedupe_joint_names()
+        |> dedupe_material_names()
+
+      links_by_name = Map.new(robot.links, &{&1.name, &1})
+      joints_by_parent = Enum.group_by(robot.joints, & &1.parent)
+      child_links = MapSet.new(robot.joints, & &1.child)
+
+      with :ok <- validate_referenced_links(robot.joints, links_by_name),
+           {:ok, root} <- roots(robot.links, child_links) do
+        {:ok,
+         %{
+           root: root,
+           links_by_name: links_by_name,
+           joints_by_parent: joints_by_parent,
+           name: robot.name,
+           warnings: robot.warnings
+         }}
       end
     end
 

--- a/lib/mix/tasks/bb.from_urdf.ex
+++ b/lib/mix/tasks/bb.from_urdf.ex
@@ -49,6 +49,7 @@ if Code.ensure_loaded?(Igniter) do
     use Igniter.Mix.Task
 
     alias BB.Urdf.{Importer, Parser}
+    alias Igniter.Code.{Common, Function}
 
     @impl Igniter.Mix.Task
     def info(_argv, _parent) do
@@ -104,12 +105,12 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     defp replace_or_insert_topology(zipper, topology_ast) do
-      case Igniter.Code.Function.move_to_function_call_in_current_scope(zipper, :topology, 1) do
+      case Function.move_to_function_call_in_current_scope(zipper, :topology, 1) do
         {:ok, found} ->
-          {:ok, Igniter.Code.Common.replace_code(found, topology_ast)}
+          {:ok, Common.replace_code(found, topology_ast)}
 
         :error ->
-          {:ok, Igniter.Code.Common.add_code(zipper, topology_ast)}
+          {:ok, Common.add_code(zipper, topology_ast)}
       end
     end
 

--- a/lib/mix/tasks/bb.from_urdf.ex
+++ b/lib/mix/tasks/bb.from_urdf.ex
@@ -12,6 +12,11 @@ if Code.ensure_loaded?(Igniter) do
     Reads a URDF XML file and writes a `defmodule` that uses `BB` with an
     equivalent topology to your project.
 
+    If the target module already exists, only its `topology do ... end` block
+    is replaced — `settings`, sensors, controllers, commands and any other
+    hand-written content are left in place. If the existing module has no
+    `topology` block, one is appended.
+
     ## Example
 
     ```bash
@@ -76,26 +81,36 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     defp generate(igniter, parsed, module_name) do
-      case Importer.to_source(parsed, module_name) do
-        {:ok, source, warnings} ->
-          igniter
-          |> create_or_replace_module(module_name, source)
-          |> add_warnings(warnings)
-
+      with {:ok, source, warnings} <- Importer.to_source(parsed, module_name),
+           {:ok, topology_ast, _} <- Importer.to_topology_quoted(parsed) do
+        igniter
+        |> find_and_update_or_create_module(module_name, source, topology_ast)
+        |> add_warnings(warnings)
+      else
         {:error, reason} ->
           Igniter.add_issue(igniter, "Could not generate BB module: #{inspect(reason)}")
       end
     end
 
-    defp create_or_replace_module(igniter, module_name, source) do
+    defp find_and_update_or_create_module(igniter, module_name, source, topology_ast) do
       body = strip_defmodule(source, module_name)
 
-      Igniter.Project.Module.create_module(
+      Igniter.Project.Module.find_and_update_or_create_module(
         igniter,
         module_name,
         body,
-        on_exists: :overwrite
+        fn zipper -> replace_or_insert_topology(zipper, topology_ast) end
       )
+    end
+
+    defp replace_or_insert_topology(zipper, topology_ast) do
+      case Igniter.Code.Function.move_to_function_call_in_current_scope(zipper, :topology, 1) do
+        {:ok, found} ->
+          {:ok, Igniter.Code.Common.replace_code(found, topology_ast)}
+
+        :error ->
+          {:ok, Igniter.Code.Common.add_code(zipper, topology_ast)}
+      end
     end
 
     defp strip_defmodule(source, module_name) do

--- a/test/mix/tasks/bb.from_urdf_test.exs
+++ b/test/mix/tasks/bb.from_urdf_test.exs
@@ -49,4 +49,61 @@ defmodule Mix.Tasks.Bb.FromUrdfTest do
 
     assert Enum.any?(igniter.issues, &(&1 =~ "Could not parse URDF"))
   end
+
+  test "re-importing replaces topology but preserves hand-written content" do
+    urdf = Path.join(@fixture_dir, "minimal.urdf")
+
+    existing = """
+    defmodule Test.Robot do
+      use BB
+
+      settings name: :custom_name
+
+      topology do
+        link :stale_link do
+        end
+      end
+
+      sensors do
+        sensor :battery, MyApp.Battery
+      end
+    end
+    """
+
+    igniter =
+      test_project(files: %{"lib/test/robot.ex" => existing})
+      |> Igniter.compose_task("bb.from_urdf", [urdf, "--module", "Test.Robot"])
+
+    {_, source} = Rewrite.source(igniter.rewrite, "lib/test/robot.ex")
+    content = source.content
+
+    assert content =~ ~r/settings[ (]name:\s+:custom_name/
+    refute content =~ ~r/name:\s+:minimal_bot/
+    assert content =~ ~r/sensor[ (]:battery/
+    assert content =~ ~r/link[ (]:base_link/
+    refute content =~ ~r/link[ (]:stale_link/
+  end
+
+  test "re-importing into a module with no topology block appends one" do
+    urdf = Path.join(@fixture_dir, "minimal.urdf")
+
+    existing = """
+    defmodule Test.Robot do
+      use BB
+
+      settings name: :custom_name
+    end
+    """
+
+    igniter =
+      test_project(files: %{"lib/test/robot.ex" => existing})
+      |> Igniter.compose_task("bb.from_urdf", [urdf, "--module", "Test.Robot"])
+
+    {_, source} = Rewrite.source(igniter.rewrite, "lib/test/robot.ex")
+    content = source.content
+
+    assert content =~ ~r/settings[ (]name:\s+:custom_name/
+    assert content =~ ~r/topology do/
+    assert content =~ ~r/link[ (]:base_link/
+  end
 end


### PR DESCRIPTION
## Summary

- `mix bb.from_urdf` no longer chokes when the target robot module already exists. Previously it passed `on_exists: :overwrite` to `Igniter.Project.Module.create_module/4`, but that helper silently drops the option, so a second run produced a `File already exists` issue and refused to write.
- On re-import, only the `topology do ... end` block is replaced. `settings`, sensors, controllers, commands and any other hand-written content are left untouched. If the existing module has no `topology` block, one is appended.
- `BB.Urdf.Importer` gains `to_topology_quoted/1` for the update path; shared normalisation/validation moves into a private `prepare/1`.

## Test plan

- [x] `mix test test/mix/tasks/bb.from_urdf_test.exs` — existing tests plus two new ones covering merge-with-preservation and missing-`topology` insertion.
- [x] `mix test` — full suite (947 tests) passes.
- [x] `mix format --check-formatted` clean.