### PR TITLE
fix: apply `options_schema` defaults at runtime, enforce component behaviour at compile time

### DIFF
--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -227,7 +227,6 @@ defmodule BB.Actuator do
   @callback options_schema() :: Spark.Options.t()
 
   @optional_callbacks [
-    options_schema: 0,
     handle_options: 2,
     handle_call: 3,
     handle_cast: 2,
@@ -235,6 +234,8 @@ defmodule BB.Actuator do
     handle_continue: 2,
     terminate: 2
   ]
+
+  alias BB.Component.OptionsSchema
 
   @doc false
   defmacro __using__(opts) do
@@ -269,18 +270,7 @@ defmodule BB.Actuator do
                      handle_continue: 2,
                      terminate: 2
 
-      unquote(
-        if schema_opts do
-          quote do
-            @__bb_options_schema Spark.Options.new!(unquote(schema_opts))
-
-            @impl BB.Actuator
-            def options_schema, do: @__bb_options_schema
-
-            defoverridable options_schema: 0
-          end
-        end
-      )
+      unquote(OptionsSchema.inject(BB.Actuator, schema_opts))
     end
   end
 

--- a/lib/bb/actuator/server.ex
+++ b/lib/bb/actuator/server.ex
@@ -19,12 +19,15 @@ defmodule BB.Actuator.Server do
   use GenServer
 
   alias BB.Actuator.MotorProfile
+  alias BB.Component.OptionsSchema
   alias BB.Message
   alias BB.Parameter.Changed, as: ParameterChanged
   alias BB.Robot
   alias BB.Server.ParamResolution
   alias BB.Transmission
   alias BB.Transmission.Resolver, as: TransmissionResolver
+
+  @framework_keys [:bb, :motor_profile]
 
   defstruct [
     :callback_module,
@@ -86,31 +89,37 @@ defmodule BB.Actuator.Server do
     motor_profile = MotorProfile.from_joint(joint, transmission)
     resolved_opts = Keyword.put(resolved_opts, :motor_profile, motor_profile)
 
-    base = %__MODULE__{
-      callback_module: callback_module,
-      resolved_opts: resolved_opts,
-      raw_opts: raw_opts,
-      param_subscriptions: param_subscriptions,
-      transmission: transmission,
-      transmission_subscriptions: transmission_subscriptions,
-      joint: joint,
-      joint_name: joint_name,
-      actuator_name: actuator_name,
-      bb: bb
-    }
+    case OptionsSchema.validate(callback_module, resolved_opts, @framework_keys) do
+      {:error, error} ->
+        {:stop, error}
 
-    case callback_module.init(resolved_opts) do
-      {:ok, user_state} ->
-        {:ok, %{base | user_state: user_state}}
+      {:ok, resolved_opts} ->
+        base = %__MODULE__{
+          callback_module: callback_module,
+          resolved_opts: resolved_opts,
+          raw_opts: raw_opts,
+          param_subscriptions: param_subscriptions,
+          transmission: transmission,
+          transmission_subscriptions: transmission_subscriptions,
+          joint: joint,
+          joint_name: joint_name,
+          actuator_name: actuator_name,
+          bb: bb
+        }
 
-      {:ok, user_state, timeout_or_continue} ->
-        {:ok, %{base | user_state: user_state}, timeout_or_continue}
+        case callback_module.init(resolved_opts) do
+          {:ok, user_state} ->
+            {:ok, %{base | user_state: user_state}}
 
-      {:stop, reason} ->
-        {:stop, reason}
+          {:ok, user_state, timeout_or_continue} ->
+            {:ok, %{base | user_state: user_state}, timeout_or_continue}
 
-      :ignore ->
-        :ignore
+          {:stop, reason} ->
+            {:stop, reason}
+
+          :ignore ->
+            :ignore
+        end
     end
   end
 
@@ -164,12 +173,14 @@ defmodule BB.Actuator.Server do
           MotorProfile.from_joint(state.joint, state.transmission)
         )
 
-      case state.callback_module.handle_options(new_resolved, state.user_state) do
-        {:ok, new_user_state} ->
-          {:noreply, %{state | resolved_opts: new_resolved, user_state: new_user_state}}
-
-        {:stop, reason} ->
-          {:stop, reason, state}
+      with {:ok, new_resolved} <-
+             OptionsSchema.validate(state.callback_module, new_resolved, @framework_keys),
+           {:ok, new_user_state} <-
+             state.callback_module.handle_options(new_resolved, state.user_state) do
+        {:noreply, %{state | resolved_opts: new_resolved, user_state: new_user_state}}
+      else
+        {:stop, reason} -> {:stop, reason, state}
+        {:error, error} -> {:stop, error, state}
       end
     else
       {:noreply, state}

--- a/lib/bb/bridge.ex
+++ b/lib/bb/bridge.ex
@@ -242,12 +242,13 @@ defmodule BB.Bridge do
   @callback subscribe_remote(param_id, state) :: {:ok, state} | {:error, term(), state}
 
   @optional_callbacks [
-    options_schema: 0,
     list_remote: 1,
     get_remote: 2,
     set_remote: 3,
     subscribe_remote: 2
   ]
+
+  alias BB.Component.OptionsSchema
 
   @doc false
   defmacro __using__(opts) do
@@ -257,18 +258,7 @@ defmodule BB.Bridge do
       use GenServer
       @behaviour BB.Bridge
 
-      unquote(
-        if schema_opts do
-          quote do
-            @__bb_options_schema Spark.Options.new!(unquote(schema_opts))
-
-            @impl BB.Bridge
-            def options_schema, do: @__bb_options_schema
-
-            defoverridable options_schema: 0
-          end
-        end
-      )
+      unquote(OptionsSchema.inject(BB.Bridge, schema_opts))
     end
   end
 end

--- a/lib/bb/command.ex
+++ b/lib/bb/command.ex
@@ -227,9 +227,7 @@ defmodule BB.Command do
   Optional. If defined, options passed to the command handler will be
   validated against this schema.
   """
-  @callback options_schema() :: Spark.Options.schema()
-
-  @optional_callbacks [options_schema: 0]
+  @callback options_schema() :: Spark.Options.t()
 
   @doc """
   Await the command result, blocking until completion or timeout.
@@ -363,6 +361,8 @@ defmodule BB.Command do
     )
   end
 
+  alias BB.Component.OptionsSchema
+
   @doc false
   defmacro __using__(opts) do
     schema_opts = opts[:options_schema]
