### PR TITLE
feat: Covariance math types, estimator payloads, error types (Phase 3, proposal 0018)

### DIFF
--- a/documentation/reference/error-types.md
+++ b/documentation/reference/error-types.md
@@ -430,6 +430,64 @@ Low-level protocol failures.
 
 Used by driver packages (e.g., Robotis Dynamixel protocol errors).
 
+## Estimator Errors
+
+State-estimation errors. Raised by `BB.Estimator` implementations or by `BB.Estimator.Server` when an input violates a constraint.
+
+### StaleInput
+
+An input arrived too late to be useful — either it exceeded the estimator's `latency_budget` or it landed outside the configured `sync_tolerance` and the algorithm opted to surface the failure rather than silently drop.
+
+**Module:** `BB.Error.Estimator.StaleInput`
+
+**Class:** `:state`
+
+**Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `input_path` | `[atom]` | The pubsub path of the late input |
+| `age_ms` | `number` | Observed input age, in milliseconds |
+| `budget_ms` | `number` | The configured budget that was exceeded |
+
+**Severity:** `:warning`
+
+### SyncMiss
+
+A driver input arrived but a paired non-driver input was older than `sync_tolerance`. The framework normally drops these dispatches silently (with `[:bb, :estimator, :dropped]` telemetry, reason `:sync_miss`); this error type exists for algorithms or supervisors that want to surface the miss as a structured value instead.
+
+**Module:** `BB.Error.Estimator.SyncMiss`
+
+**Class:** `:state`
+
+**Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `driver_path` | `[atom]` | Pubsub path of the driver input |
+| `input_path` | `[atom]` | Pubsub path of the late non-driver input |
+| `gap_ms` | `number` | Gap between driver and non-driver, in milliseconds |
+| `tolerance_ms` | `number` | The configured tolerance that was exceeded |
+
+**Severity:** `:warning`
+
+### MissingCovariance
+
+An algorithm required a covariance field on an input payload but the upstream publisher left it `nil`.
+
+**Module:** `BB.Error.Estimator.MissingCovariance`
+
+**Class:** `:invalid`
+
+**Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `estimator` | `atom` | The estimator's name |
+| `field` | `atom` | The covariance field that was missing (e.g. `:orientation_covariance`) |
+
+**Severity:** `:error`
+
 ## Creating Errors
 
 Always use `exception/1` to create errors so that Splode can capture backtraces:

--- a/documentation/reference/message-types.md
+++ b/documentation/reference/message-types.md
@@ -81,6 +81,11 @@ Inertial measurement unit data.
 | `orientation` | `Quaternion` | No | Orientation quaternion |
 | `angular_velocity` | `Vec3` | No | Angular velocity in rad/s |
 | `linear_acceleration` | `Vec3` | No | Linear acceleration in m/s² |
+| `orientation_covariance` | `Covariance3 \| nil` | No | 3x3 covariance over orientation. `nil` when unknown. |
+| `angular_velocity_covariance` | `Covariance3 \| nil` | No | 3x3 covariance over angular velocity. `nil` when unknown. |
+| `linear_acceleration_covariance` | `Covariance3 \| nil` | No | 3x3 covariance over linear acceleration. `nil` when unknown. |
+
+Drivers with known noise characteristics populate the covariance fields; ones that don't leave them `nil`. Algorithms that require covariance check for `nil` and either fall back to a configured default or raise `BB.Error.Estimator.MissingCovariance`. Mirrors the ROS `sensor_msgs/Imu` shape.
 
 **Published to:** `[:sensor, :imu]` or custom path
 
@@ -312,6 +317,42 @@ Force and torque.
 |-------|------|----------|-------------|
 | `force` | `Vec3` | Yes | Force (N) |
 | `torque` | `Vec3` | Yes | Torque (Nm) |
+
+## Estimator Messages
+
+Payloads published by `BB.Estimator` implementations. Distinguished from `Geometry.*` by carrying optional uncertainty (covariance) alongside the geometric value. Subscribers wanting fused outputs specifically can filter on these payload types to separate them from waypoints or command goals.
+
+### Estimator.Pose
+
+A 6-DOF pose estimate with optional covariance.
+
+**Module:** `BB.Message.Estimator.Pose`
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `transform` | `Transform` | Yes | Pose as a 4x4 homogeneous transform |
+| `covariance` | `Covariance6 \| nil` | No | 6x6 covariance over translation (x/y/z) and rotation (r/p/y). `nil` when unknown. |
+
+Canonical output for any estimator publishing a fused pose (AHRS, EKF, visual SLAM front-end).
+
+### Estimator.Odometry
+
+A pose-and-twist odometry estimate with separate optional covariances.
+
+**Module:** `BB.Message.Estimator.Odometry`
+
+**Fields:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `pose` | `Transform` | Yes | Pose component |
+| `twist` | `Twist` | Yes | Linear and angular velocity (as `BB.Message.Geometry.Twist`) |
+| `pose_covariance` | `Covariance6 \| nil` | No | 6x6 covariance over the pose |
+| `twist_covariance` | `Covariance6 \| nil` | No | 6x6 covariance over the twist |
+
+Mirrors ROS `nav_msgs/Odometry`. Canonical output for IMU-plus-wheel-odometry EKFs and any other fusion stage publishing both a pose and a velocity simultaneously.
 
 ## System Messages
 

