### PR TITLE
feat: add shared BB.Error.Invalid.Bridge.* error modules

### DIFF
--- a/lib/bb/error/invalid/bridge.ex
+++ b/lib/bb/error/invalid/bridge.ex
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Invalid.Bridge do
+  @moduledoc """
+  Parameter-bridge validation errors.
+
+  These errors are raised by `BB.Bridge` implementations when a parameter
+  read or write is rejected — an unknown or read-only parameter, a malformed
+  parameter id, or an attempt to modify a parameter while torque is enabled.
+
+  They live in `bb` core so every bridge driver shares one set of error
+  modules rather than each redefining them in the `BB.Error.*` namespace.
+  """
+end

--- a/lib/bb/error/invalid/bridge/invalid_param_id.ex
+++ b/lib/bb/error/invalid/bridge/invalid_param_id.ex
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Invalid.Bridge.InvalidParamId do
+  @moduledoc """
+  Invalid parameter ID format for bridge parameter.
+
+  The parameter ID must be in the format `"servo_id:param_name"` where
+  `servo_id` is an integer between 1 and 253.
+  """
+  use BB.Error,
+    class: :invalid,
+    fields: [:param_id]
+
+  @type t :: %__MODULE__{
+          param_id: term()
+        }
+
+  defimpl BB.Error.Severity do
+    def severity(_), do: :error
+  end
+
+  def message(%{param_id: param_id}) do
+    "Invalid parameter ID format: #{inspect(param_id)}. " <>
+      "Expected format: \"servo_id:param_name\" (e.g., \"1:position_p_gain\")"
+  end
+end

--- a/lib/bb/error/invalid/bridge/read_only.ex
+++ b/lib/bb/error/invalid/bridge/read_only.ex
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Invalid.Bridge.ReadOnly do
+  @moduledoc """
+  Attempted to write to a read-only parameter.
+
+  Some servo parameters (like model number, firmware version) are read-only
+  and cannot be modified.
+  """
+  use BB.Error,
+    class: :invalid,
+    fields: [:param_name]
+
+  @type t :: %__MODULE__{
+          param_name: atom()
+        }
+
+  defimpl BB.Error.Severity do
+    def severity(_), do: :error
+  end
+
+  def message(%{param_name: param_name}) do
+    "Cannot write to read-only parameter: #{inspect(param_name)}"
+  end
+end

--- a/lib/bb/error/invalid/bridge/torque_must_be_disabled.ex
+++ b/lib/bb/error/invalid/bridge/torque_must_be_disabled.ex
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Invalid.Bridge.TorqueMustBeDisabled do
+  @moduledoc """
+  Parameter modification requires torque to be disabled.
+
+  EEPROM parameters in serial bus servos can only be modified when torque
+  is disabled. Disable torque before modifying this parameter.
+  """
+  use BB.Error,
+    class: :invalid,
+    fields: [:param_name, :servo_id]
+
+  @type t :: %__MODULE__{
+          param_name: atom(),
+          servo_id: non_neg_integer() | nil
+        }
+
+  defimpl BB.Error.Severity do
+    def severity(_), do: :error
+  end
+
+  def message(%{param_name: param_name, servo_id: nil}) do
+    "Parameter #{inspect(param_name)} requires torque to be disabled before modification"
+  end
+
+  def message(%{param_name: param_name, servo_id: servo_id}) do
+    "Parameter #{inspect(param_name)} on servo #{servo_id} requires torque to be disabled before modification"
+  end
+end

--- a/lib/bb/error/invalid/bridge/unknown_param.ex
+++ b/lib/bb/error/invalid/bridge/unknown_param.ex
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Invalid.Bridge.UnknownParam do
+  @moduledoc """
+  Unknown parameter name for bridge parameter.
+
+  The parameter name is not defined in the servo's control table.
+  """
+  use BB.Error,
+    class: :invalid,
+    fields: [:param_name, :control_table]
+
+  @type t :: %__MODULE__{
+          param_name: atom(),
+          control_table: module() | nil
+        }
+
+  defimpl BB.Error.Severity do
+    def severity(_), do: :error
+  end
+
+  def message(%{param_name: param_name, control_table: nil}) do
+    "Unknown parameter: #{inspect(param_name)}"
+  end
+
+  def message(%{param_name: param_name, control_table: control_table}) do
+    "Unknown parameter: #{inspect(param_name)} not found in #{inspect(control_table)}"
+  end
+end