@@ -415,16 +415,7 @@ defmodule BB.Command do
                      handle_continue: 2,
                      terminate: 2
 
-      unquote(
-        if schema_opts do
-          quote do
-            @__bb_options_schema unquote(schema_opts)
-            @impl BB.Command
-            def options_schema, do: @__bb_options_schema
-            defoverridable options_schema: 0
-          end
-        end
-      )
+      unquote(OptionsSchema.inject(BB.Command, schema_opts))
     end
   end
 end

--- a/lib/bb/command/server.ex
+++ b/lib/bb/command/server.ex
@@ -20,6 +20,7 @@ defmodule BB.Command.Server do
 
   alias BB.Command.Context
   alias BB.Command.ResultCache
+  alias BB.Component.OptionsSchema
   alias BB.Error.State.CommandCrashed
   alias BB.Parameter.Changed, as: ParameterChanged
   alias BB.PubSub
@@ -84,34 +85,39 @@ defmodule BB.Command.Server do
         Process.send_after(self(), :command_timeout, timeout)
       end
 
-    # Build opts for user's init callback
-    user_opts =
-      Keyword.merge(resolved_opts,
-        bb: %{robot: context.robot_module},
-        goal: goal,
-        context: context
-      )
+    case OptionsSchema.validate(callback_module, resolved_opts, []) do
+      {:error, error} ->
+        {:stop, error}
 
-    case wrap_callback(nil, callback_module, :init, [user_opts]) do
-      {:ok, user_state} ->
-        state = %__MODULE__{
-          callback_module: callback_module,
-          context: context,
-          goal: goal,
-          execution_id: execution_id,
-          runtime_pid: runtime_pid,
-          timeout_ref: timeout_ref,
-          resolved_opts: resolved_opts,
-          raw_opts: raw_opts,
-          param_subscriptions: param_subscriptions,
-          awaiting: [],
-          user_state: user_state
-        }
+      {:ok, resolved_opts} ->
+        user_opts =
+          Keyword.merge(resolved_opts,
+            bb: %{robot: context.robot_module},
+            goal: goal,
+            context: context
+          )
 
-        {:ok, state, {:continue, :execute}}
+        case wrap_callback(nil, callback_module, :init, [user_opts]) do
+          {:ok, user_state} ->
+            state = %__MODULE__{
+              callback_module: callback_module,
+              context: context,
+              goal: goal,
+              execution_id: execution_id,
+              runtime_pid: runtime_pid,
+              timeout_ref: timeout_ref,
+              resolved_opts: resolved_opts,
+              raw_opts: raw_opts,
+              param_subscriptions: param_subscriptions,
+              awaiting: [],
+              user_state: user_state
+            }
 
-      {:stop, reason} ->
-        {:stop, reason}
+            {:ok, state, {:continue, :execute}}
+
+          {:stop, reason} ->
+            {:stop, reason}
+        end
     end
   end
 
@@ -218,15 +224,17 @@ defmodule BB.Command.Server do
            state.context.robot_state
          ) do
       {:changed, new_resolved} ->
-        case wrap_callback(state, state.callback_module, :handle_options, [
-               new_resolved,
-               state.user_state
-             ]) do
-          {:ok, new_user_state} ->
-            {:noreply, %{state | resolved_opts: new_resolved, user_state: new_user_state}}
-
-          {:stop, reason} ->
-            {:stop, reason, state}
+        with {:ok, new_resolved} <-
+               OptionsSchema.validate(state.callback_module, new_resolved, []),
+             {:ok, new_user_state} <-
+               wrap_callback(state, state.callback_module, :handle_options, [
+                 new_resolved,
+                 state.user_state
+               ]) do
+          {:noreply, %{state | resolved_opts: new_resolved, user_state: new_user_state}}
+        else
+          {:stop, reason} -> {:stop, reason, state}
+          {:error, error} -> {:stop, error, state}
         end
 
       :ignored ->

--- a/lib/bb/component/options_schema.ex
+++ b/lib/bb/component/options_schema.ex
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Component.OptionsSchema do
+  @moduledoc false
+
+  # Shared `options_schema/0` machinery for the component behaviours
+  # (`BB.Sensor`, `BB.Actuator`, `BB.Controller`, `BB.Estimator`,
+  # `BB.Bridge`, `BB.Command`).
+  #
+  # A component declares its schema one of two ways:
+  #
+  #   * `use BB.Sensor, options_schema: [...]` — the keyword form, for
+  #     self-contained literal schemas.
+  #   * `def options_schema, do: ...` — the callback form, for schemas that
+  #     reference module attributes, helpers, or `~u` sigils (which aren't in
+  #     scope where `use` expands).
+  #
+  # Providing both is a compile error. Providing neither yields an empty
+  # schema, so `options_schema/0` is always defined and callers never need to
+  # guard with `function_exported?/3`.
+
+  @doc """
+  Validate the user-facing options against `module.options_schema/0`,
+  applying schema defaults, and merge the framework-injected keys back in.
+
+  `framework_keys` are the keys a component server injects (e.g. `:bb`,
+  `:sensor_profile`) which are not part of the user schema; they are split
+  off before validation and merged back onto the validated result.
+
+  Assumes `module` implements the relevant component behaviour, so
+  `options_schema/0` is defined (the `use BB.X` macros guarantee it).
+  Behaviour conformance itself is enforced at compile time by
+  `BB.Dsl.Verifiers.ValidateChildSpecs`.
+  """
+  @spec validate(module(), keyword(), [atom()]) ::
+          {:ok, keyword()} | {:error, Spark.Options.ValidationError.t()}
+  def validate(module, resolved_opts, framework_keys) do
+    {framework_opts, user_opts} = Keyword.split(resolved_opts, framework_keys)
+
+    case Spark.Options.validate(user_opts, module.options_schema()) do
+      {:ok, validated} -> {:ok, Keyword.merge(framework_opts, validated)}
+      {:error, _} = error -> error
+    end
+  end
+
+  @doc false
+  def inject(behaviour, schema_opts) do
+    given? = not is_nil(schema_opts)
+
+    schema_ast =
+      if given? do
+        quote do: Spark.Options.new!(unquote(schema_opts))
+      end
+
+    quote do
+      @__bb_options_schema_behaviour unquote(behaviour)
+      @__bb_options_schema_given unquote(given?)
+      @__bb_options_schema unquote(schema_ast)
+      @before_compile BB.Component.OptionsSchema
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(env) do
+    behaviour = Module.get_attribute(env.module, :__bb_options_schema_behaviour)
+    given? = Module.get_attribute(env.module, :__bb_options_schema_given)
+    user_defined? = Module.defines?(env.module, {:options_schema, 0})
+
+    cond do
+      given? and user_defined? ->
+        raise CompileError,
+          file: env.file,
+          line: env.line,
+          description:
+            "#{inspect(env.module)} passes `options_schema:` to " <>
+              "`use #{inspect(behaviour)}` and also defines `options_schema/0`. " <>
+              "Declare the schema one way, not both."
+
+      given? ->
+        quote do
+          @impl unquote(behaviour)
+          def options_schema, do: @__bb_options_schema
+        end
+
+      user_defined? ->
+        []
+
+      true ->
+        quote do
+          @impl unquote(behaviour)
+          def options_schema, do: Spark.Options.new!([])
+        end
+    end
+  end
+end

