### PR TITLE
improvement: express forward kinematics as a single `defn` (#147)

### DIFF
--- a/lib/bb/math/vec3.ex
+++ b/lib/bb/math/vec3.ex
@@ -165,7 +165,7 @@ defmodule BB.Math.Vec3 do
   """
   @spec scale(t(), number()) :: t()
   def scale(%__MODULE__{tensor: t}, scalar) do
-    %__MODULE__{tensor: Nx.multiply(t, scalar)}
+    %__MODULE__{tensor: Nx.multiply(t, Nx.tensor(scalar, type: :f64))}
   end
 
   @doc """
@@ -300,9 +300,11 @@ defmodule BB.Math.Vec3 do
   @spec lerp(t(), t(), number()) :: t()
   def lerp(%__MODULE__{tensor: a}, %__MODULE__{tensor: b}, t) do
     # lerp(a, b, t) = a + t * (b - a) = a * (1 - t) + b * t
+    t = Nx.tensor(t, type: :f64)
+
     result =
       Nx.add(
-        Nx.multiply(a, 1 - t),
+        Nx.multiply(a, Nx.subtract(1, t)),
         Nx.multiply(b, t)
       )
 

--- a/lib/bb/robot/kinematics.ex
+++ b/lib/bb/robot/kinematics.ex
@@ -36,6 +36,7 @@ defmodule BB.Robot.Kinematics do
   alias BB.Math.Transform
   alias BB.Math.Vec3
   alias BB.Robot
+  alias BB.Robot.Kinematics.Defn
   alias BB.Robot.State
 
   @doc """
@@ -168,11 +169,46 @@ defmodule BB.Robot.Kinematics do
   defp tuple_to_vec3({x, y, z}), do: Vec3.new(x, y, z)
 
   defp compute_chain_transform(%Robot{} = robot, positions, path) do
-    path
-    |> Enum.filter(&Map.has_key?(robot.joints, &1))
-    |> Enum.reduce(Transform.identity(), fn joint_name, acc ->
-      joint_transform = compute_joint_transform(robot, positions, joint_name)
-      Transform.compose(acc, joint_transform)
-    end)
+    case Enum.filter(path, &Map.has_key?(robot.joints, &1)) do
+      [] ->
+        Transform.identity()
+
+      joint_names ->
+        joints = Enum.map(joint_names, &Map.fetch!(robot.joints, &1))
+
+        Defn.fk_chain(
+          chain_positions(positions, joint_names),
+          rows(joints, &origin_rpy(&1.origin)),
+          rows(joints, &origin_xyz(&1.origin)),
+          rows(joints, &axis_row(&1.axis)),
+          column(joints, &revolute_mask/1),
+          column(joints, &prismatic_mask/1)
+        )
+        |> Transform.from_tensor()
+    end
   end
+
+  defp chain_positions(positions, joint_names) do
+    joint_names
+    |> Enum.map(&(Map.get(positions, &1, 0.0) * 1.0))
+    |> Nx.tensor(type: :f64)
+  end
+
+  defp rows(joints, fun), do: joints |> Enum.map(fun) |> Nx.tensor(type: :f64)
+  defp column(joints, fun), do: joints |> Enum.map(fun) |> Nx.tensor(type: :f64)
+
+  defp origin_rpy(%{orientation: {roll, pitch, yaw}}), do: [roll, pitch, yaw]
+  defp origin_rpy(_), do: [0.0, 0.0, 0.0]
+
+  defp origin_xyz(%{position: {x, y, z}}), do: [x, y, z]
+  defp origin_xyz(_), do: [0.0, 0.0, 0.0]
+
+  defp axis_row({x, y, z}), do: [x, y, z]
+  defp axis_row(_), do: [0.0, 0.0, 1.0]
+
+  defp revolute_mask(%{type: type}) when type in [:revolute, :continuous], do: 1.0
+  defp revolute_mask(_), do: 0.0
+
+  defp prismatic_mask(%{type: :prismatic}), do: 1.0
+  defp prismatic_mask(_), do: 0.0
 end

--- a/lib/bb/robot/kinematics/defn.ex
+++ b/lib/bb/robot/kinematics/defn.ex
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Robot.Kinematics.Defn do
+  @moduledoc """
+  Forward kinematics expressed as a single composable `defn`.
+
+  `BB.Robot.Kinematics` packs a chain's static structure (joint origins, axes
+  and types) into plain tensors once, then calls `fk_chain/6` to walk the chain
+  in one fused computation rather than dozens of eager per-op `BB.Math` calls.
+
+  Keeping the whole chain walk in `defn` is the point of beam-bots/bb#147: the
+  computation can be JIT-compiled and, with a leading batch axis on the inputs,
+  vectorised across many joint configurations or many targets at once.
+
+  ## Tensor layout
+
+  For a chain of `n` joints (root-most first), all inputs are `:f64`:
+
+  - `positions` — `{n}` joint positions (radians for revolute, metres for prismatic)
+  - `origin_rpy` — `{n, 3}` per-joint origin orientation as `{roll, pitch, yaw}`
+  - `origin_xyz` — `{n, 3}` per-joint origin translation
+  - `axes` — `{n, 3}` per-joint motion axis (unit vector)
+  - `is_revolute` — `{n}` `1.0` for revolute/continuous joints, else `0.0`
+  - `is_prismatic` — `{n}` `1.0` for prismatic joints, else `0.0`
+
+  The result is the `{4, 4}` base-to-tip homogeneous transform. The per-joint
+  transform reproduces `BB.Math.Transform.from_origin/1` composed with the
+  motion transform: `origin = Rx · Ry · Rz · T(xyz)` and the motion is a
+  Rodrigues rotation about `axis` (revolute) or a translation along `axis`
+  (prismatic). Fixed/floating/planar joints carry both masks at `0.0`, leaving
+  an identity motion.
+  """
+
+  import Nx.Defn
+
+  @doc """
+  Walk a kinematic chain, returning the `{4, 4}` base-to-tip transform.
+
+  See the module documentation for the tensor layout.
+  """
+  defn fk_chain(positions, origin_rpy, origin_xyz, axes, is_revolute, is_prismatic) do
+    origins = build_origins(origin_rpy, origin_xyz)
+    motions = build_motions(positions, axes, is_revolute, is_prismatic)
+    chain_product(batched_matmul(origins, motions))
+  end
+
+  defnp build_origins(rpy, xyz) do
+    roll = rpy[[.., 0]]
+    pitch = rpy[[.., 1]]
+    yaw = rpy[[.., 2]]
+
+    rotation =
+      batched_matmul(batched_matmul(rotation_x(roll), rotation_y(pitch)), rotation_z(yaw))
+
+    translation = batched_matvec(rotation, xyz)
+
+    homogeneous(rotation, translation)
+  end
+
+  defnp build_motions(positions, axes, is_revolute, is_prismatic) do
+    angle = positions * is_revolute
+    distance = positions * is_prismatic
+
+    rotation = rodrigues(axes, angle)
+    translation = axes * Nx.new_axis(distance, 1)
+
+    homogeneous(rotation, translation)
+  end
+
+  defnp rotation_x(angle) do
+    c = Nx.cos(angle)
+    s = Nx.sin(angle)
+    z = angle * 0.0
+    o = z + 1.0
+
+    stack3(
+      o,
+      z,
+      z,
+      z,
+      c,
+      -s,
+      z,
+      s,
+      c
+    )
+  end
+
+  defnp rotation_y(angle) do
+    c = Nx.cos(angle)
+    s = Nx.sin(angle)
+    z = angle * 0.0
+    o = z + 1.0
+
+    stack3(
+      c,
+      z,
+      s,
+      z,
+      o,
+      z,
+      -s,
+      z,
+      c
+    )
+  end
+
+  defnp rotation_z(angle) do
+    c = Nx.cos(angle)
+    s = Nx.sin(angle)
+    z = angle * 0.0
+    o = z + 1.0
+
+    stack3(
+      c,
+      -s,
+      z,
+      s,
+      c,
+      z,
+      z,
+      z,
+      o
+    )
+  end
+
+  defnp rodrigues(axes, angle) do
+    ax = axes[[.., 0]]
+    ay = axes[[.., 1]]
+    az = axes[[.., 2]]
+
+    c = Nx.cos(angle)
+    s = Nx.sin(angle)
+    t = 1.0 - c
+
+    stack3(
+      t * ax * ax + c,
+      t * ax * ay - s * az,
+      t * ax * az + s * ay,
+      t * ax * ay + s * az,
+      t * ay * ay + c,
+      t * ay * az - s * ax,
+      t * ax * az - s * ay,
+      t * ay * az + s * ax,
+      t * az * az + c
+    )
+  end
+
+  defnp stack3(m00, m01, m02, m10, m11, m12, m20, m21, m22) do
+    Nx.stack(
+      [
+        Nx.stack([m00, m01, m02], axis: 1),
+        Nx.stack([m10, m11, m12], axis: 1),
+        Nx.stack([m20, m21, m22], axis: 1)
+      ],
+      axis: 1
+    )
+  end
+
+  defnp homogeneous(rotation, translation) do
+    n = Nx.axis_size(rotation, 0)
+
+    top = Nx.concatenate([rotation, Nx.new_axis(translation, 2)], axis: 2)
+    bottom = Nx.broadcast(Nx.tensor([0.0, 0.0, 0.0, 1.0], type: :f64), {n, 1, 4})
+
+    Nx.concatenate([top, bottom], axis: 1)
+  end
+
+  defnp batched_matmul(a, b) do
+    Nx.dot(a, [2], [0], b, [1], [0])
+  end
+
+  defnp batched_matvec(matrices, vectors) do
+    Nx.dot(matrices, [2], [0], vectors, [1], [0])
+  end
+
+  defnp chain_product(mats) do
+    n = Nx.axis_size(mats, 0)
+
+    {result, _mats, _i} =
+      while {acc = Nx.eye(4, type: :f64), m = mats, i = 0}, i < n do
+        {Nx.dot(acc, m[i]), m, i + 1}
+      end
+
+    result
+  end
+end

--- a/test/bb/math/vec3_test.exs
+++ b/test/bb/math/vec3_test.exs
@@ -92,6 +92,13 @@ defmodule BB.Math.Vec3Test do
 
       assert Vec3.to_list(s) == [-1.0, -2.0, -3.0]
     end
+
+    test "keeps f64 precision for scalars not representable in f32" do
+      v = Vec3.new(0.0, 0.0, 1.0)
+      s = Vec3.scale(v, 0.15)
+
+      assert Vec3.z(s) == 0.15
+    end
   end
 
   describe "dot/2" do

--- a/test/bb/robot/kinematics_test.exs
+++ b/test/bb/robot/kinematics_test.exs
@@ -455,4 +455,52 @@ defmodule BB.Robot.KinematicsTest do
       assert_in_delta z, -2.0, 0.0001
     end
   end
+
+  describe "defn chain matches eager joint composition" do
+    # `forward_kinematics/3` runs the chain through `BB.Robot.Kinematics.Defn`.
+    # This pins it against the eager per-joint composition it replaced, so the
+    # two cannot silently diverge.
+    cases = [
+      {BB.ExampleRobots.SixDofArm, :tool0,
+       %{
+         shoulder_pan_joint: 0.3,
+         shoulder_lift_joint: -0.5,
+         elbow_joint: 0.8,
+         wrist_1_joint: -0.4,
+         wrist_2_joint: 0.6,
+         wrist_3_joint: 0.2
+       }},
+      {BB.ExampleRobots.PanTiltCamera, :camera_link, %{pan_joint: 0.4, tilt_joint: -0.6}},
+      {BB.ExampleRobots.LinearActuator, :slider_link, %{slider_joint: 0.15}},
+      {BB.ExampleRobots.CollisionTestArm, :forearm, %{shoulder: 0.7, elbow: -0.9}}
+    ]
+
+    for {module, target, positions} <- cases do
+      test "#{inspect(module)} -> #{target}" do
+        robot = unquote(module).robot()
+        positions = unquote(Macro.escape(positions))
+
+        actual =
+          Transform.tensor(Kinematics.forward_kinematics(robot, positions, unquote(target)))
+
+        expected = Transform.tensor(reference_chain(robot, positions, unquote(target)))
+
+        for i <- 0..3, j <- 0..3 do
+          assert_in_delta Nx.to_number(actual[i][j]),
+                          Nx.to_number(expected[i][j]),
+                          1.0e-9,
+                          "mismatch at [#{i}][#{j}]"
+        end
+      end
+    end
+  end
+
+  defp reference_chain(robot, positions, target_link) do
+    robot
+    |> BB.Robot.path_to(target_link)
+    |> Enum.filter(&Map.has_key?(robot.joints, &1))
+    |> Enum.reduce(Transform.identity(), fn joint_name, acc ->
+      Transform.compose(acc, Kinematics.compute_joint_transform(robot, positions, joint_name))
+    end)
+  end
 end


### PR DESCRIPTION
Phase 2 of #147. **Stacked on #161** (base is `feature/147-math-defn-core`) — review/merge that first; this diff is against it.

## What this does

`forward_kinematics/3` now runs the chain through one composable `defn`, `BB.Robot.Kinematics.Defn.fk_chain/6`, instead of dozens of eager per-op `BB.Math` calls.

- `Kinematics` packs the chain's **static** structure (origin rpy/xyz, axes, revolute/prismatic masks) into plain tensors from Elixir — no eager `Nx` dispatch — keyed off the compile-time `Robot` struct.
- The `defn` does the whole walk in one fused computation: builds each joint's origin (`Rx·Ry·Rz·T`, exactly matching `Transform.from_origin/1`), the motion transform (branchless Rodrigues for revolute / axis translation for prismatic, masks select), composes `origin·motion` batched over the chain, and folds the chain product via `Nx.while`.

## Why (and the honest perf story)

This is the composable building block #147 is after — it can be JIT-compiled and vectorised over a leading batch axis (batched FK, multi-target solves, Jacobian via `Nx.Defn.grad`).

**On the default `Nx.Defn.Evaluator` backend, single-shot FK is at parity** (~4% slower in an apples-to-apples bench — the interpreted `while`/`gather`/`concatenate` graph is marginally heavier than the eager chain). No single-shot speedup; the payoff lands in batched/compiled work, exactly the trade-off the issue accepts. The kernel is also *more accurate* than the path it replaces (f64 throughout).

## Scope

- Single-chain only. `all_link_transforms/2` (tree walk, used by collision) stays eager — unifying it (prefix products over the tree) is the next increment. This temporarily duplicates the joint-transform math across the two paths; the differential test guards against drift.

## Latent f32 bug fixed along the way

While differential-testing I found `Vec3.scale/2` (and `lerp/3`) round bare float scalars to f32 before promoting to f64 — so `0.15` became `0.15000000596…`. This contaminated the eager prismatic path (`translation_along/2`) and `all_link_transforms`/collision. Coercing the scalar to f64 fixes it; the eager reference is now exact, letting the new differential test pin the `defn` chain to **1e-9**.

## Tests

- New differential test: `forward_kinematics/3` (defn) vs the eager `compute_joint_transform` composition across SixDofArm, PanTiltCamera, LinearActuator, CollisionTestArm — matches to 1e-9.
- New `Vec3.scale/2` f64-precision regression test.
- Full suite: **1102 passing** (31 doctests). `mix check` green except `reuse` (tool not installed locally; all new files carry SPDX headers).

## Next phases

1. Unify `all_link_transforms/2` onto the tree `defn` (prefix products) — removes the duplicated joint math.
2. Jacobian via `Nx.Defn.grad` of `fk_chain`, feeding `compute_update/3` in bb_ik_dls.
3. Batching / multi-target; revisit EXLA as a JIT backend to realise the compiled win.