--- a/lib/bb/error/estimator.ex
+++ b/lib/bb/error/estimator.ex
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Estimator do
+  @moduledoc """
+  State-estimation error classes.
+
+  Raised by estimator implementations or by `BB.Estimator.Server` when an
+  input violates a constraint (too stale, out of sync with the driver
+  input, missing a covariance that the algorithm requires).
+  """
+end

--- a/lib/bb/error/estimator/missing_covariance.ex
+++ b/lib/bb/error/estimator/missing_covariance.ex
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Estimator.MissingCovariance do
+  @moduledoc """
+  An algorithm required a covariance field on an input payload but the
+  upstream publisher left it `nil`.
+
+  Many Kalman-family algorithms cannot proceed without measurement
+  noise. They may either fall back to a configured default or raise
+  this error, depending on configuration.
+  """
+
+  use BB.Error, class: :invalid, fields: [:estimator, :field]
+
+  @type t :: %__MODULE__{
+          estimator: atom(),
+          field: atom()
+        }
+
+  defimpl BB.Error.Severity do
+    def severity(_), do: :error
+  end
+
+  def message(%{estimator: estimator, field: field}) do
+    "estimator #{inspect(estimator)} requires #{inspect(field)} but the input did not supply it"
+  end
+end

--- a/lib/bb/error/estimator/stale_input.ex
+++ b/lib/bb/error/estimator/stale_input.ex
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Estimator.StaleInput do
+  @moduledoc """
+  An input message arrived too late to be useful.
+
+  Raised when an estimator's `latency_budget` (Phase 2) is exceeded
+  between an input's `monotonic_time` and the moment it is dispatched,
+  or when a non-driver input falls outside the configured
+  `sync_tolerance` of the driver and the algorithm has opted to surface
+  the failure rather than silently drop.
+  """
+
+  use BB.Error, class: :state, fields: [:input_path, :age_ms, :budget_ms]
+
+  @type t :: %__MODULE__{
+          input_path: [atom()],
+          age_ms: number(),
+          budget_ms: number()
+        }
+
+  defimpl BB.Error.Severity do
+    def severity(_), do: :warning
+  end
+
+  def message(%{input_path: path, age_ms: age, budget_ms: budget}) do
+    "stale input at #{inspect(path)}: age #{age}ms exceeds budget #{budget}ms"
+  end
+end

--- a/lib/bb/error/estimator/sync_miss.ex
+++ b/lib/bb/error/estimator/sync_miss.ex
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Estimator.SyncMiss do
+  @moduledoc """
+  A driver input arrived but a paired non-driver input was older than
+  the estimator's `sync_tolerance`.
+
+  Normally the framework drops these dispatches silently (with
+  `[:bb, :estimator, :dropped]` telemetry, reason `:sync_miss`). This
+  error type exists for algorithms or supervisors that want to surface
+  the miss as a structured value instead.
+  """
+
+  use BB.Error,
+    class: :state,
+    fields: [:driver_path, :input_path, :gap_ms, :tolerance_ms]
+
+  @type t :: %__MODULE__{
+          driver_path: [atom()],
+          input_path: [atom()],
+          gap_ms: number(),
+          tolerance_ms: number()
+        }
+
+  defimpl BB.Error.Severity do
+    def severity(_), do: :warning
+  end
+
+  def message(%{driver_path: driver, input_path: input, gap_ms: gap, tolerance_ms: tol}) do
+    "sync miss: driver #{inspect(driver)} vs input #{inspect(input)} — gap #{gap}ms exceeds tolerance #{tol}ms"
+  end
+end