--- a/lib/bb/controller.ex
+++ b/lib/bb/controller.ex
@@ -192,7 +192,6 @@ defmodule BB.Controller do
   @callback options_schema() :: Spark.Options.t()
 
   @optional_callbacks [
-    options_schema: 0,
     disarm: 1,
     handle_options: 2,
     handle_call: 3,
@@ -201,6 +200,8 @@ defmodule BB.Controller do
     handle_continue: 2,
     terminate: 2
   ]
+
+  alias BB.Component.OptionsSchema
 
   @doc false
   defmacro __using__(opts) do
@@ -235,18 +236,7 @@ defmodule BB.Controller do
                      handle_continue: 2,
                      terminate: 2
 
-      unquote(
-        if schema_opts do
-          quote do
-            @__bb_options_schema Spark.Options.new!(unquote(schema_opts))
-
-            @impl BB.Controller
-            def options_schema, do: @__bb_options_schema
-
-            defoverridable options_schema: 0
-          end
-        end
-      )
+      unquote(OptionsSchema.inject(BB.Controller, schema_opts))
     end
   end
 end

--- a/lib/bb/controller/server.ex
+++ b/lib/bb/controller/server.ex
@@ -18,8 +18,11 @@ defmodule BB.Controller.Server do
 
   use GenServer
 
+  alias BB.Component.OptionsSchema
   alias BB.Parameter.Changed, as: ParameterChanged
   alias BB.Server.ParamResolution
+
+  @framework_keys [:bb]
 
   defstruct [
     :callback_module,
@@ -58,34 +61,32 @@ defmodule BB.Controller.Server do
     {param_subscriptions, resolved_opts} =
       ParamResolution.resolve_and_subscribe(raw_opts, bb.robot)
 
-    case callback_module.init(resolved_opts) do
-      {:ok, user_state} ->
-        {:ok,
-         %__MODULE__{
-           callback_module: callback_module,
-           resolved_opts: resolved_opts,
-           raw_opts: raw_opts,
-           param_subscriptions: param_subscriptions,
-           bb: bb,
-           user_state: user_state
-         }}
+    case OptionsSchema.validate(callback_module, resolved_opts, @framework_keys) do
+      {:error, error} ->
+        {:stop, error}
 
-      {:ok, user_state, timeout_or_continue} ->
-        {:ok,
-         %__MODULE__{
-           callback_module: callback_module,
-           resolved_opts: resolved_opts,
-           raw_opts: raw_opts,
-           param_subscriptions: param_subscriptions,
-           bb: bb,
-           user_state: user_state
-         }, timeout_or_continue}
+      {:ok, resolved_opts} ->
+        base = %__MODULE__{
+          callback_module: callback_module,
+          resolved_opts: resolved_opts,
+          raw_opts: raw_opts,
+          param_subscriptions: param_subscriptions,
+          bb: bb
+        }
 
-      {:stop, reason} ->
-        {:stop, reason}
+        case callback_module.init(resolved_opts) do
+          {:ok, user_state} ->
+            {:ok, %{base | user_state: user_state}}
 
-      :ignore ->
-        :ignore
+          {:ok, user_state, timeout_or_continue} ->
+            {:ok, %{base | user_state: user_state}, timeout_or_continue}
+
+          {:stop, reason} ->
+            {:stop, reason}
+
+          :ignore ->
+            :ignore
+        end
     end
   end
 
@@ -98,12 +99,14 @@ defmodule BB.Controller.Server do
            state.bb.robot
          ) do
       {:changed, new_resolved} ->
-        case state.callback_module.handle_options(new_resolved, state.user_state) do
-          {:ok, new_user_state} ->
-            {:noreply, %{state | resolved_opts: new_resolved, user_state: new_user_state}}
-
-          {:stop, reason} ->
-            {:stop, reason, state}
+        with {:ok, new_resolved} <-
+               OptionsSchema.validate(state.callback_module, new_resolved, @framework_keys),
+             {:ok, new_user_state} <-
+               state.callback_module.handle_options(new_resolved, state.user_state) do
+          {:noreply, %{state | resolved_opts: new_resolved, user_state: new_user_state}}
+        else
+          {:stop, reason} -> {:stop, reason, state}
+          {:error, error} -> {:stop, error, state}
         end
 
       :ignored ->

--- a/lib/bb/dsl.ex
+++ b/lib/bb/dsl.ex
@@ -1255,6 +1255,7 @@ defmodule BB.Dsl do
       __MODULE__.ValidateLimitUnitsTransformer,
       __MODULE__.SupervisorTransformer,
       __MODULE__.UniquenessTransformer,
+      __MODULE__.ValidateChildSpecBehavioursTransformer,
       __MODULE__.RobotTransformer,
       __MODULE__.CommandTransformer,
       __MODULE__.ParameterTransformer,

--- a/lib/bb/dsl/validate_child_spec_behaviours_transformer.ex
+++ b/lib/bb/dsl/validate_child_spec_behaviours_transformer.ex
@@ -148,7 +148,15 @@ defmodule BB.Dsl.ValidateChildSpecBehavioursTransformer do
   defp check_one(child_spec, path, robot_module, behaviour) do
     {module, _opts} = normalize(child_spec)
 
-    case Code.ensure_loaded(module) do
+    # `ensure_compiled` asks Mix to finish compiling the module first when it's
+    # part of the current project, so we don't race with in-tree fixtures that
+    # reference a sensor/actuator defined elsewhere in the same package. If
+    # the module genuinely can't be located, defer to runtime — the component
+    # server will refuse to start a module that doesn't implement the
+    # expected behaviour. Halting compilation here would block legitimate
+    # cross-package CI matrices where the referenced module isn't yet
+    # loadable from the transformer's vantage point.
+    case Code.ensure_compiled(module) do
       {:module, _} ->
         if behaviour in declared_behaviours(module) do
           :ok