--- a/test/bb/error/invalid/bridge_test.exs
+++ b/test/bb/error/invalid/bridge_test.exs
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Invalid.BridgeTest do
+  use ExUnit.Case, async: true
+
+  alias BB.Error.Invalid.Bridge.InvalidParamId
+  alias BB.Error.Invalid.Bridge.ReadOnly
+  alias BB.Error.Invalid.Bridge.TorqueMustBeDisabled
+  alias BB.Error.Invalid.Bridge.UnknownParam
+
+  describe "InvalidParamId" do
+    test "carries the offending param_id and is an error" do
+      err = InvalidParamId.exception(param_id: "nope")
+      assert err.param_id == "nope"
+      assert BB.Error.severity(err) == :error
+    end
+
+    test "message describes the expected format" do
+      message = InvalidParamId.message(InvalidParamId.exception(param_id: "nope"))
+      assert message =~ "\"nope\""
+      assert message =~ "servo_id:param_name"
+    end
+  end
+
+  describe "ReadOnly" do
+    test "carries the param_name and is an error" do
+      err = ReadOnly.exception(param_name: :firmware_version)
+      assert err.param_name == :firmware_version
+      assert BB.Error.severity(err) == :error
+    end
+
+    test "message names the parameter" do
+      message = ReadOnly.message(ReadOnly.exception(param_name: :firmware_version))
+      assert message =~ ":firmware_version"
+    end
+  end
+
+  describe "TorqueMustBeDisabled" do
+    test "carries param_name and servo_id and is an error" do
+      err = TorqueMustBeDisabled.exception(param_name: :max_torque, servo_id: 3)
+      assert err.param_name == :max_torque
+      assert err.servo_id == 3
+      assert BB.Error.severity(err) == :error
+    end
+
+    test "message includes the servo when present" do
+      message =
+        TorqueMustBeDisabled.message(
+          TorqueMustBeDisabled.exception(param_name: :max_torque, servo_id: 3)
+        )
+
+      assert message =~ ":max_torque"
+      assert message =~ "servo 3"
+    end
+
+    test "message omits the servo when nil" do
+      message =
+        TorqueMustBeDisabled.message(
+          TorqueMustBeDisabled.exception(param_name: :max_torque, servo_id: nil)
+        )
+
+      assert message =~ ":max_torque"
+      refute message =~ "servo"
+    end
+  end
+
+  describe "UnknownParam" do
+    test "carries param_name and control_table and is an error" do
+      err = UnknownParam.exception(param_name: :bogus, control_table: SomeTable)
+      assert err.param_name == :bogus
+      assert err.control_table == SomeTable
+      assert BB.Error.severity(err) == :error
+    end
+
+    test "message includes the control table when present" do
+      message =
+        UnknownParam.message(UnknownParam.exception(param_name: :bogus, control_table: SomeTable))
+
+      assert message =~ ":bogus"
+      assert message =~ "SomeTable"
+    end
+
+    test "message omits the control table when nil" do
+      message =
+        UnknownParam.message(UnknownParam.exception(param_name: :bogus, control_table: nil))
+
+      assert message =~ ":bogus"
+      refute message =~ "not found"
+    end
+  end
+end


### PR DESCRIPTION
Addresses #145 (the core half).

## Problem

`bb_servo_feetech` and `bb_servo_robotis` each define the same four fully-qualified error modules in the `BB.Error.*` namespace, which `bb` core owns:

- `BB.Error.Invalid.Bridge.InvalidParamId`
- `BB.Error.Invalid.Bridge.ReadOnly`
- `BB.Error.Invalid.Bridge.TorqueMustBeDisabled`
- `BB.Error.Invalid.Bridge.UnknownParam`

The definitions are identical apart from copyright year and a couple of words of doc wording. In a mixed-hardware robot (Feetech bus + Dynamixel bus) both deps load into one application; the BEAM keeps whichever compiles last, emits a "redefining module" warning, and silently discards the other — making any doc-string-sensitive match load-order dependent.

## Change

Move the canonical definitions into `bb` core (issue option 1):

- Adds the four modules under `lib/bb/error/invalid/bridge/`, byte-equivalent to the drivers' versions with hardware-neutral doc wording (no Feetech/Dynamixel specifics). Fields and `message/1` output are unchanged, so they're drop-in for the existing `alias BB.Error.Invalid.Bridge.*` usages.
- Adds a `BB.Error.Invalid.Bridge` namespace module, matching the existing `BB.Error.Hardware` / `BB.Error.Invalid` namespace-module pattern.
- Adds `test/bb/error/invalid/bridge_test.exs` covering fields, severity, and message formatting for each.

No registry wiring is needed — `use BB.Error` (→ `use Splode.Error, class: :invalid`) is self-contained.

## Follow-up

Once this is released to hex, `bb_servo_feetech` and `bb_servo_robotis` will delete their local copies (their `bridge.ex` / `bridge_test.exs` already reference these by full name via `alias`, so no other changes). That's what actually removes the collision; this PR is the prerequisite.

`mix check --no-retry` passes locally (compiler, credo, dialyzer, ex_doc, ex_unit, formatter, mix_audit, reuse, spark_formatter, spark_cheat_sheets, unused_deps).