--- a/lib/bb/math/covariance3.ex
+++ b/lib/bb/math/covariance3.ex
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Math.Covariance3 do
+  @moduledoc """
+  A 3x3 covariance matrix, backed by an Nx tensor.
+
+  Used to express uncertainty over a 3-vector quantity such as an
+  accelerometer reading, an angular velocity, or a position. The matrix
+  is mathematically expected to be symmetric and positive semi-definite;
+  this module does not enforce those invariants on construction (zero
+  matrices, in particular, are legitimate "unknown variance" placeholders
+  and must remain constructible).
+
+  Follows the same typed-Nx-wrapper pattern as `BB.Math.Vec3`,
+  `BB.Math.Quaternion`, and `BB.Math.Transform`.
+
+  ## Examples
+
+      iex> c = BB.Math.Covariance3.diagonal([0.01, 0.01, 0.02])
+      iex> BB.Math.Covariance3.get(c, 0, 0)
+      0.01
+  """
+
+  defstruct [:tensor]
+
+  @type t :: %__MODULE__{tensor: Nx.Tensor.t()}
+
+  @doc """
+  Creates a covariance from a `{3, 3}` tensor.
+
+  ## Examples
+
+      iex> tensor = Nx.tensor([[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]])
+      iex> c = BB.Math.Covariance3.new(tensor)
+      iex> BB.Math.Covariance3.get(c, 1, 1)
+      2.0
+  """
+  @spec new(Nx.Tensor.t()) :: t()
+  def new(tensor) do
+    case Nx.shape(tensor) do
+      {3, 3} -> %__MODULE__{tensor: Nx.as_type(tensor, :f64)}
+      shape -> raise ArgumentError, "expected a {3, 3} tensor, got: #{inspect(shape)}"
+    end
+  end
+
+  @doc """
+  Returns the zero covariance - all variances and correlations zero.
+
+  ## Examples
+
+      iex> c = BB.Math.Covariance3.zero()
+      iex> BB.Math.Covariance3.get(c, 0, 0)
+      0.0
+  """
+  @spec zero() :: t()
+  def zero, do: %__MODULE__{tensor: Nx.broadcast(Nx.tensor(0.0, type: :f64), {3, 3})}
+
+  @doc """
+  Returns the 3x3 identity matrix as a covariance.
+
+  ## Examples
+
+      iex> c = BB.Math.Covariance3.identity()
+      iex> {BB.Math.Covariance3.get(c, 0, 0), BB.Math.Covariance3.get(c, 0, 1)}
+      {1.0, 0.0}
+  """
+  @spec identity() :: t()
+  def identity, do: %__MODULE__{tensor: Nx.eye(3, type: :f64)}
+
+  @doc """
+  Builds a diagonal covariance from a list of three variances or a
+  `{3}` tensor.
+
+  ## Examples
+
+      iex> c = BB.Math.Covariance3.diagonal([0.1, 0.2, 0.3])
+      iex> {BB.Math.Covariance3.get(c, 0, 0), BB.Math.Covariance3.get(c, 1, 1), BB.Math.Covariance3.get(c, 2, 2)}
+      {0.1, 0.2, 0.3}
+  """
+  @spec diagonal([number()] | Nx.Tensor.t()) :: t()
+  def diagonal(values) when is_list(values) do
+    case values do
+      [_, _, _] ->
+        %__MODULE__{tensor: values |> Nx.tensor(type: :f64) |> Nx.make_diagonal()}
+
+      _ ->
+        raise ArgumentError, "expected a list of three numbers, got: #{inspect(values)}"
+    end
+  end
+
+  def diagonal(%Nx.Tensor{} = tensor) do
+    case Nx.shape(tensor) do
+      {3} -> %__MODULE__{tensor: tensor |> Nx.as_type(:f64) |> Nx.make_diagonal()}
+      shape -> raise ArgumentError, "expected a {3} tensor, got: #{inspect(shape)}"
+    end
+  end
+
+  @doc """
+  Wraps an existing `{3, 3}` tensor without validation. Convenience
+  alias for `new/1` matching the convention used by `BB.Math.Transform`.
+  """
+  @spec from_tensor(Nx.Tensor.t()) :: t()
+  def from_tensor(tensor), do: new(tensor)
+
+  @doc "Returns the underlying tensor."
+  @spec to_tensor(t()) :: Nx.Tensor.t()
+  def to_tensor(%__MODULE__{tensor: t}), do: t
+
+  @doc """
+  Reads a scalar element at row/column `(i, j)`.
+
+  ## Examples
+
+      iex> c = BB.Math.Covariance3.diagonal([0.5, 1.5, 2.5])
+      iex> BB.Math.Covariance3.get(c, 2, 2)
+      2.5
+  """
+  @spec get(t(), 0..2, 0..2) :: float()
+  def get(%__MODULE__{tensor: t}, i, j) when i in 0..2 and j in 0..2 do
+    Nx.to_number(t[i][j])
+  end
+end

