### PR TITLE
feat(controller): add handle_safety_state_change safety hook to BB.Controller

### DIFF
--- a/lib/bb/controller.ex
+++ b/lib/bb/controller.ex
@@ -176,6 +176,43 @@ defmodule BB.Controller do
               | {:stop, reason :: term(), new_state :: term()}
 
   @doc """
+  Handle safety state changes.
+
+  Called when the robot's safety state transitions to `:disarming`, `:disarmed`,
+  or `:error`.
+
+  Unlike a `BB.Command` (which is short-lived and stops on disarm), a controller
+  is **long-lived**: the default implementation returns `{:continue, state}` so
+  the controller keeps running across arm/disarm cycles.
+
+  Because the controller keeps running, it is responsible for **gating its own
+  output** while the robot is not armed — it must stop publishing actuator
+  commands so the downstream floor sees command-silence and reaches its safe
+  state. This is the §05 "disarm = command-silence" contract: the controller is
+  the thing that has to produce the silence.
+
+  The default `{:continue, state}` does **not** itself stop output — it only
+  keeps the controller alive. The framework cannot know what "stop output" means
+  for an arbitrary controller, so it simply notifies the controller and lets the
+  controller decide. A controller that wants to be disarm-safe should override
+  this callback (for example, to set a flag in its state that its control loop
+  checks before publishing):
+
+      @impl BB.Controller
+      def handle_safety_state_change(_new_state, state) do
+        {:continue, %{state | armed?: false}}
+      end
+
+  Return `{:stop, reason, state}` to shut the controller down instead.
+  """
+  @callback handle_safety_state_change(
+              new_state :: :disarming | :disarmed | :error,
+              state :: term()
+            ) ::
+              {:continue, new_state :: term()}
+              | {:stop, reason :: term(), new_state :: term()}
+
+  @doc """
   Clean up before termination.
 
   Same semantics as `c:GenServer.terminate/2`.
@@ -194,6 +231,7 @@ defmodule BB.Controller do
   @optional_callbacks [
     disarm: 1,
     handle_options: 2,
+    handle_safety_state_change: 2,
     handle_call: 3,
     handle_cast: 2,
     handle_info: 2,
@@ -214,6 +252,11 @@ defmodule BB.Controller do
       @impl BB.Controller
       def handle_options(_new_opts, state), do: {:ok, state}
 
+      # Controllers are long-lived: the default keeps running across disarm.
+      # Override to gate output (stop publishing) or to stop the controller.
+      @impl BB.Controller
+      def handle_safety_state_change(_new_state, state), do: {:continue, state}
+
       @impl BB.Controller
       def handle_call(_request, _from, state), do: {:reply, {:error, :not_implemented}, state}
 
@@ -230,6 +273,7 @@ defmodule BB.Controller do
       def terminate(_reason, _state), do: :ok
 
       defoverridable handle_options: 2,
+                     handle_safety_state_change: 2,
                      handle_call: 3,
                      handle_cast: 2,
                      handle_info: 2,

--- a/lib/bb/controller/server.ex
+++ b/lib/bb/controller/server.ex
@@ -20,7 +20,9 @@ defmodule BB.Controller.Server do
 
   alias BB.Component.OptionsSchema
   alias BB.Parameter.Changed, as: ParameterChanged
+  alias BB.PubSub
   alias BB.Server.ParamResolution
+  alias BB.StateMachine.Transition
 
   @framework_keys [:bb]
 
@@ -58,6 +60,11 @@ defmodule BB.Controller.Server do
     raw_opts = Keyword.delete(init_arg, :__callback_module__)
     bb = Keyword.fetch!(raw_opts, :bb)
 
+    # Subscribe to safety state changes so the controller can gate its output
+    # when the robot disarms (controllers are long-lived; see
+    # BB.Controller.handle_safety_state_change/2).
+    PubSub.subscribe(bb.robot, [:state_machine])
+
     {param_subscriptions, resolved_opts} =
       ParamResolution.resolve_and_subscribe(raw_opts, bb.robot)
 
@@ -91,6 +98,17 @@ defmodule BB.Controller.Server do
   end
 
   @impl GenServer
+  def handle_info({:bb, [:state_machine], %{payload: %Transition{to: new_safety_state}}}, state)
+      when new_safety_state in [:disarming, :disarmed, :error] do
+    case state.callback_module.handle_safety_state_change(new_safety_state, state.user_state) do
+      {:continue, new_user_state} ->
+        {:noreply, %{state | user_state: new_user_state}}
+
+      {:stop, reason, new_user_state} ->
+        {:stop, reason, %{state | user_state: new_user_state}}
+    end
+  end
+
   def handle_info({:bb, [:param | param_path], %{payload: %ParameterChanged{}}}, state) do
     case ParamResolution.handle_change(
            param_path,

--- a/test/bb/safety/controller_safety_state_test.exs
+++ b/test/bb/safety/controller_safety_state_test.exs
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Safety.ControllerSafetyStateTest do
+  @moduledoc """
+  Tests for the `handle_safety_state_change/2` hook on `BB.Controller`.
+
+  Unlike a `BB.Command` (short-lived, stops on disarm), a controller is
+  long-lived: the default keeps it running across arm/disarm so it can gate its
+  own output (command-silence) rather than be killed.
+
+  These tests run synchronously because they drive the global safety state
+  machine via `BB.Safety.arm/1` and `BB.Safety.disarm/1`.
+  """
+  use ExUnit.Case, async: false
+
+  alias BB.Process, as: BBProcess
+
+  # A controller that uses the DEFAULT handle_safety_state_change/2 (i.e. it does
+  # not override it). The default must return {:continue, state} so the
+  # controller stays alive through disarm.
+  defmodule DefaultController do
+    @moduledoc false
+    use BB.Controller, options_schema: []
+
+    @impl BB.Controller
+    def init(opts) do
+      {:ok, %{bb: opts[:bb]}}
+    end
+
+    @impl BB.Controller
+    def handle_call(:get_state, _from, state) do
+      {:reply, state, state}
+    end
+  end
+
+  # The registered name the OverridingController notifies on a safety change.
+  @notify_name :bb_controller_safety_state_test_notify
+
+  # A controller that OVERRIDES handle_safety_state_change/2 to record the
+  # callback firing (by sending to a registered test process) and to flip an
+  # `armed?` flag in its state — the disarm-safe pattern of gating its own
+  # output.
+  defmodule OverridingController do
+    @moduledoc false
+    use BB.Controller, options_schema: []
+
+    @notify_name :bb_controller_safety_state_test_notify
+
+    @impl BB.Controller
+    def init(opts) do
+      {:ok, %{bb: opts[:bb], armed?: true, last_safety_state: nil}}
+    end
+
+    @impl BB.Controller
+    def handle_safety_state_change(new_state, state) do
+      case Process.whereis(@notify_name) do
+        nil -> :ok
+        pid -> send(pid, {:safety_state_change, new_state})
+      end
+
+      {:continue, %{state | armed?: false, last_safety_state: new_state}}
+    end
+
+    @impl BB.Controller
+    def handle_call(:get_state, _from, state) do
+      {:reply, state, state}
+    end
+  end
+
+  # A controller that OVERRIDES the hook to STOP itself on disarm, proving the
+  # {:stop, reason, state} return path is honoured by the server.
+  defmodule StoppingController do
+    @moduledoc false
+    use BB.Controller, options_schema: []
+
+    @impl BB.Controller
+    def init(opts) do
+      {:ok, %{bb: opts[:bb]}}
+    end
+
+    @impl BB.Controller
+    def handle_safety_state_change(_new_state, state) do
+      {:stop, :disarmed, state}
+    end
+  end
+
+  defmodule DefaultControllerRobot do
+    @moduledoc false
+    use BB
+
+    controllers do
+      controller(:driver, BB.Safety.ControllerSafetyStateTest.DefaultController)
+    end
+
+    topology do
+      link :base_link do
+      end
+    end
+  end
+
+  defmodule OverridingControllerRobot do
+    @moduledoc false
+    use BB
+
+    controllers do
+      controller(:driver, BB.Safety.ControllerSafetyStateTest.OverridingController)
+    end
+
+    topology do
+      link :base_link do
+      end
+    end
+  end
+
+  defmodule StoppingControllerRobot do
+    @moduledoc false
+    use BB
+
+    controllers do
+      controller(:driver, BB.Safety.ControllerSafetyStateTest.StoppingController)
+    end
+
+    topology do
+      link :base_link do
+      end
+    end
+  end
+
+  describe "default handle_safety_state_change/2" do
+    test "controller stays alive across disarm (default returns {:continue})" do
+      start_supervised!(DefaultControllerRobot)
+
+      controller_pid = BBProcess.whereis(DefaultControllerRobot, :driver)
+      assert is_pid(controller_pid)
+      assert Process.alive?(controller_pid)
+
+      :ok = BB.Safety.arm(DefaultControllerRobot)
+      :ok = BB.Safety.disarm(DefaultControllerRobot)
+
+      # Give the async safety-state message time to be delivered and handled.
+      Process.sleep(50)
+
+      # Same pid, still alive: the default did not stop the controller.
+      assert BBProcess.whereis(DefaultControllerRobot, :driver) == controller_pid
+      assert Process.alive?(controller_pid)
+      assert match?(%{bb: _}, GenServer.call(controller_pid, :get_state))
+    end
+  end
+
+  describe "overridden handle_safety_state_change/2" do
+    test "override is invoked with the new safety state and can update state" do
+      # The overriding controller notifies a process registered under a known
+      # name; register this test process so we observe the callback firing.
+      Process.register(self(), @notify_name)
+      on_exit(fn -> safe_unregister(@notify_name) end)
+
+      start_supervised!(OverridingControllerRobot)
+
+      controller_pid = BBProcess.whereis(OverridingControllerRobot, :driver)
+      assert is_pid(controller_pid)
+
+      :ok = BB.Safety.arm(OverridingControllerRobot)
+      :ok = BB.Safety.disarm(OverridingControllerRobot)
+
+      # Disarm walks armed -> disarming -> disarmed, so the hook fires for the
+      # disarming transition first.
+      assert_receive {:safety_state_change, :disarming}, 1_000
+
+      # Controller is still alive (override returned {:continue}) and recorded
+      # the disarm by flipping its armed? flag.
+      assert Process.alive?(controller_pid)
+      state = GenServer.call(controller_pid, :get_state)
+      assert state.armed? == false
+      assert state.last_safety_state in [:disarming, :disarmed]
+    end
+
+    test "override returning {:stop, reason, state} stops the controller" do
+      Process.flag(:trap_exit, true)
+
+      start_supervised!(StoppingControllerRobot)
+
+      controller_pid = BBProcess.whereis(StoppingControllerRobot, :driver)
+      assert is_pid(controller_pid)
+
+      ref = Process.monitor(controller_pid)
+
+      :ok = BB.Safety.arm(StoppingControllerRobot)
+      :ok = BB.Safety.disarm(StoppingControllerRobot)
+
+      assert_receive {:DOWN, ^ref, :process, ^controller_pid, :disarmed}, 1_000
+    end
+  end
+
+  defp safe_unregister(name) do
+    Process.unregister(name)
+  rescue
+    ArgumentError -> :ok
+  end
+end


### PR DESCRIPTION
## Problem

`BB.Command` already reacts to safety-state transitions — its server subscribes to `[:state_machine]`, dispatches `handle_safety_state_change/2`, and default-stops on disarm. **`BB.Controller` has no equivalent.**

So a long-lived controller that publishes actuator commands every tick keeps publishing straight through a disarm. The robot's safety state flips to `:disarmed`, but the control loop never knows — it keeps commanding the actuators, which (on a hub framework with a dead-man/floor safe-state) keeps the floor *armed* because it never sees command-silence. **The disarm doesn't actually stop the actuators.**

This is especially fatal for a self-balancing robot, whose controller *must* keep commanding to stay upright — it will never fall silent on its own, so disarm is defeated by design.

## Fix

Add the same `handle_safety_state_change/2` hook to `BB.Controller`, mirroring `BB.Command` — but with the **controller-correct default**.

A `BB.Command` is short-lived, so its default is to **stop**. A `BB.Controller` is **long-lived**, so stopping/restarting it on every arm/disarm cycle would be wrong. The default here is `{:continue, state}` — the controller keeps running and is responsible for **gating its own output** (stop publishing commands) while not armed, so the downstream floor sees command-silence and reaches its safe state.

The framework only *notifies* the controller — it can't know what "stop output" means for an arbitrary controller. A controller that wants to be disarm-safe overrides the callback (typically to set an `armed?` flag its loop checks before publishing), or returns `{:stop, reason, state}` to shut down.

## What changed

- `lib/bb/controller.ex` — the `@callback`, added to `@optional_callbacks` + `defoverridable`, and a `__using__` default of `{:continue, state}` with docs explaining the long-lived / gate-your-own-output contract.
- `lib/bb/controller/server.ex` — subscribe to `[:state_machine]` in `init`, dispatch the callback on `:disarming`/`:disarmed`/`:error` (other transitions fall through), mapping `{:continue}`/`{:stop}` like `BB.Command.Server`.
- 3 integration tests (default-continue, override-invoked, stop-path).

`BB.Command` is untouched. Full suite green (1069 tests).
