### PR TITLE
improvement: generate a `robot_opts/0` helper for new robots

### DIFF
--- a/documentation/tutorials/02-starting-and-stopping.md
+++ b/documentation/tutorials/02-starting-and-stopping.md
@@ -6,22 +6,54 @@ SPDX-License-Identifier: Apache-2.0
 
 # Starting and Stopping
 
-In the previous tutorial, we defined a robot using the Beam Bots DSL. Now we'll bring it to life by starting its supervision tree and understanding the process structure.
+In the previous tutorial, we defined a robot using the Beam Bots DSL. Now we'll bring it to life and understand the supervision tree that runs it.
 
 ## Prerequisites
 
 Complete [Your First Robot](01-first-robot.md) first. You should have a `MyRobot.Robot` module defined.
 
-## Starting the Robot
+## Your Robot Starts With Your Application
 
-Start your robot with `BB.Supervisor.start_link/2`:
+When you installed Beam Bots, the installer added your robot to your application's supervision tree. You can see it in `lib/my_robot/application.ex`:
 
 ```elixir
-iex> {:ok, pid} = BB.Supervisor.start_link(MyRobot.Robot)
-{:ok, #PID<0.234.0>}
+defmodule MyRobot.Application do
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      {MyRobot.Robot, robot_opts()}
+    ]
+
+    opts = [strategy: :one_for_one, name: MyRobot.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  defp robot_opts do
+    if System.get_env("SIMULATE") do
+      [simulation: :kinematic]
+    else
+      Application.get_env(:my_robot, MyRobot.Robot, [])
+    end
+  end
+end
 ```
 
-Your robot is now running. The supervisor has spawned a tree of processes that mirrors your robot's physical structure.
+So your robot starts automatically whenever your application boots. The generated `robot_opts/0` decides how: set the `SIMULATE` environment variable to boot in kinematic simulation (see [Simulation Mode](10-simulation.md)), otherwise it reads any startup options you've placed in config (see [Parameters](07-parameters.md)). Launch an IEx session with your project loaded:
+
+```sh
+iex -S mix
+```
+
+Your robot is already running. The supervisor has spawned a tree of processes that mirrors your robot's physical structure. Confirm it's alive by asking for its state:
+
+```elixir
+iex> BB.Robot.Runtime.state(MyRobot.Robot)
+:disarmed
+```
+
+> **Note:** Because the robot is already supervised, calling `MyRobot.Robot.start_link/1` yourself returns `{:error, {:already_started, pid}}` rather than starting a second copy. That's expected — there is one robot, and it is already running. See [Starting a Robot Manually](#starting-a-robot-manually) if you want to control startup yourself.
 
 ## Understanding the Process Tree
 
@@ -89,41 +121,47 @@ iex> :observer.start()
 
 Navigate to the Applications tab and find your robot's supervision tree.
 
-## Stopping the Robot
+## Stopping and Restarting
 
-Stop the robot by stopping its supervisor:
+Your robot is a permanent child of your application's supervisor, so stopping it directly just triggers an immediate restart:
 
 ```elixir
 iex> Supervisor.stop(MyRobot.Robot)
 :ok
+iex> BB.Robot.Runtime.state(MyRobot.Robot)
+:disarmed  # MyRobot.Supervisor has already restarted it
 ```
 
-This gracefully shuts down all child processes in reverse order.
-
-## Adding to Your Application
-
-In a real application, you'll want to start the robot as part of your application supervision tree.
-
-In your `application.ex`:
+To stop it and keep it stopped — while experimenting, say — terminate it through its parent supervisor:
 
 ```elixir
-defmodule MyApp.Application do
-  use Application
-
-  @impl true
-  def start(_type, _args) do
-    children = [
-      # Start the robot supervisor
-      MyRobot.Robot
-    ]
-
-    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
-    Supervisor.start_link(children, opts)
-  end
-end
+iex> Supervisor.terminate_child(MyRobot.Supervisor, MyRobot.Robot)
+:ok
 ```
 