@@ -165,13 +173,8 @@ defmodule BB.Dsl.ValidateChildSpecBehavioursTransformer do
            )}
         end
 
-      {:error, reason} ->
-        {:error,
-         DslError.exception(
-           module: robot_module,
-           path: path,
-           message: "Could not load #{inspect(module)}: #{inspect(reason)}"
-         )}
+      {:error, _reason} ->
+        :ok
     end
   end
 

--- a/lib/bb/dsl/validate_child_spec_behaviours_transformer.ex
+++ b/lib/bb/dsl/validate_child_spec_behaviours_transformer.ex
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Dsl.ValidateChildSpecBehavioursTransformer do
+  @moduledoc """
+  Enforces that every module wired into a component slot in the topology DSL
+  implements the matching BB component behaviour.
+
+  Spark's built-in `{:behaviour, X}` schema type only validates that the
+  value is an atom — it does not check behaviour conformance — so a bare
+  `use GenServer` module could otherwise be wired in as e.g. an actuator,
+  passing DSL compilation only to crash at runtime when the server expects
+  callbacks (`options_schema/0`, `init/1`, etc.) that aren't defined.
+
+  This check lives in a transformer (rather than a verifier) so it raises
+  at compile time. Verifiers run in `@after_verify` where Elixir does not
+  tolerate errors, so they can only warn.
+  """
+
+  use Spark.Dsl.Transformer
+
+  alias BB.Dsl.{Actuator, Bridge, Controller, Estimator, Joint, Link, Sensor}
+  alias Spark.Dsl.Transformer
+  alias Spark.Error.DslError
+
+  @impl true
+  def after?(BB.Dsl.DefaultNameTransformer), do: true
+  def after?(BB.Dsl.UniquenessTransformer), do: true
+  def after?(_), do: false
+
+  @impl true
+  def before?(BB.Dsl.RobotTransformer), do: true
+  def before?(_), do: false
+
+  @impl true
+  def transform(dsl) do
+    robot_module = Transformer.get_persisted(dsl, :module)
+
+    with :ok <- check_controllers(dsl, robot_module),
+         :ok <- check_robot_sensors(dsl, robot_module),
+         :ok <- check_bridges(dsl, robot_module),
+         :ok <- check_topology(dsl, robot_module) do
+      {:ok, dsl}
+    end
+  end
+
+  defp check_controllers(dsl, robot_module) do
+    dsl
+    |> Transformer.get_entities([:controllers])
+    |> reduce_check(robot_module, BB.Controller, fn %Controller{name: name} ->
+      [:controllers, name]
+    end)
+  end
+
+  defp check_robot_sensors(dsl, robot_module) do
+    dsl
+    |> Transformer.get_entities([:sensors])
+    |> reduce_check(robot_module, BB.Sensor, fn %Sensor{name: name} ->
+      [:sensors, name]
+    end)
+  end
+
+  defp check_bridges(dsl, robot_module) do
+    dsl
+    |> Transformer.get_entities([:parameters])
+    |> Enum.filter(&is_struct(&1, Bridge))
+    |> reduce_check(robot_module, BB.Bridge, fn %Bridge{name: name} ->
+      [:parameters, name]
+    end)
+  end
+
+  defp check_topology(dsl, robot_module) do
+    dsl
+    |> Transformer.get_entities([:topology])
+    |> reduce_topology([], robot_module)
+  end
+
+  defp reduce_topology(entities, path, robot_module) do
+    Enum.reduce_while(entities, :ok, fn entity, :ok ->
+      entity
+      |> check_topology_entity(path, robot_module)
+      |> to_reduce_acc()
+    end)
+  end
+
+  defp check_topology_entity(%Link{} = link, path, robot_module) do
+    link_path = path ++ [:topology, :link, link.name]
+
+    with :ok <-
+           reduce_check(link.sensors, robot_module, BB.Sensor, fn %Sensor{name: name} ->
+             link_path ++ [:sensor, name]
+           end),
+         :ok <- check_estimators_with_nested(link.sensors, link_path, robot_module),
+         :ok <-
+           reduce_check(link.estimators, robot_module, BB.Estimator, fn %Estimator{name: name} ->
+             link_path ++ [:estimator, name]
+           end) do
+      reduce_topology(link.joints, link_path, robot_module)
+    end
+  end
+
+  defp check_topology_entity(%Joint{} = joint, path, robot_module) do
+    joint_path = path ++ [:joint, joint.name]
+    sensors = Map.get(joint, :sensors, [])
+    actuators = Map.get(joint, :actuators, [])
+
+    with :ok <-
+           reduce_check(sensors, robot_module, BB.Sensor, fn %Sensor{name: name} ->
+             joint_path ++ [:sensor, name]
+           end),
+         :ok <- check_estimators_with_nested(sensors, joint_path, robot_module),
+         :ok <-
+           reduce_check(actuators, robot_module, BB.Actuator, fn %Actuator{name: name} ->
+             joint_path ++ [:actuator, name]
+           end) do
+      case Map.get(joint, :link) do
+        nil -> :ok
+        nested -> check_topology_entity(nested, path, robot_module)
+      end
+    end
+  end
+
+  defp check_topology_entity(_entity, _path, _robot_module), do: :ok
+
+  defp check_estimators_with_nested(sensors, parent_path, robot_module) do
+    Enum.reduce_while(sensors, :ok, fn %Sensor{} = sensor, :ok ->
+      sensor_path = parent_path ++ [:sensor, sensor.name]
+      path_fun = fn %Estimator{name: name} -> sensor_path ++ [:estimator, name] end
+
+      sensor.estimators
+      |> reduce_check(robot_module, BB.Estimator, path_fun)
+      |> to_reduce_acc()
+    end)
+  end
+
+  defp reduce_check(entities, robot_module, behaviour, path_fun) do
+    Enum.reduce_while(entities, :ok, fn entity, :ok ->
+      entity.child_spec
+      |> check_one(path_fun.(entity), robot_module, behaviour)
+      |> to_reduce_acc()
+    end)
+  end
+
+  defp to_reduce_acc(:ok), do: {:cont, :ok}
+  defp to_reduce_acc({:error, _} = error), do: {:halt, error}
+
+  defp check_one(child_spec, path, robot_module, behaviour) do
+    {module, _opts} = normalize(child_spec)
+
+    case Code.ensure_loaded(module) do
+      {:module, _} ->
+        if behaviour in declared_behaviours(module) do
+          :ok
+        else
+          {:error,
+           DslError.exception(
+             module: robot_module,
+             path: path,
+             message: """
+             Module #{inspect(module)} must implement the #{inspect(behaviour)} behaviour.
+
+             Add `use #{inspect(behaviour)}` (or `@behaviour #{inspect(behaviour)}` and the required callbacks) to #{inspect(module)}.
+             """
+           )}
+        end
+
+      {:error, reason} ->
+        {:error,
+         DslError.exception(
+           module: robot_module,
+           path: path,
+           message: "Could not load #{inspect(module)}: #{inspect(reason)}"
+         )}
+    end
+  end
+
+  defp normalize(module) when is_atom(module), do: {module, []}
+  defp normalize({module, opts}) when is_atom(module), do: {module, opts}
+
+  defp declared_behaviours(module) do
+    module.module_info(:attributes)
+    |> Keyword.get_values(:behaviour)
+    |> List.flatten()
+  end
+end