--- a/lib/bb/math/covariance6.ex
+++ b/lib/bb/math/covariance6.ex
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Math.Covariance6 do
+  @moduledoc """
+  A 6x6 covariance matrix, backed by an Nx tensor.
+
+  Used to express uncertainty over 6-DOF pose or twist estimates (3
+  translation + 3 rotation, or 3 linear + 3 angular). The matrix is
+  mathematically expected to be symmetric and positive semi-definite;
+  this module does not enforce those invariants on construction.
+
+  Follows the same typed-Nx-wrapper pattern as `BB.Math.Covariance3`.
+
+  ## Examples
+
+      iex> c = BB.Math.Covariance6.diagonal([0.01, 0.01, 0.01, 0.001, 0.001, 0.001])
+      iex> BB.Math.Covariance6.get(c, 3, 3)
+      0.001
+  """
+
+  defstruct [:tensor]
+
+  @type t :: %__MODULE__{tensor: Nx.Tensor.t()}
+
+  @doc """
+  Creates a covariance from a `{6, 6}` tensor.
+  """
+  @spec new(Nx.Tensor.t()) :: t()
+  def new(tensor) do
+    case Nx.shape(tensor) do
+      {6, 6} -> %__MODULE__{tensor: Nx.as_type(tensor, :f64)}
+      shape -> raise ArgumentError, "expected a {6, 6} tensor, got: #{inspect(shape)}"
+    end
+  end
+
+  @doc """
+  Returns the zero covariance.
+
+  ## Examples
+
+      iex> c = BB.Math.Covariance6.zero()
+      iex> BB.Math.Covariance6.get(c, 0, 0)
+      0.0
+  """
+  @spec zero() :: t()
+  def zero, do: %__MODULE__{tensor: Nx.broadcast(Nx.tensor(0.0, type: :f64), {6, 6})}
+
+  @doc """
+  Returns the 6x6 identity matrix as a covariance.
+
+  ## Examples
+
+      iex> c = BB.Math.Covariance6.identity()
+      iex> {BB.Math.Covariance6.get(c, 0, 0), BB.Math.Covariance6.get(c, 0, 1)}
+      {1.0, 0.0}
+  """
+  @spec identity() :: t()
+  def identity, do: %__MODULE__{tensor: Nx.eye(6, type: :f64)}
+
+  @doc """
+  Builds a diagonal covariance from a list of six variances or a `{6}`
+  tensor.
+
+  ## Examples
+
+      iex> c = BB.Math.Covariance6.diagonal([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+      iex> BB.Math.Covariance6.get(c, 5, 5)
+      6.0
+  """
+  @spec diagonal([number()] | Nx.Tensor.t()) :: t()
+  def diagonal(values) when is_list(values) do
+    case values do
+      [_, _, _, _, _, _] ->
+        %__MODULE__{tensor: values |> Nx.tensor(type: :f64) |> Nx.make_diagonal()}
+
+      _ ->
+        raise ArgumentError, "expected a list of six numbers, got: #{inspect(values)}"
+    end
+  end
+
+  def diagonal(%Nx.Tensor{} = tensor) do
+    case Nx.shape(tensor) do
+      {6} -> %__MODULE__{tensor: tensor |> Nx.as_type(:f64) |> Nx.make_diagonal()}
+      shape -> raise ArgumentError, "expected a {6} tensor, got: #{inspect(shape)}"
+    end
+  end
+
+  @doc """
+  Wraps an existing `{6, 6}` tensor. Convenience alias for `new/1`.
+  """
+  @spec from_tensor(Nx.Tensor.t()) :: t()
+  def from_tensor(tensor), do: new(tensor)
+
+  @doc "Returns the underlying tensor."
+  @spec to_tensor(t()) :: Nx.Tensor.t()
+  def to_tensor(%__MODULE__{tensor: t}), do: t
+
+  @doc """
+  Reads a scalar element at row/column `(i, j)`.
+  """
+  @spec get(t(), 0..5, 0..5) :: float()
+  def get(%__MODULE__{tensor: t}, i, j) when i in 0..5 and j in 0..5 do
+    Nx.to_number(t[i][j])
+  end
+end

--- a/lib/bb/message/estimator/odometry.ex
+++ b/lib/bb/message/estimator/odometry.ex
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Estimator.Odometry do
+  @moduledoc """
+  An odometry estimate: pose + twist with separate covariances.
+
+  Mirrors ROS `nav_msgs/Odometry`. The canonical output for IMU + wheel
+  odometry EKFs and any other fusion stage that publishes both a pose
+  and a velocity simultaneously.
+
+  ## Fields
+
+  - `pose` - Pose component as `BB.Math.Transform.t()`.
+  - `twist` - Linear and angular velocity as `BB.Message.Geometry.Twist.t()`.
+  - `pose_covariance` - Optional `BB.Math.Covariance6.t()` over the pose.
+  - `twist_covariance` - Optional `BB.Math.Covariance6.t()` over the twist.
+
+  ## Examples
+
+      alias BB.Message.Estimator.Odometry
+      alias BB.Message.Geometry.Twist
+      alias BB.Math.{Transform, Vec3, Covariance6}
+
+      twist_payload = %Twist{linear: Vec3.zero(), angular: Vec3.zero()}
+
+      {:ok, msg} =
+        Odometry.new(:base_link,
+          pose: Transform.identity(),
+          twist: twist_payload,
+          pose_covariance: Covariance6.identity(),
+          twist_covariance: nil
+        )
+  """
+
+  import BB.Message.Option
+
+  alias BB.Math.Covariance6
+  alias BB.Math.Transform
+  alias BB.Message.Geometry.Twist
+
+  defstruct [:pose, :twist, :pose_covariance, :twist_covariance]
+
+  use BB.Message,
+    schema: [
+      pose: [type: transform_type(), required: true, doc: "Pose component as Transform"],
+      twist: [
+        type: {:struct, BB.Message.Geometry.Twist},
+        required: true,
+        doc: "Linear and angular velocity as a Twist payload"
+      ],
+      pose_covariance: [
+        type: {:or, [covariance6_type(), nil]},
+        required: false,
+        default: nil,
+        doc: "6x6 covariance over the pose, or nil if unknown"
+      ],
+      twist_covariance: [
+        type: {:or, [covariance6_type(), nil]},
+        required: false,
+        default: nil,
+        doc: "6x6 covariance over the twist, or nil if unknown"
+      ]
+    ]
+
+  @type t :: %__MODULE__{
+          pose: Transform.t(),
+          twist: Twist.t(),
+          pose_covariance: nil | Covariance6.t(),
+          twist_covariance: nil | Covariance6.t()
+        }
+end

