### PR TITLE
chore: remove unreachable current_position/1 clause

### DIFF
--- a/lib/bb/sensor/open_loop_position_estimator.ex
+++ b/lib/bb/sensor/open_loop_position_estimator.ex
@@ -239,8 +239,6 @@ defmodule BB.Sensor.OpenLoopPositionEstimator do
     {:noreply, state, state.max_silence_ms}
   end
 
-  defp current_position(%{target_position: nil}), do: nil
-
   defp current_position(state) do
     now = System.monotonic_time(:millisecond)
 


### PR DESCRIPTION
Elixir 1.20's type system flags the `%{target_position: nil}` clause of `current_position/1` as unreachable: the only caller (`handle_info/2`) guards the call with `if state.target_position`, so it is never invoked with a nil target.

Removing the dead clause preserves behaviour and compiles cleanly on Elixir 1.19 and 1.20.
