### PR TITLE
improvement: application-env robot config via `set_robot_param_default/4`

### DIFF
--- a/lib/bb/igniter.ex
+++ b/lib/bb/igniter.ex
@@ -96,18 +96,59 @@ if Code.ensure_loaded?(Igniter) do
     end
 
     @doc """
-    Ensures the robot's child spec in the application module carries the given
-    opts.
+    Sets a default for a robot parameter in the application config and wires the
+    robot's child spec to load its opts from the application environment.
 
-    For new robot children, the opts are inserted directly. For existing
-    children, the existing opts are replaced. This is a coarse operation; if
-    multiple installers need to set different keys, the last one to run wins.
+    `param_path` is the path of the parameter within the robot's `params`, e.g.
+    `[:config, :feetech, :device]`. The default is written to `config/config.exs`
+    as a single leaf under `config <app>, <robot_module>, params: [...]`. Writing
+    a leaf (rather than the whole opts list) lets independent installers each
+    contribute their own defaults without clobbering one another.
+
+    The robot's child spec in the application module is rewritten to
+    `{<robot_module>, Application.get_env(<app>, <robot_module>, [])}`. If the
+    existing child opts are already a non-literal expression — e.g. a
+    `robot_opts()` helper call inserted by a composing installer — they're left
+    untouched so that switch logic is preserved.
     """