--- a/lib/bb/message/estimator/pose.ex
+++ b/lib/bb/message/estimator/pose.ex
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Estimator.Pose do
+  @moduledoc """
+  A 6-DOF pose estimate with optional covariance.
+
+  The canonical output payload for any estimator that publishes a fused
+  pose (e.g. an AHRS, an EKF combining IMU and odometry, a visual SLAM
+  front-end). Subscribers wanting fused poses specifically can filter on
+  this payload type to distinguish them from waypoints
+  (`BB.Message.Geometry.Pose`) or command goals.
+
+  ## Fields
+
+  - `transform` - The pose as `BB.Math.Transform.t()` in the frame named
+    by the wrapping message's `:frame_id`.
+  - `covariance` - Optional `BB.Math.Covariance6.t()` over the pose's
+    6 DOF (translation x/y/z, rotation r/p/y). `nil` if the estimator
+    does not produce a covariance.
+
+  ## Examples
+
+      alias BB.Message.Estimator.Pose
+      alias BB.Math.{Transform, Covariance6}
+
+      {:ok, msg} =
+        Pose.new(:base_link,
+          transform: Transform.identity(),
+          covariance: Covariance6.diagonal([0.01, 0.01, 0.01, 0.001, 0.001, 0.001])
+        )
+  """
+
+  import BB.Message.Option
+
+  alias BB.Math.Covariance6
+  alias BB.Math.Transform
+
+  defstruct [:transform, :covariance]
+
+  use BB.Message,
+    schema: [
+      transform: [type: transform_type(), required: true, doc: "Pose as Transform"],
+      covariance: [
+        type: {:or, [covariance6_type(), nil]},
+        required: false,
+        default: nil,
+        doc: "6x6 covariance over translation and rotation, or nil if unknown"
+      ]
+    ]
+
+  @type t :: %__MODULE__{
+          transform: Transform.t(),
+          covariance: nil | Covariance6.t()
+        }
+end

