### PR TITLE
fix: stop commands gracefully so cancellation isn't logged as a crash

### DIFF
--- a/lib/bb/command.ex
+++ b/lib/bb/command.ex
@@ -307,12 +307,14 @@ defmodule BB.Command do
   @doc """
   Cancel a running command.
 
-  Stops the command server with `:cancelled` reason. Awaiting callers will
-  receive `{:error, :cancelled}` (depending on how `result/1` handles this).
+  Stops the command server with a `{:shutdown, :cancelled}` reason. This is a
+  graceful stop (no crash report), while still being distinguishable from a
+  normal completion. The command's `terminate/2` still runs, so awaiting callers
+  receive whatever `result/1` returns.
   """
   @spec cancel(pid()) :: :ok
   def cancel(pid) do
-    GenServer.stop(pid, :cancelled)
+    GenServer.stop(pid, {:shutdown, :cancelled})
   catch
     :exit, {:noproc, _} -> :ok
   end
@@ -383,7 +385,7 @@ defmodule BB.Command do
 
       @impl BB.Command
       def handle_safety_state_change(_new_state, state) do
-        {:stop, :disarmed, state}
+        {:stop, {:shutdown, :disarmed}, state}
       end
 
       @impl BB.Command

--- a/lib/bb/command/server.ex
+++ b/lib/bb/command/server.ex
@@ -243,7 +243,7 @@ defmodule BB.Command.Server do
   end
 
   def handle_info(:command_timeout, state) do
-    {:stop, :timeout, state}
+    {:stop, {:shutdown, :timeout}, state}
   end
 
   def handle_info(msg, state) do

--- a/test/bb/robot/runtime_test.exs
+++ b/test/bb/robot/runtime_test.exs
@@ -283,9 +283,14 @@ defmodule BB.Robot.RuntimeTest do
       :ok = BB.Safety.arm(RobotWithCommands)
 
       {:ok, cmd} = Runtime.execute(RobotWithCommands, :async_cmd, %{notify: self()})
+      ref = Process.monitor(cmd)
       assert_receive {:executing, ^cmd}, 500
 
       assert :ok = Runtime.cancel(RobotWithCommands)
+
+      # Cancellation is a graceful shutdown, not a crash, so the process exits
+      # with `{:shutdown, :cancelled}` (which OTP does not log as an error report).
+      assert_receive {:DOWN, ^ref, :process, ^cmd, {:shutdown, :cancelled}}, 500
 
       # Task returns cancelled error
       assert {:error, :cancelled} = BB.Command.await(cmd)


### PR DESCRIPTION
Closes #166.

## Problem

Cancelling (or otherwise stopping) a running command logged a full error-level crash report with a state dump, even though the stop was intentional and handled cleanly. The command actually terminated correctly — `terminate/2` ran, the result was cached, awaiting callers were replied to — but the stop reasons were non-normal, so OTP treated each as a crash.

The three intentional-stop reasons:

- `BB.Command.cancel/1` — `GenServer.stop(pid, :cancelled)`
- default `handle_safety_state_change/2` — `{:stop, :disarmed, state}`
- command timeout — `{:stop, :timeout, state}`

Because none are `:normal`, `:shutdown`, or `{:shutdown, term}`, the GenServer terminated as a "crash" and OTP emitted an error report. A `terminate/2` callback can't downgrade the exit reason, so this couldn't be worked around in command modules.

## Fix

Wrap each reason in `{:shutdown, reason}` — OTP treats this as a graceful shutdown (no error report) while remaining distinguishable from `:normal`.

`BB.Command.Server.terminate/2` already extracts the result and notifies awaiting callers regardless of reason, so result delivery is unaffected. The runtime's `:DOWN` handler matches the reason with a wildcard, and no command pattern-matches the bare reason atoms, so behaviour is unchanged.

## Tests

Added an assertion to "cancel terminates running command" that the process exits with `{:shutdown, :cancelled}`. Full suite passes (1108 tests).