-    @spec set_robot_opts(Igniter.t(), module(), keyword()) :: Igniter.t()
-    def set_robot_opts(igniter, robot_module, opts) do
-      Igniter.Project.Application.add_new_child(igniter, {robot_module, opts},
-        opts_updater: fn zipper -> {:ok, Sourceror.Zipper.replace(zipper, opts)} end
+    @spec set_robot_param_default(Igniter.t(), module(), [atom(), ...], term()) :: Igniter.t()
+    def set_robot_param_default(igniter, robot_module, param_path, value)
+        when is_list(param_path) and param_path != [] do
+      app_name = Igniter.Project.Application.app_name(igniter)
+
+      igniter
+      |> Igniter.Project.Config.configure(
+        "config.exs",
+        app_name,
+        [robot_module, :params | param_path],
+        value
       )
+      |> load_robot_opts_from_env(robot_module, app_name)
+    end
+
+    defp load_robot_opts_from_env(igniter, robot_module, app_name) do
+      env_ast =
+        Sourceror.parse_string!(
+          "Application.get_env(#{inspect(app_name)}, #{inspect(robot_module)}, [])"
+        )
+
+      Igniter.Project.Application.add_new_child(igniter, {robot_module, {:code, env_ast}},
+        opts_updater: fn zipper ->
+          if literal_opts?(zipper) do
+            {:ok, Sourceror.Zipper.replace(zipper, env_ast)}
+          else
+            {:ok, zipper}
+          end
+        end
+      )
+    end
+
+    defp literal_opts?(zipper) do
+      case Sourceror.Zipper.node(zipper) do
+        list when is_list(list) -> true
+        {:__block__, _, [list]} when is_list(list) -> true
+        _ -> false
+      end
     end
 
     @doc """

--- a/lib/bb/igniter.ex
+++ b/lib/bb/igniter.ex
@@ -12,6 +12,7 @@ if Code.ensure_loaded?(Igniter) do
 
     alias Igniter.Code.Common
     alias Igniter.Code.Function
+    alias Igniter.Project.Config
 
     @doc """
     Returns the robot module to operate on.
@@ -117,7 +118,7 @@ if Code.ensure_loaded?(Igniter) do
       app_name = Igniter.Project.Application.app_name(igniter)
 
       igniter
-      |> Igniter.Project.Config.configure(
+      |> Config.configure(
         "config.exs",
         app_name,
         [robot_module, :params | param_path],

--- a/test/bb/igniter_test.exs
+++ b/test/bb/igniter_test.exs
@@ -104,20 +104,47 @@ defmodule BB.IgniterTest do
     end
   end
 
-  describe "set_robot_opts/3" do
-    test "sets opts on the robot's child spec in the application module" do
+  describe "set_robot_param_default/4" do
+    test "writes the default as a config leaf under the robot module" do
       project_with_robot()
-      |> BB.Igniter.set_robot_opts(Test.Robot, params: [config: [widget: [speed: 100]]])
+      |> BB.Igniter.set_robot_param_default(Test.Robot, [:config, :widget, :speed], 100)
+      |> assert_creates("config/config.exs", """
+      import Config
+      config :test, Test.Robot, params: [config: [widget: [speed: 100]]]
+      """)
+    end
+
+    test "rewrites the robot child spec to read from the application env" do
+      project_with_robot()
+      |> BB.Igniter.set_robot_param_default(Test.Robot, [:config, :widget, :speed], 100)
       |> assert_has_patch("lib/test/application.ex", ~s'''
-      + |    children = [{Test.Robot, [params: [config: [widget: [speed: 100]]]]}]
+      + |    children = [{Test.Robot, Application.get_env(:test, Test.Robot, [])}]
       ''')
     end
 
-    test "replaces existing opts on subsequent calls" do
+    test "leaves independent defaults from separate calls side by side" do
       project_with_robot()
-      |> BB.Igniter.set_robot_opts(Test.Robot, params: [config: [widget: [speed: 100]]])
+      |> BB.Igniter.set_robot_param_default(Test.Robot, [:config, :widget, :speed], 100)
       |> apply_igniter!()
-      |> BB.Igniter.set_robot_opts(Test.Robot, params: [config: [widget: [speed: 100]]])
+      |> BB.Igniter.set_robot_param_default(Test.Robot, [:config, :gadget, :size], 5)
+      |> assert_has_patch("config/config.exs", """
+      + |config :test, Test.Robot, params: [config: [widget: [speed: 100], gadget: [size: 5]]]
+      """)
+    end
+
+    test "does not clobber non-literal child opts (e.g. a robot_opts/0 call)" do
+      project_with_robot()
+      |> set_child_opts_to_call()
+      |> apply_igniter!()
+      |> BB.Igniter.set_robot_param_default(Test.Robot, [:config, :widget, :speed], 100)
+      |> assert_unchanged("lib/test/application.ex")
+    end
+
+    test "is idempotent" do
+      project_with_robot()
+      |> BB.Igniter.set_robot_param_default(Test.Robot, [:config, :widget, :speed], 100)
+      |> apply_igniter!()
+      |> BB.Igniter.set_robot_param_default(Test.Robot, [:config, :widget, :speed], 100)
       |> assert_unchanged()
     end
   end
@@ -183,5 +210,13 @@ defmodule BB.IgniterTest do
 
   defp put_options(igniter, options) do
     %{igniter | args: %{igniter.args | options: options}}
+  end
+
+  defp set_child_opts_to_call(igniter) do
+    Igniter.Project.Application.add_new_child(igniter, {Test.Robot, []},
+      opts_updater: fn zipper ->
+        {:ok, Sourceror.Zipper.replace(zipper, Sourceror.parse_string!("robot_opts()"))}
+      end
+    )
   end
 end


### PR DESCRIPTION
## What

Replaces `BB.Igniter.set_robot_opts/3` with `set_robot_param_default/4`.

The old helper replaced the *entire* opts node on the robot's child spec, so its own docstring admitted "last one to run wins" — installing two add-ons (e.g. both sensors) silently dropped one's config.

`set_robot_param_default/4` instead:

- Writes a single config **leaf** to `config/config.exs` — `config :app, Robot, params: [config: [<group>: [<key>: val]]]` — so independent installers merge per-key rather than overwriting.
- Rewrites the robot child spec in `application.ex` to `{Robot, Application.get_env(:app, Robot, [])}`, loading the config at application start.
- Only rewrites a **literal** opts list, leaving an existing `robot_opts()` call (or `Application.get_env`) untouched — so installing a sensor onto an `bb_so101` project doesn't clobber its `SIMULATE` switch.

## Breaking change

`BB.Igniter.set_robot_opts/3` is **removed**. Nothing in the beam-bots ecosystem references it any more; the add-on installers move to `set_robot_param_default/4` in their own PRs. Any external installer using it will need to migrate.

## Tests

`mix test --include igniter` — 18 tests, 0 failures. Includes a merge test proving two installers' defaults coexist, and a non-clobber test for `robot_opts()`.

## Related

Consumed by the matching PRs in `bb_servo_feetech`, `bb_sensor_bmi323`, `bb_sensor_ina219`, and `bb_so101`. Those depend on this helper, so this should merge (and release) first.