### PR TITLE
docs: correct safety contract and document which component disarms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,13 +124,14 @@ See `documentation/tutorials/10-simulation.md` for details.
 
 ### Safety System (CRITICAL)
 
-See `documentation/topics/safety.md` for comprehensive safety documentation.
+See `documentation/topics/understanding-safety.md` for comprehensive safety documentation.
 
 **Changes to safety-critical code require extra care** - bugs here could result in physical harm.
 
 Key points:
-- Actuators controlling hardware MUST implement `BB.Safety` behaviour
-- `disarm/1` callback must work without GenServer state (process may have crashed)
+- Components that drive hardware implement a `disarm/1` callback defined on their behaviour: `BB.Actuator` (required), `BB.Controller`/`BB.Sensor` (optional). `BB.Safety` is the arm/disarm API, not a behaviour.
+- Components register with the safety system via `BB.Safety.register/2`
+- `disarm/1` is called with the opts given at registration and must work without GenServer state (process may have crashed)
 - Safety states: `:disarmed` → `:armed` → `:disarming` → `:disarmed` (or `:error` on failure)
 - Disarm callbacks run concurrently with 5 second timeout
 - The `:error` state means hardware may not be safe - requires `force_disarm/1` to recover
@@ -191,7 +192,7 @@ When adding a new payload, pick the convention that matches its shape rather tha
 - Commands: Return `{:ok, result}` or `{:ok, result, next_state: state}` for state transitions
 - State machine: Robots start `:disarmed`, transition to `:idle` when armed, `:executing` during commands
 - **Errors**: Use structured `BB.Error` types instead of tuple-based errors. All errors must implement `BB.Error.Severity`
-- **Safety**: Actuators controlling physical hardware must implement `BB.Safety` behaviour. Test disarm callbacks thoroughly - they run when things have already gone wrong
+- **Safety**: Components that drive hardware implement the `disarm/1` callback from their behaviour (`BB.Actuator` required; `BB.Controller`/`BB.Sensor` optional) and register via `BB.Safety.register/2`. Test disarm callbacks thoroughly - they run when things have already gone wrong
 
 ## Proposals
 

--- a/documentation/how-to/implement-safety-callbacks.md
+++ b/documentation/how-to/implement-safety-callbacks.md
@@ -123,6 +123,9 @@ end
 
 ### Serial-based servos (e.g., Dynamixel)
 
+This pattern applies when the **actuator owns the serial port** (a single servo
+on its own port):
+
 ```elixir
 @impl BB.Actuator
 def disarm(opts) do
@@ -143,6 +146,15 @@ def disarm(opts) do
   :ok
 end
 ```
+
+When many servos **share one serial bus** (the usual case — `bb_servo_feetech`,
+`bb_servo_robotis`), the controller owns the port, not the actuators. There the
+*controller* registers and implements `disarm/1` (disabling torque on every
+servo in one bulk write), and each actuator's `disarm/1` is `def disarm(_opts),
+do: :ok`. See [Which Component Registers and
+Disarms?](../topics/understanding-safety.md#which-component-registers-and-disarms)
+for the rule, and [How to Integrate a Servo
+Driver](integrate-servo-driver.md) for the controller-side example.
 
 ## Step 3: Handle Registration Options
 

--- a/documentation/topics/understanding-safety.md
+++ b/documentation/topics/understanding-safety.md
@@ -58,6 +58,38 @@ The `disarm/1` callback receives only options, not GenServer state. This design 
 
 The trade-off: you must pass all hardware access information at registration time.
 
+## Which Component Registers and Disarms?
+
+Exactly one component owns each piece of hardware, and that component is
+responsible for its safety: it registers with `BB.Safety.register/2` at init and
+implements the `disarm/1` callback that makes its hardware safe. Other components
+that share the same hardware do not register and do not disarm — they only gate
+their own commands on `BB.Safety.armed?/1`.
+
+Which component owns the hardware depends on the driver shape:
+
+- **Standalone actuator** (independent channel — e.g. PWM servos like
+  `bb_servo_pca9685`, `bb_servo_pigpio`). Each actuator owns its own GPIO pin or
+  PWM channel, so **each actuator registers and implements `disarm/1`**. Its
+  disarm makes that one channel safe (e.g. zero the pulse width, disable the
+  channel).
+
+- **Controller + actuator** (shared serial bus — e.g. `bb_servo_feetech`,
+  `bb_servo_robotis`). A single controller owns the serial port; the actuators
+  cannot open it independently. So **the controller registers and implements
+  `disarm/1`**, disabling torque on every servo on the bus in one bulk write. The
+  actuators delegate: their `disarm/1` is `def disarm(_opts), do: :ok` and they
+  gate commands on `BB.Safety.armed?/1`.
+
+The rule is the same in both shapes: *whoever owns the hardware connection
+registers and disarms.* A no-op `disarm/1` is only safe when another component —
+the controller that owns the bus — has registered to disarm that hardware. Never
+leave a hardware resource with no registered owner.
+
+See [How to Implement Safety Callbacks](../how-to/implement-safety-callbacks.md)
+and [How to Integrate a Servo Driver](../how-to/integrate-servo-driver.md) for
+worked examples of each shape.
+
 ## Concurrent Execution with Timeouts
 
 Disarm callbacks run concurrently with a 5-second timeout per callback. This design reflects practical constraints:


### PR DESCRIPTION
The docs described `BB.Safety` as a behaviour that actuators "must implement". It isn't one — `BB.Safety` is the arm/disarm API, and the `disarm/1` callback is defined on the `BB.Actuator` (required), `BB.Controller`, and `BB.Sensor` behaviours.

## Changes

- **`AGENTS.md`** — corrected the Safety System key points and bottom-of-file summary; fixed the stale `documentation/topics/safety.md` path to `understanding-safety.md`.
- **`documentation/topics/understanding-safety.md`** — added a "Which Component Registers and Disarms?" section stating the contract: whoever owns the hardware connection registers via `BB.Safety.register/2` and implements `disarm/1`. Covers both driver shapes (standalone actuator vs controller + shared bus).
- **`documentation/how-to/implement-safety-callbacks.md`** — the serial example showed actuator-side disarm with no caveat; clarified that this applies when the actuator owns the port, and that shared-bus drivers disarm at the controller.

Docs only; no code changes.