--- a/lib/bb/dsl/verifiers/validate_child_specs.ex
+++ b/lib/bb/dsl/verifiers/validate_child_specs.ex
@@ -4,15 +4,12 @@
 
 defmodule BB.Dsl.Verifiers.ValidateChildSpecs do
   @moduledoc """
-  Validates that child_spec options match the module's schema.
+  Validates that child_spec options match the module's `options_schema/0`.
 
-  Behaviour validation is handled by Spark's schema types (e.g., `{:behaviour, BB.Sensor}`).
-  This verifier handles the additional validation:
-
-  - If options are provided in the DSL (as `{Module, opts}` tuple),
-    the module must define `options_schema/0`
-  - If `options_schema/0` is defined, the provided options are validated
-    against that schema
+  Behaviour conformance is enforced separately (and at hard-error severity)
+  by `BB.Dsl.ValidateChildSpecBehavioursTransformer`; this verifier assumes
+  every wired-in module is already a proper component and so always has
+  `options_schema/0` defined.
 
   Options containing `param()` references are skipped from validation as they
   will be resolved at runtime.
@@ -188,53 +185,29 @@ defmodule BB.Dsl.Verifiers.ValidateChildSpecs do
   defp normalize_child_spec({module, opts}) when is_atom(module), do: {module, opts}
 
   defp validate_options(module, opts, path, robot_module) do
-    Code.ensure_loaded(module)
-    has_schema? = function_exported?(module, :options_schema, 0)
-    has_opts? = opts != []
+    schema = module.options_schema()
+    param_ref_keys = get_param_ref_keys(opts)
+    schema_for_validation = mark_keys_as_optional(schema, param_ref_keys)
+    opts_without_param_refs = filter_param_refs(opts)
 
-    cond do
-      has_opts? and not has_schema? ->
+    case Spark.Options.validate(opts_without_param_refs, schema_for_validation) do
+      {:ok, _validated} ->
+        :ok
+
+      {:error, %Spark.Options.ValidationError{} = error} ->
         {:error,
          DslError.exception(
            module: robot_module,
            path: path,
            message: """
-           Module #{inspect(module)} does not define options_schema/0 but options were provided.
+           Invalid options for #{inspect(module)}:
 