-Now your robot starts automatically with your application.
+Start it again with:
+
+```elixir
+iex> Supervisor.restart_child(MyRobot.Supervisor, MyRobot.Robot)
+{:ok, #PID<0.260.0>}
+```
+
+Stopping a supervisor gracefully shuts down all of its child processes in reverse order.
+
+## Starting a Robot Manually
+
+If a robot is *not* part of a supervision tree — in a script, a test, or a fresh `iex` session started without your application — start it yourself:
+
+```elixir
+iex> {:ok, pid} = MyRobot.Robot.start_link()
+{:ok, #PID<0.234.0>}
+```
+
+`MyRobot.Robot.start_link/1` accepts the same options as its child spec, such as `params:` and `simulation:`:
+
+```elixir
+iex> {:ok, pid} = MyRobot.Robot.start_link(simulation: :kinematic)
+```
 
 ## Multiple Robots
 

--- a/documentation/tutorials/03-sensors-and-pubsub.md
+++ b/documentation/tutorials/03-sensors-and-pubsub.md
@@ -99,10 +99,9 @@ Key points:
 
 ## Subscribing to Messages
 
-Start your robot and subscribe to sensor messages:
+Your robot is already running (it starts with your application), so subscribe to its sensor messages:
 
 ```elixir
-iex> {:ok, _} = BB.Supervisor.start_link(MyRobot.Robot)
 iex> BB.PubSub.subscribe(MyRobot.Robot, [:sensor])
 {:ok, #PID<0.234.0>}
 ```

--- a/documentation/tutorials/04-kinematics.md
+++ b/documentation/tutorials/04-kinematics.md
@@ -51,7 +51,6 @@ Positions are in **radians** for revolute joints and **metres** for prismatic jo
 For a running robot, query the Runtime for current joint positions:
 
 ```elixir
-iex> {:ok, _} = BB.Supervisor.start_link(MyRobot.Robot)
 iex> positions = BB.Robot.Runtime.positions(MyRobot.Robot)
 %{pan_joint: 0.0, tilt_joint: 0.0}
 

--- a/documentation/tutorials/05-commands.md
+++ b/documentation/tutorials/05-commands.md
@@ -39,7 +39,6 @@ BB.Robot.Runtime.operational_state(MyRobot.Robot)  # => :idle (the actual state)
 Query the current state:
 
 ```elixir
-iex> {:ok, _} = BB.Supervisor.start_link(MyRobot.Robot)
 iex> BB.Robot.Runtime.state(MyRobot.Robot)
 :disarmed
 ```

--- a/documentation/tutorials/07-parameters.md
+++ b/documentation/tutorials/07-parameters.md
@@ -96,38 +96,37 @@ This creates paths like `[:controller, :pid, :kp]`.
 
 ## Passing Parameters at Startup
 
-You can override default values when starting the robot by passing a `params` option. The format is a nested keyword list matching your group structure:
+You override default values with a `params` option passed where the robot starts. The generated `robot_opts/0` reads runtime options from your application config, so set startup params under `config :my_robot, MyRobot.Robot`. The value is a nested keyword list matching your group structure:
 
 ```elixir
+# config/config.exs
+
 # Override a single parameter
-{:ok, _} = BB.Supervisor.start_link(MyRobot.Robot, params: [
-  motion: [max_linear_speed: 2.0]
-])
+config :my_robot, MyRobot.Robot,
+  params: [motion: [max_linear_speed: 2.0]]
 
 # Override multiple parameters
-{:ok, _} = BB.Supervisor.start_link(MyRobot.Robot, params: [
-  motion: [max_linear_speed: 2.0, max_angular_speed: 1.0],
-  safety: [enabled: false]
-])
+config :my_robot, MyRobot.Robot,
+  params: [
+    motion: [max_linear_speed: 2.0, max_angular_speed: 1.0],
+    safety: [enabled: false]
+  ]
 
 # Nested groups use nested keyword lists