--- a/lib/bb/message/option.ex
+++ b/lib/bb/message/option.ex
@@ -20,6 +20,8 @@ defmodule BB.Message.Option do
       ])
   """
 
+  alias BB.Math.Covariance3
+  alias BB.Math.Covariance6
   alias BB.Math.Quaternion
   alias BB.Math.Transform
   alias BB.Math.Vec3
@@ -109,5 +111,49 @@ defmodule BB.Message.Option do
 
   def validate_transform(value, _opts) do
     {:error, "expected BB.Math.Transform.t(), got: #{inspect(value)}"}
+  end
+
+  @doc """
+  Returns a Spark.Options type for validating `BB.Math.Covariance3.t()`.
+
+  ## Examples
+
+      iex> BB.Message.Option.covariance3_type()
+      {:custom, BB.Message.Option, :validate_covariance3, [[]]}
+  """
+  @spec covariance3_type() :: {:custom, module(), atom(), list()}
+  def covariance3_type, do: {:custom, __MODULE__, :validate_covariance3, [[]]}
+
+  @doc """
+  Validates a BB.Math.Covariance3 struct.
+  """
+  @spec validate_covariance3(term(), keyword()) ::
+          {:ok, Covariance3.t()} | {:error, String.t()}
+  def validate_covariance3(%Covariance3{} = cov, _opts), do: {:ok, cov}
+
+  def validate_covariance3(value, _opts) do
+    {:error, "expected BB.Math.Covariance3.t(), got: #{inspect(value)}"}
+  end
+
+  @doc """
+  Returns a Spark.Options type for validating `BB.Math.Covariance6.t()`.
+
+  ## Examples
+
+      iex> BB.Message.Option.covariance6_type()
+      {:custom, BB.Message.Option, :validate_covariance6, [[]]}
+  """
+  @spec covariance6_type() :: {:custom, module(), atom(), list()}
+  def covariance6_type, do: {:custom, __MODULE__, :validate_covariance6, [[]]}
+
+  @doc """
+  Validates a BB.Math.Covariance6 struct.
+  """
+  @spec validate_covariance6(term(), keyword()) ::
+          {:ok, Covariance6.t()} | {:error, String.t()}
+  def validate_covariance6(%Covariance6{} = cov, _opts), do: {:ok, cov}
+
+  def validate_covariance6(value, _opts) do
+    {:error, "expected BB.Math.Covariance6.t(), got: #{inspect(value)}"}
   end
 end

--- a/lib/bb/message/sensor/imu.ex
+++ b/lib/bb/message/sensor/imu.ex
@@ -8,14 +8,25 @@ defmodule BB.Message.Sensor.Imu do
 
   ## Fields
 
-  - `orientation` - Orientation as `BB.Quaternion.t()`
-  - `angular_velocity` - Angular velocity as `BB.Vec3.t()` in rad/s
-  - `linear_acceleration` - Linear acceleration as `BB.Vec3.t()` in m/s²
+  - `orientation` - Orientation as `BB.Math.Quaternion.t()`
+  - `angular_velocity` - Angular velocity as `BB.Math.Vec3.t()` in rad/s
+  - `linear_acceleration` - Linear acceleration as `BB.Math.Vec3.t()` in m/s²
+
+  ## Optional uncertainty fields
+
+  Drivers with known noise characteristics may populate per-channel
+  covariance matrices. Algorithms that consume them check for `nil` and
+  either fall back to a configured default or refuse the reading.
+  Mirrors the ROS `sensor_msgs/Imu` shape.
+
+  - `orientation_covariance` - `BB.Math.Covariance3.t() | nil`
+  - `angular_velocity_covariance` - `BB.Math.Covariance3.t() | nil`
+  - `linear_acceleration_covariance` - `BB.Math.Covariance3.t() | nil`
 
   ## Examples
 
       alias BB.Message.Sensor.Imu
-      alias BB.{Vec3, Quaternion}
+      alias BB.Math.{Vec3, Quaternion}
 
       {:ok, msg} = Imu.new(:imu_link,
         orientation: Quaternion.identity(),
@@ -26,10 +37,18 @@ defmodule BB.Message.Sensor.Imu do
 
   import BB.Message.Option
 
+  alias BB.Math.Covariance3
   alias BB.Math.Quaternion
   alias BB.Math.Vec3
 
-  defstruct [:orientation, :angular_velocity, :linear_acceleration]
+  defstruct [
+    :orientation,
+    :angular_velocity,
+    :linear_acceleration,
+    :orientation_covariance,
+    :angular_velocity_covariance,
+    :linear_acceleration_covariance
+  ]
 
   use BB.Message,
     schema: [
@@ -39,12 +58,33 @@ defmodule BB.Message.Sensor.Imu do
         type: vec3_type(),
         required: true,
         doc: "Linear acceleration in m/s²"
+      ],
+      orientation_covariance: [
+        type: {:or, [covariance3_type(), nil]},
+        required: false,
+        default: nil,
+        doc: "3x3 covariance over orientation, or nil if unknown"
+      ],
+      angular_velocity_covariance: [
+        type: {:or, [covariance3_type(), nil]},
+        required: false,
+        default: nil,
+        doc: "3x3 covariance over angular velocity, or nil if unknown"
+      ],
+      linear_acceleration_covariance: [
+        type: {:or, [covariance3_type(), nil]},
+        required: false,
+        default: nil,
+        doc: "3x3 covariance over linear acceleration, or nil if unknown"
       ]
     ]
 
   @type t :: %__MODULE__{
           orientation: Quaternion.t(),
           angular_velocity: Vec3.t(),
-          linear_acceleration: Vec3.t()
+          linear_acceleration: Vec3.t(),
+          orientation_covariance: nil | Covariance3.t(),
+          angular_velocity_covariance: nil | Covariance3.t(),
+          linear_acceleration_covariance: nil | Covariance3.t()
         }
 end

--- a/test/bb/error/estimator_test.exs
+++ b/test/bb/error/estimator_test.exs
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.EstimatorTest do
+  use ExUnit.Case, async: true
+
+  alias BB.Error.Estimator.MissingCovariance
+  alias BB.Error.Estimator.StaleInput
+  alias BB.Error.Estimator.SyncMiss
+
+  describe "StaleInput" do
+    test "carries input_path, age_ms, budget_ms" do
+      err = StaleInput.exception(input_path: [:sensor, :imu], age_ms: 42, budget_ms: 20)
+      assert err.input_path == [:sensor, :imu]
+      assert err.age_ms == 42
+      assert err.budget_ms == 20
+    end
+
+    test "is a warning" do
+      err = StaleInput.exception(input_path: [], age_ms: 1, budget_ms: 0)
+      assert BB.Error.severity(err) == :warning
+    end
+
+    test "message includes path and ages" do
+      err = StaleInput.exception(input_path: [:sensor, :imu], age_ms: 42, budget_ms: 20)
+      message = StaleInput.message(err)
+      assert message =~ "[:sensor, :imu]"
+      assert message =~ "42"
+      assert message =~ "20"
+    end
+  end
+
+  describe "SyncMiss" do
+    test "carries gap and tolerance" do
+      err =
+        SyncMiss.exception(
+          driver_path: [:sensor, :imu],
+          input_path: [:sensor, :odom],
+          gap_ms: 150,
+          tolerance_ms: 50
+        )
+
+      assert err.gap_ms == 150
+      assert err.tolerance_ms == 50
+    end
+
+    test "is a warning" do
+      err =
+        SyncMiss.exception(driver_path: [], input_path: [], gap_ms: 0, tolerance_ms: 0)
+
+      assert BB.Error.severity(err) == :warning
+    end
+  end
+
+  describe "MissingCovariance" do
+    test "carries estimator and field" do
+      err = MissingCovariance.exception(estimator: :pose, field: :orientation_covariance)
+      assert err.estimator == :pose
+      assert err.field == :orientation_covariance
+    end
+
+    test "is an error" do
+      err = MissingCovariance.exception(estimator: :pose, field: :orientation_covariance)
+      assert BB.Error.severity(err) == :error
+    end
+  end
+end

--- a/test/bb/math/covariance3_test.exs
+++ b/test/bb/math/covariance3_test.exs
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Math.Covariance3Test do
+  use ExUnit.Case, async: true
+  doctest BB.Math.Covariance3
+
+  alias BB.Math.Covariance3
+
+  describe "new/1" do
+    test "wraps a {3, 3} tensor" do
+      tensor = Nx.tensor([[1.0, 0.0, 0.0], [0.0, 2.0, 0.0], [0.0, 0.0, 3.0]])
+      cov = Covariance3.new(tensor)
+      assert Covariance3.get(cov, 1, 1) == 2.0
+    end
+
+    test "rejects non-3x3 tensors" do
+      assert_raise ArgumentError, ~r/expected a \{3, 3\} tensor/, fn ->
+        Covariance3.new(Nx.tensor([[1.0]]))
+      end
+    end
+  end
+
+  describe "zero/0" do
+    test "returns a 3x3 zero matrix" do
+      cov = Covariance3.zero()
+
+      for i <- 0..2, j <- 0..2 do
+        assert Covariance3.get(cov, i, j) == 0.0
+      end
+    end
+  end
+
+  describe "identity/0" do
+    test "is 1 on the diagonal, 0 off-diagonal" do
+      cov = Covariance3.identity()
+      assert Covariance3.get(cov, 0, 0) == 1.0
+      assert Covariance3.get(cov, 1, 1) == 1.0
+      assert Covariance3.get(cov, 2, 2) == 1.0
+      assert Covariance3.get(cov, 0, 1) == 0.0
+      assert Covariance3.get(cov, 2, 0) == 0.0
+    end
+  end
+
+  describe "diagonal/1" do
+    test "from a list of three numbers" do
+      cov = Covariance3.diagonal([0.1, 0.2, 0.3])
+
+      assert Covariance3.get(cov, 0, 0) == 0.1
+      assert Covariance3.get(cov, 1, 1) == 0.2
+      assert Covariance3.get(cov, 2, 2) == 0.3
+      assert Covariance3.get(cov, 0, 1) == 0.0
+    end
+
+    test "from a {3} tensor" do
+      cov = Covariance3.diagonal(Nx.tensor([0.5, 1.5, 2.5], type: :f64))
+      assert Covariance3.get(cov, 1, 1) == 1.5
+    end
+
+    test "rejects non-three lists" do
+      assert_raise ArgumentError, fn -> Covariance3.diagonal([1.0]) end
+      assert_raise ArgumentError, fn -> Covariance3.diagonal([1.0, 2.0]) end
+      assert_raise ArgumentError, fn -> Covariance3.diagonal([1.0, 2.0, 3.0, 4.0]) end
+    end
+  end
+
+  describe "to_tensor/1" do
+    test "round-trips through new/1" do
+      original = Nx.tensor([[1.0, 0.5, 0.0], [0.5, 2.0, 0.0], [0.0, 0.0, 3.0]])
+      cov = Covariance3.new(original)
+      assert Nx.to_flat_list(Covariance3.to_tensor(cov)) == Nx.to_flat_list(original)
+    end
+  end
+end

--- a/test/bb/math/covariance6_test.exs
+++ b/test/bb/math/covariance6_test.exs
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Math.Covariance6Test do
+  use ExUnit.Case, async: true
+  doctest BB.Math.Covariance6
+
+  alias BB.Math.Covariance6
+
+  describe "new/1" do
+    test "wraps a {6, 6} tensor" do
+      tensor = Nx.broadcast(Nx.tensor(0.0, type: :f64), {6, 6})
+      cov = Covariance6.new(tensor)
+      assert Covariance6.get(cov, 0, 0) == 0.0
+    end
+
+    test "rejects non-6x6 tensors" do
+      assert_raise ArgumentError, ~r/expected a \{6, 6\} tensor/, fn ->
+        Covariance6.new(Nx.tensor([[1.0]]))
+      end
+    end
+  end
+
+  describe "identity/0" do
+    test "is 1 on diagonal, 0 off-diagonal" do
+      cov = Covariance6.identity()
+
+      for i <- 0..5 do
+        assert Covariance6.get(cov, i, i) == 1.0
+      end
+
+      assert Covariance6.get(cov, 0, 5) == 0.0
+      assert Covariance6.get(cov, 5, 0) == 0.0
+    end
+  end
+
+  describe "diagonal/1" do
+    test "from a list of six numbers" do
+      cov = Covariance6.diagonal([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+
+      assert Covariance6.get(cov, 0, 0) == 1.0
+      assert Covariance6.get(cov, 5, 5) == 6.0
+      assert Covariance6.get(cov, 0, 5) == 0.0
+    end
+
+    test "from a {6} tensor" do
+      cov = Covariance6.diagonal(Nx.tensor([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], type: :f64))
+      assert Covariance6.get(cov, 3, 3) == 0.4
+    end
+
+    test "rejects non-six lists" do
+      assert_raise ArgumentError, fn -> Covariance6.diagonal([1.0, 2.0]) end
+    end
+  end
+end

--- a/test/bb/message/estimator/odometry_test.exs
+++ b/test/bb/message/estimator/odometry_test.exs
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Estimator.OdometryTest do
+  use ExUnit.Case, async: true
+
+  alias BB.Math.Covariance6
+  alias BB.Math.Transform
+  alias BB.Math.Vec3
+  alias BB.Message.Estimator.Odometry
+  alias BB.Message.Geometry.Twist
+
+  describe "new/2" do
+    test "constructs with pose, twist, and both covariances" do
+      twist = %Twist{linear: Vec3.zero(), angular: Vec3.zero()}
+
+      {:ok, msg} =
+        Odometry.new(:base_link,
+          pose: Transform.identity(),
+          twist: twist,
+          pose_covariance: Covariance6.identity(),
+          twist_covariance: Covariance6.identity()
+        )
+
+      assert %Odometry{} = msg.payload
+      assert %Transform{} = msg.payload.pose
+      assert %Twist{} = msg.payload.twist
+    end
+
+    test "covariances default to nil" do
+      twist = %Twist{linear: Vec3.zero(), angular: Vec3.zero()}
+
+      {:ok, msg} =
+        Odometry.new(:base_link, pose: Transform.identity(), twist: twist)
+
+      assert msg.payload.pose_covariance == nil
+      assert msg.payload.twist_covariance == nil
+    end
+  end
+end

--- a/test/bb/message/estimator/pose_test.exs
+++ b/test/bb/message/estimator/pose_test.exs
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Estimator.PoseTest do
+  use ExUnit.Case, async: true
+
+  alias BB.Math.Covariance6
+  alias BB.Math.Transform
+  alias BB.Message.Estimator.Pose
+
+  describe "new/2" do
+    test "constructs without covariance" do
+      {:ok, msg} = Pose.new(:base_link, transform: Transform.identity())
+
+      assert msg.frame_id == :base_link
+      assert %Pose{} = msg.payload
+      assert msg.payload.covariance == nil
+    end
+
+    test "constructs with a covariance" do
+      cov = Covariance6.identity()
+      {:ok, msg} = Pose.new(:base_link, transform: Transform.identity(), covariance: cov)
+
+      assert %Covariance6{} = msg.payload.covariance
+    end
+
+    test "rejects a non-Transform" do
+      assert {:error, _} = Pose.new(:base_link, transform: :not_a_transform)
+    end
+
+    test "rejects a non-Covariance6 covariance" do
+      assert {:error, _} =
+               Pose.new(:base_link, transform: Transform.identity(), covariance: :not_a_cov)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Phase 3 of [proposal 0018](https://github.com/beam-bots/proposals/blob/main/accepted/0018-bb-estimator.md). Purely additive: extends `BB.Math`, `BB.Message`, and `BB.Error` with the pieces estimators need to express uncertainty.

**Does not depend on Phase 1** ([#115](https://github.com/beam-bots/bb/pull/115)). Can land in either order. They merge cleanly together.

### What's in this PR

- **`BB.Math.Covariance3`** (3x3, Nx-backed) and **`BB.Math.Covariance6`** (6x6). Mirror the typed-tensor-wrapper pattern of `BB.Math.Vec3` / `Quaternion` / `Transform`. Each provides `new/1`, `zero/0`, `identity/0`, `diagonal/1`, `from_tensor/1`, `to_tensor/1`, `get/3`. No invariant enforcement at construction (zero matrices are legitimate \"unknown variance\" placeholders).
- **Message schema helpers**: `BB.Message.Option.covariance3_type/0` and `covariance6_type/0` plus their validators, so payload schemas can declare typed covariance fields.
- **Payloads**:
  - `BB.Message.Sensor.Imu` gains three optional, nil-defaulting covariance fields. **Backwards-compatible** — all existing constructors and consumers keep working.
  - `BB.Message.Estimator.Pose`: transform + optional `Covariance6`. The canonical fused-pose payload, distinguishable from `BB.Message.Geometry.Pose` (which remains the raw geometric payload without uncertainty).
  - `BB.Message.Estimator.Odometry`: pose + twist with separate optional covariances. Mirrors ROS `nav_msgs/Odometry`.
- **Error types** (all implement `BB.Error.Severity`):
  - `BB.Error.Estimator.StaleInput` (warning)
  - `BB.Error.Estimator.SyncMiss` (warning)
  - `BB.Error.Estimator.MissingCovariance` (error)

### Tests

New tests under `test/bb/math/covariance{3,6}_test.exs`, `test/bb/message/estimator/{pose,odometry}_test.exs`, `test/bb/error/estimator_test.exs`. Full suite (1028 tests + 31 doctests) passes; `mix check --no-retry` green.

## Test plan

- [x] `mix test`
- [x] `mix check --no-retry`

Refs [proposals#21](https://github.com/beam-bots/proposals/pull/21).