### PR TITLE
feat: add `BB.Message.Sensor.PowerState`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,14 @@ end
 
 `BB.Message` wraps payloads with timestamp/frame_id. Payload types use `use BB.Message` with a schema for validation via Spark.Options.
 
+**Payload naming conventions** under `BB.Message.Sensor.*` and `BB.Message.Actuator.*`:
+
+- **`*State`** — multi-field snapshot of an identifiable entity's *current condition*. Used when several coupled fields together describe the entity at one moment in time. Examples: `BatteryState`, `JointState`, `PowerState`.
+- **Naked noun** — a single-purpose reading where the message *is* the sample. Examples: `Image`, `Range`, `LaserScan`. (`Imu` lives here too although it could have been `ImuState` — kept as-is for precedent.)
+- **`VerbObject`** — events / notifications. Example: `BeginMotion`. Future likely candidates: `EndMotion`, `Stalled`, `LimitReached`.
+
+When adding a new payload, pick the convention that matches its shape rather than inventing a new suffix.
+
 ## Key Patterns
 
 - Units: Use `Cldr.Unit` throughout DSL, converted to floats (SI) in Robot struct

--- a/lib/bb/message/sensor/power_state.ex
+++ b/lib/bb/message/sensor/power_state.ex
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Sensor.PowerState do
+  @moduledoc """
+  Instantaneous electrical state of a measured circuit, bus, or device.
+
+  Published by power-monitor chips (e.g. INA219, INA226) and any device
+  that exposes voltage and current as part of its normal telemetry (e.g.
+  Robotis or Feetech servos reporting their own draw).
+
+  This is a raw electrical snapshot. Battery-aware concepts like
+  state-of-charge, percentage, or health belong in
+  `BB.Message.Sensor.BatteryState` and are the job of a downstream
+  consumer that subscribes to `PowerState` and maintains charge state.
+
+  ## Fields
+
+  - `voltage` - Bus voltage in Volts
+  - `current` - Current in Amperes (signed; sign convention is producer-defined,
+    typically positive = flowing in the measured direction)
+  - `power` - Power in Watts, or `nil` if the producer doesn't measure it
+  - `shunt_voltage` - Shunt voltage in Volts, or `nil` if not exposed (diagnostic)
+
+  ## Examples
+
+      alias BB.Message.Sensor.PowerState
+
+      {:ok, msg} = PowerState.new(:battery_bus,
+        voltage: 12.4,
+        current: 0.85,
+        power: 10.54
+      )
+  """
+
+  defstruct [:voltage, :current, :power, :shunt_voltage]
+
+  use BB.Message,
+    schema: [
+      voltage: [type: :float, required: true, doc: "Bus voltage in Volts"],
+      current: [type: :float, required: true, doc: "Current in Amperes (signed)"],
+      power: [
+        type: {:or, [:float, {:literal, nil}]},
+        default: nil,
+        doc: "Power in Watts (nil if not measured)"
+      ],
+      shunt_voltage: [
+        type: {:or, [:float, {:literal, nil}]},
+        default: nil,
+        doc: "Shunt voltage in Volts (diagnostic; nil if not exposed)"
+      ]
+    ]
+
+  @type t :: %__MODULE__{
+          voltage: float(),
+          current: float(),
+          power: float() | nil,
+          shunt_voltage: float() | nil
+        }
+end


### PR DESCRIPTION
## Summary

- Adds `BB.Message.Sensor.PowerState` carrying `voltage` / `current` / `power` / `shunt_voltage` in SI units. Intended for power-monitor chips (INA219, INA226, …) and any device that exposes electrical telemetry as part of its normal output (Robotis/Feetech servos already report voltage and current — they could publish this too in a future PR).
- `BatteryState` is unchanged. Battery-aware concepts (charge, percentage, health) belong in a downstream consumer that subscribes to `PowerState` and maintains the extra state.
- Documents the existing `BB.Message.*` payload naming conventions in `AGENTS.md` (`*State` for multi-field snapshots, naked noun for single-purpose readings, `VerbObject` for events) — observed practice that wasn't written down.

## Motivation

`bb_ina219` (separate sibling repo, will be published once this lands and ships) needs a generic V/I/P message to publish. Forcing the INA219 into `BatteryState` would bake battery-specific concepts into a sensor that can't measure them — the chip is just as happy being wired inline with a servo for stall detection or watching a logic rail.

## Test plan

- [x] `mix check --no-retry` passes (`compiler`, `credo`, `dialyzer`, `ex_doc`, `ex_unit`, `formatter`, `mix_audit`, `reuse`, `unused_deps`)
- [x] 1001 tests still pass
- [x] Smoke-tested end-to-end via a sibling `bb_ina219` package against a real INA219 over an FT232H — `PowerState` messages arrive on `[:sensor, …]` with sensible voltage/current values