-{:ok, _} = BB.Supervisor.start_link(MyRobot.Robot, params: [
-  controller: [pid: [kp: 2.5, ki: 0.2]]
-])
+config :my_robot, MyRobot.Robot,
+  params: [controller: [pid: [kp: 2.5, ki: 0.2]]]
 ```
 
-Startup parameters are validated against the schema. Invalid values or unknown parameter names cause the robot to fail to start:
+Startup parameters are validated against the schema. Invalid values or unknown parameter names cause the robot to fail to start — and because it's a supervised child, your application won't boot:
 
 ```elixir
-# Type mismatch - fails immediately
-{:error, _} = BB.Supervisor.start_link(MyRobot.Robot, params: [
-  motion: [max_linear_speed: "fast"]  # Expected float
-])
+# Type mismatch
+config :my_robot, MyRobot.Robot,
+  params: [motion: [max_linear_speed: "fast"]]  # Expected float
 
-# Unknown parameter - fails immediately
-{:error, _} = BB.Supervisor.start_link(MyRobot.Robot, params: [
-  motion: [unknown_param: 1.0]
-])
+# Unknown parameter
+config :my_robot, MyRobot.Robot,
+  params: [motion: [unknown_param: 1.0]]
 ```
 
 The precedence for parameter values is:
@@ -140,10 +139,9 @@ This lets you define sensible defaults in the DSL, persist tuned values across r
 
 ## Reading Parameters
 
-Start your robot and read parameter values:
+Read parameter values:
 
 ```elixir
-iex> {:ok, _} = BB.Supervisor.start_link(MyRobot.Robot)
 iex> BB.Parameter.get(MyRobot.Robot, [:motion, :max_linear_speed])
 {:ok, 1.0}
 

--- a/documentation/tutorials/08-parameter-bridges.md
+++ b/documentation/tutorials/08-parameter-bridges.md
@@ -132,7 +132,6 @@ end
 Now when parameters change, you'll see debug output:
 
 ```elixir
-iex> {:ok, _} = BB.Supervisor.start_link(MyRobot.Robot)
 iex> BB.Parameter.set(MyRobot.Robot, [:max_speed], 2.0)
 [DEBUG] Parameter [:max_speed] changed:
   Old: 1.0
@@ -264,8 +263,6 @@ end
 Access remote parameters through the `BB.Parameter` API:
 
 ```elixir