-           Either:
-           1. Use the module without options: #{inspect(module)}
-           2. Add options_schema/0 to #{inspect(module)} to accept options
+           #{Exception.message(error)}
+
+           Expected schema:
+           #{format_schema(schema)}
            """
          )}
-
-      has_schema? ->
-        schema = module.options_schema()
-        param_ref_keys = get_param_ref_keys(opts)
-        schema_for_validation = mark_keys_as_optional(schema, param_ref_keys)
-        opts_without_param_refs = filter_param_refs(opts)
-
-        case Spark.Options.validate(opts_without_param_refs, schema_for_validation) do
-          {:ok, _validated} ->
-            :ok
-
-          {:error, %Spark.Options.ValidationError{} = error} ->
-            {:error,
-             DslError.exception(
-               module: robot_module,
-               path: path,
-               message: """
-               Invalid options for #{inspect(module)}:
-
-               #{Exception.message(error)}
-
-               Expected schema:
-               #{format_schema(schema)}
-               """
-             )}
-        end
-
-      true ->
-        :ok
     end
   end
 

--- a/lib/bb/estimator.ex
+++ b/lib/bb/estimator.ex
@@ -227,7 +227,6 @@ defmodule BB.Estimator do
   @callback options_schema() :: Spark.Options.t()
 
   @optional_callbacks [
-    options_schema: 0,
     handle_options: 2,
     handle_call: 3,
     handle_cast: 2,
@@ -235,6 +234,8 @@ defmodule BB.Estimator do
     handle_continue: 2,
     terminate: 2
   ]
+
+  alias BB.Component.OptionsSchema
 
   @doc false
   defmacro __using__(opts) do
@@ -268,18 +269,7 @@ defmodule BB.Estimator do
                      handle_continue: 2,
                      terminate: 2
 
-      unquote(
-        if schema_opts do
-          quote do
-            @__bb_options_schema Spark.Options.new!(unquote(schema_opts))
-
-            @impl BB.Estimator
-            def options_schema, do: @__bb_options_schema
-
-            defoverridable options_schema: 0
-          end
-        end
-      )
+      unquote(OptionsSchema.inject(BB.Estimator, schema_opts))
     end
   end
 

--- a/lib/bb/estimator/server.ex
+++ b/lib/bb/estimator/server.ex
@@ -50,11 +50,14 @@ defmodule BB.Estimator.Server do
 
   use GenServer
 
+  alias BB.Component.OptionsSchema
   alias BB.Estimator.Context
   alias BB.Message
   alias BB.Parameter.Changed, as: ParameterChanged
   alias BB.Robot.Runtime
   alias BB.Server.ParamResolution
+
+  @framework_keys [:bb, :estimator_context]
 
   defstruct [
     :callback_module,
@@ -166,43 +169,49 @@ defmodule BB.Estimator.Server do
       BB.PubSub.subscribe(bb.robot, path)
     end)
 
-    base = %__MODULE__{
-      callback_module: callback_module,
-      resolved_opts: resolved_opts,
-      raw_opts: raw_opts,
-      param_subscriptions: param_subscriptions,
-      bb: bb,
-      context: context,
-      mode: input_config.mode,
-      inputs: input_config.inputs,
-      driver_input: driver_input,
-      input_name_by_path: input_name_by_path,
-      sync_tolerance_ns: Map.get(input_config, :sync_tolerance_ns),
-      outputs: outputs,
-      last_messages: %{},
-      latency_budget_ns: health.latency_budget_ns,
-      lost_after_ns: health.lost_after_ns,
-      recover_after: health.recover_after,
-      on_degraded: health.on_degraded,
-      on_lost: health.on_lost,
-      on_recovered: health.on_recovered,
-      health_state: :healthy,
-      consecutive_ok: 0,
-      lost_timer_ref: nil
-    }
+    case OptionsSchema.validate(callback_module, resolved_opts, @framework_keys) do
+      {:error, error} ->
+        {:stop, error}
 
-    case callback_module.init(resolved_opts) do
-      {:ok, user_state} ->
-        {:ok, reset_lost_timer(%{base | user_state: user_state})}
+      {:ok, resolved_opts} ->
+        base = %__MODULE__{
+          callback_module: callback_module,
+          resolved_opts: resolved_opts,
+          raw_opts: raw_opts,
+          param_subscriptions: param_subscriptions,
+          bb: bb,
+          context: context,
+          mode: input_config.mode,
+          inputs: input_config.inputs,
+          driver_input: driver_input,
+          input_name_by_path: input_name_by_path,
+          sync_tolerance_ns: Map.get(input_config, :sync_tolerance_ns),
+          outputs: outputs,
+          last_messages: %{},
+          latency_budget_ns: health.latency_budget_ns,
+          lost_after_ns: health.lost_after_ns,
+          recover_after: health.recover_after,
+          on_degraded: health.on_degraded,
+          on_lost: health.on_lost,
+          on_recovered: health.on_recovered,
+          health_state: :healthy,
+          consecutive_ok: 0,
+          lost_timer_ref: nil
+        }
 
-      {:ok, user_state, timeout_or_continue} ->
-        {:ok, reset_lost_timer(%{base | user_state: user_state}), timeout_or_continue}
+        case callback_module.init(resolved_opts) do
+          {:ok, user_state} ->
+            {:ok, reset_lost_timer(%{base | user_state: user_state})}
 
-      {:stop, reason} ->
-        {:stop, reason}
+          {:ok, user_state, timeout_or_continue} ->
+            {:ok, reset_lost_timer(%{base | user_state: user_state}), timeout_or_continue}
 
-      :ignore ->
-        :ignore
+          {:stop, reason} ->
+            {:stop, reason}
+
+          :ignore ->
+            :ignore
+        end
     end
   end
 
@@ -230,12 +239,14 @@ defmodule BB.Estimator.Server do
            state.bb.robot
          ) do
       {:changed, new_resolved} ->
-        case state.callback_module.handle_options(new_resolved, state.user_state) do
-          {:ok, new_user_state} ->
-            {:noreply, %{state | resolved_opts: new_resolved, user_state: new_user_state}}
-
-          {:stop, reason} ->
-            {:stop, reason, state}
+        with {:ok, new_resolved} <-
+               OptionsSchema.validate(state.callback_module, new_resolved, @framework_keys),
+             {:ok, new_user_state} <-
+               state.callback_module.handle_options(new_resolved, state.user_state) do
+          {:noreply, %{state | resolved_opts: new_resolved, user_state: new_user_state}}
+        else
+          {:stop, reason} -> {:stop, reason, state}
+          {:error, error} -> {:stop, error, state}
         end
 
       :ignored ->

--- a/lib/bb/sensor.ex
+++ b/lib/bb/sensor.ex
@@ -200,7 +200,6 @@ defmodule BB.Sensor do
   @callback options_schema() :: Spark.Options.t()
 
   @optional_callbacks [
-    options_schema: 0,
     disarm: 1,
     handle_options: 2,
     handle_call: 3,
@@ -209,6 +208,8 @@ defmodule BB.Sensor do
     handle_continue: 2,
     terminate: 2
   ]
+
+  alias BB.Component.OptionsSchema
 
   @doc false
   defmacro __using__(opts) do
@@ -243,18 +244,7 @@ defmodule BB.Sensor do
                      handle_continue: 2,
                      terminate: 2
 
-      unquote(
-        if schema_opts do
-          quote do
-            @__bb_options_schema Spark.Options.new!(unquote(schema_opts))
-
-            @impl BB.Sensor
-            def options_schema, do: @__bb_options_schema
-
-            defoverridable options_schema: 0
-          end
-        end
-      )
+      unquote(OptionsSchema.inject(BB.Sensor, schema_opts))
     end
   end
 

--- a/lib/bb/sensor/server.ex
+++ b/lib/bb/sensor/server.ex
@@ -19,11 +19,14 @@ defmodule BB.Sensor.Server do
 
   use GenServer
 
+  alias BB.Component.OptionsSchema
   alias BB.Parameter.Changed, as: ParameterChanged
   alias BB.Sensor.SensorProfile
   alias BB.Server.ParamResolution
   alias BB.Transmission
   alias BB.Transmission.Resolver, as: TransmissionResolver
+
+  @framework_keys [:bb, :sensor_profile]
 
   defstruct [
     :callback_module,
@@ -83,30 +86,36 @@ defmodule BB.Sensor.Server do
     sensor_profile = %SensorProfile{joint_name: joint_name, transmission: transmission}
     resolved_opts = Keyword.put(resolved_opts, :sensor_profile, sensor_profile)
 
-    base = %__MODULE__{
-      callback_module: callback_module,
-      resolved_opts: resolved_opts,
-      raw_opts: raw_opts,
-      param_subscriptions: param_subscriptions,
-      transmission: transmission,
-      transmission_subscriptions: transmission_subscriptions,
-      sensor_name: sensor_name,
-      joint_name: joint_name,
-      bb: bb
-    }
+    case OptionsSchema.validate(callback_module, resolved_opts, @framework_keys) do
+      {:error, error} ->
+        {:stop, error}
 
-    case callback_module.init(resolved_opts) do
-      {:ok, user_state} ->
-        {:ok, %{base | user_state: user_state}}
+      {:ok, resolved_opts} ->
+        base = %__MODULE__{
+          callback_module: callback_module,
+          resolved_opts: resolved_opts,
+          raw_opts: raw_opts,
+          param_subscriptions: param_subscriptions,
+          transmission: transmission,
+          transmission_subscriptions: transmission_subscriptions,
+          sensor_name: sensor_name,
+          joint_name: joint_name,
+          bb: bb
+        }
 
-      {:ok, user_state, timeout_or_continue} ->
-        {:ok, %{base | user_state: user_state}, timeout_or_continue}
+        case callback_module.init(resolved_opts) do
+          {:ok, user_state} ->
+            {:ok, %{base | user_state: user_state}}
 
-      {:stop, reason} ->
-        {:stop, reason}
+          {:ok, user_state, timeout_or_continue} ->
+            {:ok, %{base | user_state: user_state}, timeout_or_continue}
 
-      :ignore ->
-        :ignore
+          {:stop, reason} ->
+            {:stop, reason}
+
+          :ignore ->
+            :ignore
+        end
     end
   end
 
@@ -157,12 +166,14 @@ defmodule BB.Sensor.Server do
           %SensorProfile{joint_name: state.joint_name, transmission: state.transmission}
         )
 
-      case state.callback_module.handle_options(new_resolved, state.user_state) do
-        {:ok, new_user_state} ->
-          {:noreply, %{state | resolved_opts: new_resolved, user_state: new_user_state}}
-
-        {:stop, reason} ->
-          {:stop, reason, state}
+      with {:ok, new_resolved} <-
+             OptionsSchema.validate(state.callback_module, new_resolved, @framework_keys),
+           {:ok, new_user_state} <-
+             state.callback_module.handle_options(new_resolved, state.user_state) do
+        {:noreply, %{state | resolved_opts: new_resolved, user_state: new_user_state}}
+      else
+        {:stop, reason} -> {:stop, reason, state}
+        {:error, error} -> {:stop, error, state}
       end
     else
       {:noreply, state}

--- a/test/bb/command/options_test.exs
+++ b/test/bb/command/options_test.exs
@@ -30,7 +30,11 @@ defmodule BB.Command.OptionsTest do
     @moduledoc """
     Test command that receives static options via handler tuple.
     """
-    use BB.Command
+    use BB.Command,
+      options_schema: [
+        max_velocity: [type: :float],
+        timeout_ms: [type: :integer]
+      ]
 
     @impl BB.Command
     def init(opts) do
@@ -63,7 +67,7 @@ defmodule BB.Command.OptionsTest do
     @moduledoc """
     Test command that receives parameterised options and handles updates.
     """
-    use BB.Command
+    use BB.Command, options_schema: [gain: [type: :float]]
 
     @impl BB.Command
     def init(opts) do

--- a/test/bb/component/options_schema_test.exs
+++ b/test/bb/component/options_schema_test.exs
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Component.OptionsSchemaTest do
+  use ExUnit.Case, async: true
+
+  alias BB.Component.OptionsSchema
+
+  defmodule Fixture do
+    @moduledoc false
+    use BB.Sensor,
+      options_schema: [
+        beta: [type: :float, default: 0.1],
+        accel_threshold: [type: :float, default: 0.05],
+        gain: [type: :integer, required: true]
+      ]
+
+    @impl BB.Sensor
+    def init(opts), do: {:ok, opts}
+  end
+
+  @framework_keys [:bb, :sensor_profile]
+
+  describe "validate/3" do
+    test "applies schema defaults for keys the caller omitted" do
+      {:ok, validated} =
+        OptionsSchema.validate(
+          Fixture,
+          [bb: :fake_bb, sensor_profile: :fake_profile, gain: 7],
+          @framework_keys
+        )
+
+      assert validated[:gain] == 7
+      assert validated[:beta] == 0.1
+      assert validated[:accel_threshold] == 0.05
+    end
+
+    test "preserves framework-injected keys verbatim, not validated by the schema" do
+      bb = %{robot: :robot_mod, path: [:base, :imu]}
+
+      {:ok, validated} =
+        OptionsSchema.validate(
+          Fixture,
+          [bb: bb, sensor_profile: :prof, gain: 3],
+          @framework_keys
+        )
+
+      assert validated[:bb] == bb
+      assert validated[:sensor_profile] == :prof
+    end
+
+    test "returns a validation error when a user key is not in the schema" do
+      assert {:error, %Spark.Options.ValidationError{}} =
+               OptionsSchema.validate(
+                 Fixture,
+                 [bb: :fake, gain: 1, surprise: :unexpected],
+                 @framework_keys
+               )
+    end
+
+    test "returns a validation error when a required key is missing" do
+      assert {:error, %Spark.Options.ValidationError{}} =
+               OptionsSchema.validate(Fixture, [bb: :fake], @framework_keys)
+    end
+  end
+
+  describe "schema declaration" do
+    test "passing options_schema: to `use` AND defining options_schema/0 is a compile error" do
+      assert_raise CompileError, ~r/Declare the schema one way, not both/, fn ->
+        defmodule DoubleDeclaration do
+          @moduledoc false
+          use BB.Sensor, options_schema: [foo: [type: :integer]]
+
+          @impl BB.Sensor
+          def options_schema, do: Spark.Options.new!([])
+
+          @impl BB.Sensor
+          def init(opts), do: {:ok, opts}
+        end
+      end
+    end
+
+    test "omitting the schema entirely yields an empty default options_schema/0" do
+      defmodule NoSchema do
+        @moduledoc false
+        use BB.Sensor
+
+        @impl BB.Sensor
+        def init(opts), do: {:ok, opts}
+      end
+
+      assert %Spark.Options{schema: []} = NoSchema.options_schema()
+    end
+  end
+end

--- a/test/bb/dsl/validate_child_specs_test.exs
+++ b/test/bb/dsl/validate_child_specs_test.exs
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Dsl.Verifiers.ValidateChildSpecsTest do
+  use ExUnit.Case, async: true
+
+  # A bare GenServer that does NOT declare any BB component behaviour. The
+  # verifier should refuse to wire this in as a sensor / actuator / etc.
+  defmodule NotAComponent do
+    @moduledoc false
+    use GenServer
+
+    @impl GenServer
+    def init(opts), do: {:ok, opts}
+  end
+
+  describe "behaviour enforcement" do
+    test "actuator module without @behaviour BB.Actuator raises DslError" do
+      assert_raise Spark.Error.DslError, ~r/must implement the BB\.Actuator behaviour/, fn ->
+        defmodule ActuatorBadRobot do
+          @moduledoc false
+          use BB
+
+          topology do
+            link :base do
+              joint :shoulder do
+                type :revolute
+
+                limit do
+                  effort(~u(10 newton_meter))
+                  velocity(~u(180 degree_per_second))
+                end
+
+                actuator :motor, BB.Dsl.Verifiers.ValidateChildSpecsTest.NotAComponent
+
+                link :arm
+              end
+            end
+          end
+        end
+      end
+    end
+
+    test "link sensor module without @behaviour BB.Sensor raises DslError" do
+      assert_raise Spark.Error.DslError, ~r/must implement the BB\.Sensor behaviour/, fn ->
+        defmodule SensorBadRobot do
+          @moduledoc false
+          use BB
+
+          topology do
+            link :base do
+              sensor :imu, BB.Dsl.Verifiers.ValidateChildSpecsTest.NotAComponent
+            end
+          end
+        end
+      end
+    end
+
+    test "robot-level controller without @behaviour BB.Controller raises DslError" do
+      assert_raise Spark.Error.DslError, ~r/must implement the BB\.Controller behaviour/, fn ->
+        defmodule ControllerBadRobot do
+          @moduledoc false
+          use BB
+
+          controllers do
+            controller(:bad, BB.Dsl.Verifiers.ValidateChildSpecsTest.NotAComponent)
+          end
+
+          topology do
+            link :base
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Bug

Schema `default:` values declared in a component's `options_schema/0` were never applied at runtime. The component servers called `callback_module.init/1` with opts straight from `ParamResolution.resolve/2`, which only swaps `ParamRef`s — it never ran `Spark.Options.validate/2`. The schema's `default:` was exercised only by the compile-time verifier, which threw the validated result away.

Symptom: `BB.Sensor.BMI323` declared sensible defaults but `init/1` crashed with `KeyError` whenever a defaulted key was omitted — even though the readme said the default would be applied. Same bug bit every AHRS filter in `bb_estimator_ahrs` (`Madgwick`, `Mahony`, `Complementary`): `Keyword.fetch!(opts, :beta)` raised when `beta` was omitted.

`BB.Sensor.OpenLoopPositionEstimator` only worked because it re-stated every default defensively via `Map.get(opts, :easing, :linear)` — a duplication smell this fix retires.

## Approach

Two interlocking concerns:

**Concern A — unify schema declaration.** Two ways to declare the schema existed (`use BB.X, options_schema: [...]` vs `def options_schema/0`) and could silently fight. They now share a single helper, and providing both is a hard compile error. Keyword form stays for self-contained literal schemas; the callback form remains the escape hatch for schemas that reference module attributes / helpers / sigils (which aren't in scope at `use` expansion). With no schema declared, an empty default is injected, so `options_schema/0` is always defined and callers never need a `function_exported?` guard.

**Concern B — apply defaults at runtime.** The five component servers (sensor / actuator / controller / estimator / command) now split off framework-injected keys, run `Spark.Options.validate/2` against `module.options_schema/0` (applying defaults), and merge framework keys back — both in `init` and on the `handle_options/2` param-change path. Bridges are unchanged (they have no intermediary server).

## Changes

- New `BB.Component.OptionsSchema` helper:
  - `validate/3` — runtime split / validate / merge.
  - `inject/2` — the declaration machinery used by the six `use` macros (was duplicated per behaviour).
- The six `use BB.X` macros now delegate to the shared helper. Double declaration of keyword + callback raises `CompileError` via `@before_compile`.
- Five component servers do runtime validation in `init` and `handle_options`.
- Command is held to the same standard — a command that passes options must declare `options_schema/0`. The two test commands in `BB.Command.OptionsTest` were given schemas to match.
- Command's stored schema is now a compiled `%Spark.Options{}` like the other components (was a raw keyword list). Low-risk: only the verifier consumes it and `Spark.Options.validate/2` accepts both forms.
- New `BB.Dsl.ValidateChildSpecBehavioursTransformer` enforces that every module wired into a component slot actually implements the matching behaviour. Spark's built-in `{:behaviour, X}` schema type only validates `is_atom`, not conformance, so a bare `use GenServer` module could otherwise be wired in as e.g. an actuator, passing DSL compilation only to crash at runtime when the server expected callbacks (`options_schema/0`, `init/1`, etc.) that weren't defined. Implemented as a transformer (raises) rather than a verifier (would only warn — `@after_verify` doesn't tolerate errors). Runs after `UniquenessTransformer` so name conflicts are reported first.
- New regression tests:
  - `test/bb/component/options_schema_test.exs` — `validate/3` applies defaults, preserves framework keys, errors on unknown/missing required keys; double declaration raises `CompileError`; missing schema yields an empty default.
  - `test/bb/dsl/validate_child_specs_test.exs` — non-conformant modules raise `Spark.Error.DslError` for actuator / sensor / controller slots.

## Downstream impact

This is the first release where a command's `options_schema/0` becomes load-bearing at runtime — a command that passes options without declaring a schema will fail at startup with Spark's `unknown options ...` error. A sweep across the workspace (`bb_example_so101`, `bb_example_wx200`, `bb_ik_dls`, `bb_ik_fabrik`, `bb_jido`, `bb_kino`, `bb_mcp`, `bb_reactor`) found 19 command modules; **none declare a schema, but none are wired with tuple-form `handler({Module, opts})`** — they all use bare `handler(Module)`, so empty opts validate against the empty default schema. Confirmed empirically against `BB_VERSION=local`: `bb_kino` 6/0, `bb_mcp` 88/0, `bb_reactor` 28/0, `bb_jido` 37/0. No downstream changes required.


## Verification

- `mix check --no-retry` clean (compiler, credo, dialyzer, ex_doc, ex_unit, formatter, mix_audit, reuse, spark_cheat_sheets, spark_formatter, unused_deps). 1057 tests / 0 failures.
- `BB_VERSION=local` proves the fix on `bb_sensor_bmi323` (40/0) and `bb_estimator_ahrs` (42/0).
- A full `mix check --no-retry` sweep across all 20 workspace repos against this branch passes everywhere that's currently green; the residual failures (`bb_servo_pca9685`, `bb_servo_robotis`) are a pre-existing `BB.Igniter.set_robot_opts/3` API drift addressed in companion PRs (#39 and #34 respectively).

## Open follow-ups (left for review feedback)

- Remove `BB.Sensor.OpenLoopPositionEstimator`'s defensive `Map.get(opts, key, default)` duplication now that the server applies the schema defaults? It would assert that callback `init/1` may assume server pre-validation — that affects the test which currently calls `init/1` directly with partial opts. Worth its own change if you want to make that contract explicit.