-iex> {:ok, _} = BB.Supervisor.start_link(MyRobot.Robot)
-
 # List parameters on the flight controller
 iex> {:ok, params} = BB.Parameter.list_remote(MyRobot.Robot, :fc)
 {:ok, [

--- a/documentation/tutorials/09-inverse-kinematics.md
+++ b/documentation/tutorials/09-inverse-kinematics.md
@@ -205,10 +205,7 @@ The `BB.Motion` module bridges IK solving with actuator commands, making it easy
 ```elixir
 alias BB.Motion
 
-# Start your robot
-{:ok, _pid} = MyRobot.Robot.start_link([])
-
-# Move the end-effector to a target position
+# Move the end-effector to a target position (your robot is already running)
 case Motion.move_to(MyRobot.Robot, :tip, {0.3, 0.2, 0.1}, solver: BB.IK.FABRIK) do
   {:ok, meta} ->
     IO.puts("Moved in #{meta.iterations} iterations")

--- a/documentation/tutorials/10-simulation.md
+++ b/documentation/tutorials/10-simulation.md
@@ -14,11 +14,10 @@ Complete [Your First Robot](01-first-robot.md) and [Starting and Stopping](02-st
 
 ## Starting in Simulation Mode
 
-Start your robot in kinematic simulation mode by passing the `simulation` option:
+Your robot's child spec calls the generated `robot_opts/0` (in `application.ex`), which boots it in kinematic simulation when the `SIMULATE` environment variable is set (see [Starting and Stopping](02-starting-and-stopping.md)). So to run the whole app in simulation, set it when you launch:
 
-```elixir
-iex> {:ok, pid} = MyRobot.Robot.start_link(simulation: :kinematic)
-{:ok, #PID<0.234.0>}
+```sh
+SIMULATE=1 iex -S mix
 ```
 
 The robot is now running entirely in software. Actuators receive commands and publish motion messages, but no hardware communication occurs.
@@ -56,10 +55,9 @@ The existing `OpenLoopPositionEstimator` sensor works unchanged, estimating posi
 
 ## Example: Testing Motion
 
-```elixir
-# Start in simulation
-{:ok, _pid} = MyRobot.Robot.start_link(simulation: :kinematic)
+With your robot running in simulation (see [Starting in Simulation Mode](#starting-in-simulation-mode) above):
 
+```elixir
 # Arm the robot (required even in simulation)
 :ok = BB.Safety.arm(MyRobot.Robot)
 
@@ -148,77 +146,58 @@ This is sufficient for:
 
 ## Future Simulation Modes
 
-The simulation option is an atom to allow future expansion:
+The `simulation` option is an atom to allow future expansion:
 
 ```elixir
 # Current: kinematic simulation
-MyRobot.Robot.start_link(simulation: :kinematic)
+config :my_robot, MyRobot.Robot, simulation: :kinematic
 
 # Future: external physics engine
-MyRobot.Robot.start_link(simulation: :external)
+config :my_robot, MyRobot.Robot, simulation: :external
 
 # Future: built-in physics
-MyRobot.Robot.start_link(simulation: :physics)
+config :my_robot, MyRobot.Robot, simulation: :physics
 ```
 
 ## Environment-Based Mode Selection
 
-To switch between hardware and simulation based on environment:
+The generated `robot_opts/0` already switches on the `SIMULATE` environment variable, so `SIMULATE=1 iex -S mix` runs in simulation and a plain start runs on hardware.
 
-```elixir
-# In your application.ex
-defmodule MyApp.Application do
-  use Application
-
-  @impl true
-  def start(_type, _args) do
-    simulation_mode =
-      if Application.get_env(:my_app, :simulate, false) do
-        :kinematic
-      else
-        nil
-      end
-
-    children = [
-      {MyRobot.Robot, simulation: simulation_mode}
-    ]
-
-    Supervisor.start_link(children, strategy: :one_for_one)
-  end
-end
-```
-
-Then in your config:
+To pin a mode per environment, set the robot's options in config — `robot_opts/0` reads them when `SIMULATE` is unset:
 
 ```elixir
 # config/dev.exs
-config :my_app, simulate: true
+config :my_robot, MyRobot.Robot, simulation: :kinematic
 
-# config/prod.exs (or target.exs for Nerves)
-config :my_app, simulate: false
+# config/prod.exs (or target.exs for Nerves) — hardware is the default
 ```
+
+If you need richer logic, edit `robot_opts/0` in `application.ex` directly.
 
 ## Testing with Simulation
 
-Simulation mode is useful for integration tests:
+Run your robot in simulation for integration tests by selecting the mode in `config/test.exs`:
+
+```elixir
+# config/test.exs
+config :my_robot, MyRobot.Robot, simulation: :kinematic
+```
+
+Your application then starts the robot in simulation for the test run, so tests drive the already-running robot:
 
 ```elixir
 defmodule MyRobotTest do
   use ExUnit.Case
 
   test "robot moves to home position" do
-    {:ok, pid} = MyRobot.Robot.start_link(simulation: :kinematic)
-
     :ok = BB.Safety.arm(MyRobot.Robot)
     :ok = BB.Command.execute(MyRobot.Robot, :home)
 
     # Verify the robot reached home position
-    assert_eventually fn ->
+    assert_eventually(fn ->
       pos = BB.Robot.Runtime.joint_position(MyRobot.Robot, :shoulder)
       abs(pos - 0.0) < 0.01
-    end
-
-    Supervisor.stop(pid)
+    end)
   end
 end
 ```

--- a/lib/mix/tasks/bb.add_robot.ex
+++ b/lib/mix/tasks/bb.add_robot.ex
@@ -21,7 +21,7 @@ if Code.ensure_loaded?(Igniter) do
 
     use Igniter.Mix.Task
 
-    alias Igniter.Project.Application
+    alias Igniter.Code.{Common, Function}
     alias Igniter.Project.Module
 
     @impl Igniter.Mix.Task
@@ -74,12 +74,70 @@ if Code.ensure_loaded?(Igniter) do
       """
     end
 
+    # The robot starts with the application. Its child-spec opts come from a
+    # generated `robot_opts/0` helper so a project can boot into `:kinematic`
+    # simulation with `SIMULATE=1 iex -S mix`, or feed startup opts from config,
+    # without editing the supervision tree by hand.
     defp add_to_supervision_tree(igniter, robot_module) do
-      Application.add_new_child(
-        igniter,
-        {robot_module, []},
+      igniter
+      |> add_robot_child(robot_module)
+      |> set_robot_child_opts(robot_module)
+      |> add_robot_opts_function(robot_module)
+    end
+
+    defp add_robot_child(igniter, robot_module) do
+      Igniter.Project.Application.add_new_child(igniter, {robot_module, []},
         after: fn _ -> true end
       )
+    end
+
+    # `opts_updater` only runs against an already-present child, so this second
+    # call replaces the `[]` placed by `add_robot_child/2` with `robot_opts()`.
+    defp set_robot_child_opts(igniter, robot_module) do
+      Igniter.Project.Application.add_new_child(igniter, {robot_module, []},
+        opts_updater: fn zipper ->
+          {:ok, Sourceror.Zipper.replace(zipper, quote(do: robot_opts()))}
+        end
+      )
+    end
+
+    defp add_robot_opts_function(igniter, robot_module) do
+      app_module = application_module(igniter)
+      app_name = Igniter.Project.Application.app_name(igniter)
+      code = robot_opts_function_code(app_name, robot_module)
+
+      Module.find_and_update_module!(igniter, app_module, fn zipper ->
+        if robot_opts_defined?(zipper) do
+          {:ok, zipper}
+        else
+          {:ok, Common.add_code(zipper, code)}
+        end
+      end)
+    end
+
+    defp robot_opts_defined?(zipper) do
+      with :error <- Function.move_to_def(zipper, :robot_opts, 0),
+           :error <- Function.move_to_defp(zipper, :robot_opts, 0) do
+        false
+      else
+        {:ok, _} -> true
+      end
+    end
+
+    defp application_module(igniter) do
+      Elixir.Module.concat(Module.module_name_prefix(igniter), Application)
+    end
+
+    defp robot_opts_function_code(app_name, robot_module) do
+      """
+      defp robot_opts do
+        if System.get_env("SIMULATE") do
+          [simulation: :kinematic]
+        else
+          Application.get_env(#{inspect(app_name)}, #{inspect(robot_module)}, [])
+        end
+      end
+      """
     end
   end
 else

--- a/test/bb/igniter_test.exs
+++ b/test/bb/igniter_test.exs
@@ -114,8 +114,10 @@ defmodule BB.IgniterTest do
       """)
     end
 
-    test "rewrites the robot child spec to read from the application env" do
+    test "rewrites a literal robot child spec to read from the application env" do
       project_with_robot()
+      |> reset_child_opts_to_literal()
+      |> apply_igniter!()
       |> BB.Igniter.set_robot_param_default(Test.Robot, [:config, :widget, :speed], 100)
       |> assert_has_patch("lib/test/application.ex", ~s'''
       + |    children = [{Test.Robot, Application.get_env(:test, Test.Robot, [])}]
@@ -216,6 +218,14 @@ defmodule BB.IgniterTest do
     Igniter.Project.Application.add_new_child(igniter, {Test.Robot, []},
       opts_updater: fn zipper ->
         {:ok, Sourceror.Zipper.replace(zipper, Sourceror.parse_string!("robot_opts()"))}
+      end
+    )
+  end
+
+  defp reset_child_opts_to_literal(igniter) do
+    Igniter.Project.Application.add_new_child(igniter, {Test.Robot, []},
+      opts_updater: fn zipper ->
+        {:ok, Sourceror.Zipper.replace(zipper, Sourceror.parse_string!("[]"))}
       end
     )
   end

--- a/test/mix/tasks/bb.add_robot_test.exs
+++ b/test/mix/tasks/bb.add_robot_test.exs
@@ -49,7 +49,11 @@ defmodule Mix.Tasks.Bb.AddRobotTest do
     assert_creates(igniter, "lib/test/application.ex")
 
     {_, source} = Rewrite.source(igniter.rewrite, "lib/test/application.ex")
-    assert source.content =~ "{Test.MyRobot, []}"
+    assert source.content =~ "{Test.MyRobot, robot_opts()}"
+    assert source.content =~ "defp robot_opts do"
+    assert source.content =~ "if System.get_env(\"SIMULATE\") do"
+    assert source.content =~ "[simulation: :kinematic]"
+    assert source.content =~ "Application.get_env(:test, Test.MyRobot, [])"
   end
 
   test "can add multiple robots" do

--- a/test/mix/tasks/bb.install_test.exs
+++ b/test/mix/tasks/bb.install_test.exs
@@ -43,7 +43,9 @@ defmodule Mix.Tasks.Bb.InstallTest do
     assert_creates(igniter, "lib/test/application.ex")
 
     {_, source} = Rewrite.source(igniter.rewrite, "lib/test/application.ex")
-    assert source.content =~ "{Test.Robot, []}"
+    assert source.content =~ "{Test.Robot, robot_opts()}"
+    assert source.content =~ "defp robot_opts do"
+    assert source.content =~ "Application.get_env(:test, Test.Robot, [])"
   end
 
   test "adds bb to formatter imports" do


### PR DESCRIPTION
## What

`bb.add_robot` now generates the robot's child spec as `{Robot, robot_opts()}` and injects a private `robot_opts/0` helper into `application.ex`:

```elixir
defp robot_opts do
  if System.get_env("SIMULATE") do
    [simulation: :kinematic]
  else
    Application.get_env(:my_robot, MyRobot.Robot, [])
  end
end
```

## Why

Previously the robot was wired in as `{Robot, []}`, so a generated project always booted in hardware mode with no ergonomic way to switch to simulation or pass startup options — you had to hand-edit `application.ex`. With the helper:

- `SIMULATE=1 iex -S mix` boots straight into kinematic simulation.
- Startup options come from `config :my_robot, MyRobot.Robot, ...`.

This is the same pattern `bb_so101` used to add as a post-processing step (`lift_robot_opts_to_function/2`). Moving it into `bb.add_robot` means every `bb.install` project gets it, and `bb_so101` can drop its post-processing (separate PR, after a `bb` release).

## Docs

The tutorials were instructing readers to start a robot the installer had already supervised, so the `start_link` calls returned `{:error, {:already_started, _}}` under `iex -S mix`. This PR also fixes the startup/simulation narrative across tutorials 02–10:

- **02** shows the real generated `robot_opts/0`.
- **07** passes startup params via `config :my_robot, MyRobot.Robot, params: [...]`.
- **10** runs simulation via `SIMULATE=1 iex -S mix`, with per-environment selection via config.
- **03/04/05/08/09** use the already-running robot instead of re-starting it.

Originally surfaced by a new user following the getting-started tutorial.

## Verification

- `mix compile --warnings-as-errors` clean.
- `bb.add_robot` / `bb.install` task tests updated and passing (10/10).
- Verified end-to-end against `bb_so101` with `BB_VERSION=local`: its installer (with the post-processing removed) produces the correct `application.ex` and all 17 install tests pass.

## Follow-up

After this is released, bump `bb_so101`'s `bb` constraint to the release containing this change and remove its `lift_robot_opts_to_function/2`.