### PR TITLE
docs: ship usage-rules.md for AI coding assistants (#146)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,8 @@ defmodule BB.MixProject do
     [
       maintainers: ["James Harton <james@harton.nz>"],
       licenses: ["Apache-2.0"],
+      files:
+        ~w(lib .formatter.exs mix.exs README* CHANGELOG* LICENSE* usage-rules.md usage-rules),
       links: %{
         "Source" => "https://github.com/beam-bots/bb",
         "Sponsor" => "https://github.com/sponsors/jimsynz"
@@ -214,7 +216,8 @@ defmodule BB.MixProject do
       {:git_ops, "~> 2.9", only: [:dev, :test], runtime: false},
       {:igniter, "~> 0.6", optional: true},
       {:mimic, "~> 2.2", only: :test},
-      {:mix_audit, "~> 2.1", only: [:dev, :test], runtime: false}
+      {:mix_audit, "~> 2.1", only: [:dev, :test], runtime: false},
+      {:usage_rules, "~> 1.2", only: [:dev], runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -45,6 +45,7 @@
   "statistex": {:hex, :statistex, "1.1.1", "73612aa7f79e53c30569be065fd121e380f1cf57bc4c2da5b41be9246da18df9", [:mix], [], "hexpm", "310c4b49b34adf683de3103639006bed233ab54c08a4add65a531448e653857c"},
   "telemetry": {:hex, :telemetry, "1.4.2", "a0cb522801dffb1c49fe6e30561badffc7b6d0e180db1300df759faa22062855", [:rebar3], [], "hexpm", "928f6495066506077862c0d1646609eed891a4326bee3126ba54b60af61febb1"},
   "text_diff": {:hex, :text_diff, "0.1.0", "1caf3175e11a53a9a139bc9339bd607c47b9e376b073d4571c031913317fecaa", [:mix], [], "hexpm", "d1ffaaecab338e49357b6daa82e435f877e0649041ace7755583a0ea3362dbd7"},
+  "usage_rules": {:hex, :usage_rules, "1.2.6", "a7b3f8d6e5d265701139d5714749c37c54bb82230a4c51ec54a12a1e4769b9d1", [:mix], [{:igniter, ">= 0.6.6 and < 1.0.0-0", [hex: :igniter, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}, {:req, "~> 0.5", [hex: :req, repo: "hexpm", optional: false]}], "hexpm", "608411b9876a16a9d62a427dbaf42faf458e4cd0a508b3bd7e5ee71502073582"},
   "yamerl": {:hex, :yamerl, "0.10.0", "4ff81fee2f1f6a46f1700c0d880b24d193ddb74bd14ef42cb0bcf46e81ef2f8e", [:rebar3], [], "hexpm", "346adb2963f1051dc837a2364e4acf6eb7d80097c0f53cbdc3046ec8ec4b4e6e"},
   "yaml_elixir": {:hex, :yaml_elixir, "2.12.0", "30343ff5018637a64b1b7de1ed2a3ca03bc641410c1f311a4dbdc1ffbbf449c7", [:mix], [{:yamerl, "~> 0.10", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "ca6bacae7bac917a7155dca0ab6149088aa7bc800c94d0fe18c5238f53b313c6"},
 }

--- a/test/usage_rules_test.exs
+++ b/test/usage_rules_test.exs
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.UsageRulesTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :usage_rules
+
+  test "the main usage-rules.md exists" do
+    assert File.regular?("usage-rules.md")
+  end
+
+  test "usage-rules/ ships focused sub-rules" do
+    sub_rules = Path.wildcard("usage-rules/*.md")
+    assert sub_rules != []
+
+    for path <- sub_rules do
+      assert File.read!(path) =~ "SPDX-License-Identifier",
+             "#{path} is missing its SPDX header"
+    end
+  end
+
+  test "usage rules are included in the hex package files" do
+    files = Keyword.fetch!(Mix.Project.config()[:package], :files)
+    assert "usage-rules.md" in files
+    assert "usage-rules" in files
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -1,0 +1,56 @@
+<!--
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Beam Bots (BB) Usage Rules
+
+BB is a framework for building resilient robots in Elixir. You describe a
+robot's physical structure with a Spark DSL (`use BB`); BB compiles that to a
+struct and generates a supervision tree that mirrors the robot, so a crash is
+isolated to the affected subtree rather than taking the whole robot down.
+
+Read the documentation before reaching for a feature. Do not assume prior
+knowledge of BB — its DSL, its safety model, and its message conventions are
+specific and easy to guess wrong. Search it with
+`mix usage_rules.search_docs "<topic>" -p bb` and consult
+[hexdocs](https://hexdocs.pm/bb) rather than inventing an API.
+
+## Golden rules
+
+1. **A robot is a module that does `use BB`.** By convention it is named
+   `MyRobot.Robot`. Never hand-roll GenServers or a `Supervisor` for a robot's
+   components — declare them in the DSL and let BB build the tree.
+2. **Physical quantities use the `~u` sigil, never bare numbers:**
+   `~u(90 degree)`, not `1.57`. `use BB` brings the sigil into scope. Values are
+   converted to SI base units (metres, radians, kg) in the compiled struct.
+3. **A robot starts `:disarmed` and ignores motion commands until armed.**
+   Arming runs user-defined prearm checks. Change the safety state through the
+   command system, never by calling `BB.Safety` directly.
+4. **Talk to a running robot through its public API** — `BB.PubSub`,
+   `BB.Actuator`, `BB.Parameter`, `BB.Motion`, and the command functions
+   generated onto the robot module — not by messaging its processes yourself.
+
+## Sub-rules
+
+Consult the focused rules for the area you are working in:
+
+| Sub-rule | Covers |
+|---|---|
+| `bb:dsl-topology` | Defining a robot: links, joints, units, attaching components |
+| `bb:safety-and-commands` | The arm/disarm contract, the state machine, writing commands |
+| `bb:pubsub-and-sensors` | Subscribing to and publishing messages; message naming |
+| `bb:actuators` | Commanding motion; joint-space vs motor-space |
+| `bb:kinematics` | Forward kinematics and inverse kinematics |
+| `bb:parameters` | Runtime-adjustable configuration and bridges |
+| `bb:simulation` | Running a robot without hardware |
+| `bb:anti-patterns` | The mistakes assistants make most often |
+
+Pull them into your project with `mix usage_rules.sync <file> bb:all`.
+
+## Further reading
+
+- [Your First Robot](https://hexdocs.pm/bb/01-first-robot.html) — start here
+- [DSL reference](https://hexdocs.pm/bb/dsl-bb.html)
+- [Understanding Safety](https://hexdocs.pm/bb/understanding-safety.html)

--- a/usage-rules/actuators.md
+++ b/usage-rules/actuators.md
@@ -1,0 +1,60 @@
+<!--
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Actuators and Commanding Motion
+
+Send an actuator a target with `BB.Actuator`. The robot must be **armed**
+first (see `bb:safety-and-commands`) — commands to a disarmed robot are
+ignored.
+
+```elixir
+# By full path within the topology ([joint, actuator]), value in radians:
+BB.Actuator.set_position(MyRobot.Robot, [:pan_joint, :servo], 0.785)
+
+# By the actuator's unique name (raises on error):
+BB.Actuator.set_position!(MyRobot.Robot, :servo, 0.785)
+```
+
+The DSL takes `~u` sigil values; the runtime command functions take plain
+numbers in SI base units (radians here).
+
+- `set_position/4` takes the **full path** (a list) to the actuator;
+  `set_position!/4` takes just the actuator's unique **name**. `set_velocity`
+  and `set_effort` follow the same pair.
+- Positions are in **radians**, velocities in rad/s — SI base units, the same
+  units the compiled robot struct uses.
+- Use `set_position_sync/5` when you need to wait for acknowledgement rather
+  than fire-and-forget.
+
+## Joint-space in, motor-space handled for you
+
+You command joints in **joint-space**. BB applies the joint's `transmission`
+(gearing, `offset`, `reversed?`) and hands the driver **motor-space** values.
+By the time a `%BB.Message.Actuator.Command.Position{}` (or `Velocity`,
+`Effort`, `Trajectory`) reaches an actuator callback, the numbers are already
+in motor-space — the driver does no joint-to-motor maths.
+
+## Writing an actuator
+
+`use BB.Actuator`, define `init/1`, the GenServer callbacks, and the
+**required** `disarm/1`. Handle command messages in `handle_cast/2`:
+
+```elixir
+alias BB.Message.Actuator.Command
+
+def handle_cast({:command, %BB.Message{payload: %Command.Position{} = cmd}}, state) do
+  drive_hardware(cmd, state)
+  {:noreply, state}
+end
+
+def disarm(opts), do: cut_power(opts)   # must work without GenServer state
+```
+
+To report position back in joint-space, either let BB publish for you
+(`BB.Actuator.publish_begin_motion/3`) or translate with
+`BB.Actuator.to_joint_space/3` and publish yourself.
+
+See [Writing an Actuator](https://hexdocs.pm/bb/12-writing-an-actuator.html).

--- a/usage-rules/anti-patterns.md
+++ b/usage-rules/anti-patterns.md
@@ -1,0 +1,68 @@
+<!--
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Anti-patterns
+
+The mistakes assistants make most often with BB. Each has a correct form in the
+matching sub-rule.
+
+### Don't command a disarmed robot
+
+A new robot is `:disarmed` and ignores motion. Arm it first through the command
+system:
+
+```elixir
+{:ok, cmd} = MyRobot.Robot.arm()
+{:ok, :armed, _} = BB.Command.await(cmd)
+BB.Actuator.set_position!(MyRobot.Robot, :servo, 0.5)
+```
+
+### Don't manipulate the safety system directly
+
+```elixir
+# Bad — skips the user's prearm checks
+BB.Safety.arm(MyRobot.Robot)
+
+# Good — the Arm command runs prearm checks
+{:ok, cmd} = MyRobot.Robot.arm()
+```
+
+### Don't use bare numbers for physical quantities in the DSL
+
+```elixir
+limit lower: -1.57, upper: 1.57                        # Bad — ambiguous units
+limit lower: ~u(-90 degree), upper: ~u(90 degree)      # Good
+```
+
+### Don't hand-roll supervision
+
+```elixir
+Supervisor.start_link([MyServo], strategy: :one_for_one)   # Bad
+MyRobot.Robot.start_link()                                 # Good — BB builds the tree
+```
+
+### Don't pass the robot module where kinematics wants the struct
+
+```elixir
+# Bad — Kinematics operates on %BB.Robot{}, not the module
+BB.Robot.Kinematics.link_position(MyRobot.Robot, positions, :tip)
+
+# Good
+BB.Robot.Kinematics.link_position(MyRobot.Robot.robot(), positions, :tip)
+```
+
+### Don't guess API names
+
+Current, easily-confused signatures:
+
+- Current joint positions: `BB.Robot.Runtime.positions/1` (not
+  `joint_positions/1`).
+- Command callback is `handle_command/3` (goal, context, state) — not `/2`.
+- IK goes through `BB.Motion.move_to/4` with a required `:solver:`; there is no
+  default solver in core.
+
+When unsure, `mix usage_rules.search_docs "<topic>" -p bb` rather than
+inventing a function.

--- a/usage-rules/dsl-topology.md
+++ b/usage-rules/dsl-topology.md
@@ -1,0 +1,86 @@
+<!--
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Defining a Robot: Topology
+
+A robot is a module that does `use BB`. Convention names it `MyRobot.Robot`.
+The `topology` section describes the physical structure as a tree of links and
+joints; `use BB` also injects a `robot/0` function returning the compiled
+`%BB.Robot{}` struct.
+
+```elixir
+defmodule MyRobot.Robot do
+  use BB
+
+  topology do
+    link :base_link do
+      joint :pan_joint do
+        type :revolute
+
+        limit lower: ~u(-90 degree),
+              upper: ~u(90 degree),
+              effort: ~u(5 newton_meter),
+              velocity: ~u(60 degree_per_second)
+
+        actuator :servo, {MyDriver, servo_id: 1}
+
+        link :pan_link
+      end
+    end
+  end
+end
+```
+
+## Writing the DSL
+
+This is a Spark DSL — every entity is a macro. Follow the house style:
+
+- **Omit brackets on DSL calls:** `type :revolute`, not `type(:revolute)`.
+- **Each entity takes positional arguments then options, in one of three
+  forms:**
+  - `entity <positional>, <options as a keyword list>`
+  - `entity <positional> do <options as nested calls> end`
+  - `entity do <positional and options as nested calls> end`
+- **Prefer the keyword-list form** unless the entity contains *nested DSL* that
+  needs a `do`/`end` block. So `limit lower: ~u(...), upper: ~u(...)` (plain
+  options), but `link`/`joint` take a block because they nest other entities.
+
+## Rules
+
+- **Nesting encodes the kinematic chain.** A `joint` lives inside its parent
+  `link`; the child `link` lives inside the `joint`. This nesting *is* the
+  chain — there is no separate parent/child field.
+- **Joint `type`** is one of `:revolute`, `:prismatic`, `:fixed`,
+  `:continuous`, `:floating`, `:planar`.
+- **`limit` requires `effort` and `velocity`**; `lower`/`upper`/`acceleration`
+  are optional. It has no nested DSL, so use the keyword form.
+- **`axis` defaults to the Z-axis** and can be omitted. Reorient it with
+  `roll`/`pitch`/`yaw`, e.g. `axis roll: ~u(90 degree)`.
+- **Attach components as `{Module, opts}`** in an actuator/sensor slot:
+  `actuator :servo, {MyDriver, servo_id: 1}`. A bare `Module` works when it
+  needs no options. Names must be unique across the whole robot — BB registers
+  each process under its name. Add a `do`/`end` block only to nest further DSL
+  such as `transmission`.
+- **Per-attachment `transmission`** describes how *that* actuator/sensor maps
+  joint-space to its hardware (`reversed?`, `offset`, gearing). It belongs on
+  the attachment, not the joint, because several devices can share one joint.
+
+## Units
+
+Every physical value uses the `~u` sigil — `~u(90 degree)`,
+`~u(5 newton_meter)`, `~u(60 degree_per_second)`. Unit names are validated
+dynamically by the [`localize`](https://hexdocs.pm/localize) package, which is
+the authoritative source for valid names — including composite units, which
+join their parts with underscores and `per`: `~u(1.0 meter_per_second)`,
+`~u(0.5 meter_per_second_squared)`, `~u(1.5 newton_second_per_meter)`. If a
+unit is rejected, check `localize` rather than guessing.
+
+Robot-level components not attached to a joint (a GPS, a battery monitor, a bus
+controller) go in the top-level `sensors` and `controllers` sections rather
+than inside `topology`.
+
+See the [DSL reference](https://hexdocs.pm/bb/dsl-bb.html) and
+[Your First Robot](https://hexdocs.pm/bb/01-first-robot.html).

--- a/usage-rules/kinematics.md
+++ b/usage-rules/kinematics.md
@@ -1,0 +1,53 @@
+<!--
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Kinematics
+
+## Forward kinematics — "where is this link?"
+
+`BB.Robot.Kinematics` works on the **compiled `%BB.Robot{}` struct**, not the
+robot module. Get the struct with `MyRobot.Robot.robot()`, and current joint
+positions from the runtime with `BB.Robot.Runtime.positions/1`:
+
+```elixir
+robot = MyRobot.Robot.robot()
+positions = BB.Robot.Runtime.positions(MyRobot.Robot)   # %{joint_name => radians}
+
+# Cartesian position of a link:
+{x, y, z} = BB.Robot.Kinematics.link_position(robot, positions, :camera_link)
+
+# Full 4x4 pose (position + orientation):
+transform = BB.Robot.Kinematics.forward_kinematics(robot, positions, :camera_link)
+
+# Every link at once (more efficient than repeated calls):
+transforms = BB.Robot.Kinematics.all_link_transforms(robot, positions)
+```
+
+You can also pass an explicit `%{joint => radians}` map instead of the live
+positions to ask "where *would* this link be". Transforms are
+`BB.Math.Transform` 4x4 matrices; angles are radians throughout.
+
+## Inverse kinematics — "what joint angles reach this point?"
+
+IK solvers are **pluggable** and ship in satellite packages (`bb_ik_dls`,
+`bb_ik_fabrik`) implementing the `BB.IK.Solver` behaviour. Drive them through
+`BB.Motion`, which solves, updates state, and commands the actuators:
+
+```elixir
+{:ok, meta} =
+  BB.Motion.move_to(MyRobot.Robot, :gripper, {0.3, 0.2, 0.1}, solver: BB.IK.FABRIK)
+```
+
+- **`:solver` is required** — core ships no default. Add a solver package and
+  pass its module.
+- Targets are `{x, y, z}` in metres.
+- Use `BB.Motion.solve_only/4` to compute angles without moving.
+- Solver options (`:max_iterations`, `:tolerance`, `:respect_limits`) are
+  passed through untyped; defaults differ between solvers, so set them
+  explicitly when it matters.
+
+See [Forward Kinematics](https://hexdocs.pm/bb/04-kinematics.html) and
+[Inverse Kinematics](https://hexdocs.pm/bb/09-inverse-kinematics.html).

--- a/usage-rules/parameters.md
+++ b/usage-rules/parameters.md
@@ -1,0 +1,73 @@
+<!--
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Parameters
+
+Parameters are validated, runtime-adjustable configuration values with change
+notifications — think ROS2 parameters. Declare them in a `parameters` section;
+`group` nests them into a path.
+
+```elixir
+parameters do
+  param :max_speed, type: :float, default: 1.0,
+    min: 0.0, max: 10.0, doc: "Maximum velocity in m/s"
+
+  group :motion do
+    param :gain, type: :float, default: 0.5
+  end
+end
+```
+
+Each `param` needs a `type` (`:float`, `:integer`, `:boolean`, `:string`,
+`:atom`, or `{:unit, unit_type}` for physical quantities) and a `default`.
+`min`/`max` bound numeric types.
+
+## Reading and writing at runtime
+
+Address a parameter by its **path** (a list reflecting the group nesting):
+
+```elixir
+{:ok, speed} = BB.Parameter.get(MyRobot.Robot, [:max_speed])
+1.0 = BB.Parameter.get!(MyRobot.Robot, [:max_speed])
+:ok = BB.Parameter.set(MyRobot.Robot, [:motion, :gain], 0.8)
+:ok = BB.Parameter.set_many(MyRobot.Robot, [{[:max_speed], 2.0}, {[:motion, :gain], 0.9}])
+```
+
+`set/3` validates against the schema and returns `{:error, reason}` on invalid
+values; unknown paths return `{:error, :not_found}`.
+
+## Reacting to changes
+
+A change is more than a stored value — it propagates two ways:
+
+- **Component options that reference a parameter update live.** Reference one in
+  a DSL declaration with `param([...])`; when it changes, BB re-resolves the
+  options and calls the component's `handle_options/2` callback with the new
+  values. This is the idiomatic way for a sensor, actuator, controller, or
+  estimator to track configuration — do **not** hand-wire your own subscription
+  inside the component for this.
+
+  ```elixir
+  controller :bus, {MyController, port: param([:config, :port])}
+
+  # in MyController:
+  def handle_options(new_opts, state), do: {:ok, reconfigure(state, new_opts)}
+  ```
+
+- **Every change is published on `[:param | path]`.** Any process can
+  `BB.PubSub.subscribe(MyRobot.Robot, [:param])` (or a narrower path) to receive
+  change notifications directly — this is how bridges mirror parameters to
+  external systems.
+
+## Startup and bridges
+
+Pass overrides at start (`MyRobot.Robot.start_link(params: [max_speed: 2.0])`);
+invalid or unknown values make the supervised robot fail to boot. A `bridge`
+declaration exposes parameters bidirectionally to an external system (a servo
+bus, a ground station).
+
+See [Parameters](https://hexdocs.pm/bb/07-parameters.html) and
+[Parameter Bridges](https://hexdocs.pm/bb/08-parameter-bridges.html).

--- a/usage-rules/pubsub-and-sensors.md
+++ b/usage-rules/pubsub-and-sensors.md
@@ -1,0 +1,66 @@
+<!--
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# PubSub and Sensors
+
+BB routes messages hierarchically by **path** — the list of names locating a
+component in the topology. Subscribe to a path to receive that node and
+everything beneath it.
+
+## Subscribing
+
+```elixir
+BB.PubSub.subscribe(MyRobot.Robot, [:sensor])            # all sensor messages
+BB.PubSub.subscribe(MyRobot.Robot, [:sensor, :base_link]) # one subtree
+BB.PubSub.subscribe(MyRobot.Robot, [])                    # everything
+```
+
+Messages arrive as a three-element tuple whose payload is a `%BB.Message{}`:
+
+```elixir
+def handle_info({:bb, path, %BB.Message{payload: payload}}, state) do
+  # payload is e.g. %BB.Message.Sensor.Imu{}, %BB.Message.Sensor.JointState{}
+  {:noreply, state}
+end
+```
+
+`BB.Message` wraps every payload with a timestamp and frame id — carry the
+whole struct, don't unwrap it early. (`BB.subscribe/3` and `BB.publish/3` are
+shortcuts for the `BB.PubSub` functions.)
+
+## Writing a sensor
+
+`use BB.Sensor`, define `init/1` plus GenServer-style callbacks. BB injects
+`:bb => %{robot: ..., path: ...}` into your options and supervises the process
+for you — you never write a `child_spec`. Publish readings under
+`[:sensor | path]`:
+
+```elixir
+def handle_info(:read, %{bb: %{robot: robot, path: path}} = state) do
+  {:ok, message} = BB.Message.Sensor.Range.new(:range, range: read_hardware())
+  BB.PubSub.publish(robot, [:sensor | path], message)
+  {:noreply, state}
+end
+```
+
+Build a payload with its module's generated `new/2` — `Module.new(frame_id,
+attrs)` validates against the payload schema and returns
+`{:ok, %BB.Message{}}`. The first argument is the frame id (an atom naming the
+coordinate frame, conventionally the sensor's own name).
+
+## Message naming
+
+When choosing a payload type under `BB.Message.Sensor.*` / `.Actuator.*`, match
+the existing convention rather than inventing a suffix:
+
+- **`*State`** — a multi-field snapshot of an entity's current condition
+  (`BatteryState`, `JointState`, `PowerState`).
+- **A naked noun** — a single reading that *is* the sample (`Image`, `Range`,
+  `LaserScan`, `Imu`).
+- **`VerbObject`** — an event or notification (`BeginMotion`).
+
+See [Sensors and PubSub](https://hexdocs.pm/bb/03-sensors-and-pubsub.html) and
+the [message-types reference](https://hexdocs.pm/bb/message-types.html).

--- a/usage-rules/safety-and-commands.md
+++ b/usage-rules/safety-and-commands.md
@@ -1,0 +1,80 @@
+<!--
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Safety and Commands
+
+A robot has an operational state machine:
+`:disarmed → :idle → :executing → :idle`. It starts `:disarmed` and **will not
+move** until armed. Arming is not a flag you set — it runs the prearm checks a
+robot may define and, for hardware components, the reverse (`disarm`) path.
+
+## Arming and disarming
+
+Arm and disarm are ordinary commands. Declare them in the DSL:
+
+```elixir
+commands do
+  command :arm do
+    handler BB.Command.Arm
+    allowed_states [:disarmed]
+  end
+
+  command :disarm do
+    handler BB.Command.Disarm
+    allowed_states [:idle]
+  end
+end
+```
+
+Each declared command becomes a function on the robot module. Commands are
+short-lived processes; call the generated function to start one, then
+`BB.Command.await/2` for the result:
+
+```elixir
+{:ok, cmd} = MyRobot.Robot.arm()
+{:ok, :armed, _opts} = BB.Command.await(cmd)
+```
+
+- **Never call `BB.Safety` (or its internal controller) directly to change
+  state.** Going through the command system is what runs the user's prearm
+  checks. Poking safety directly bypasses them.
+- `allowed_states` gates when a command may run. A command invoked from a
+  disallowed state fails with a `BB.Error.State` error rather than executing.
+
+## Writing a command
+
+`use BB.Command`, implement `handle_command/3` and `result/1`. Return
+`{:ok, result}`, or `{:ok, result, next_state: state}` to drive the state
+machine (this is how `Arm`/`Disarm` transition it):
+
+```elixir
+defmodule MyRobot.Command.Home do
+  use BB.Command
+
+  def handle_command(_goal, context, state) do
+    # context carries the compiled robot struct; move via BB.Motion / BB.Actuator
+    {:ok, state}
+  end
+
+  def result(state), do: {:ok, :home}
+end
+```
+
+A command can also react to messages mid-execution and to safety changes via
+optional callbacks (`handle_info/2`, `handle_safety_state_change/2`).
+
+## The disarm contract (hardware components)
+
+Components that drive hardware implement a `disarm/1` callback from their
+behaviour — required for `BB.Actuator`, optional for `BB.Controller` and
+`BB.Sensor` — and register with `BB.Safety.register/2`. `disarm/1` receives the
+opts given at registration and **must work without GenServer state**: it runs
+when things have already gone wrong, possibly after the process has crashed.
+Disarm callbacks run concurrently with a 5-second timeout; a failure moves the
+robot to `:error`, which needs `BB.Safety.force_disarm/1` to clear.
+
+See [Commands and State Machine](https://hexdocs.pm/bb/05-commands.html) and
+[Understanding Safety](https://hexdocs.pm/bb/understanding-safety.html).

--- a/usage-rules/simulation.md
+++ b/usage-rules/simulation.md
@@ -1,0 +1,36 @@
+<!--
+SPDX-FileCopyrightText: 2026 James Harton
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Simulation
+
+Run a robot without hardware by starting it in a simulation mode:
+
+```elixir
+MyRobot.Robot.start_link(simulation: :kinematic)
+BB.Robot.Runtime.simulation_mode(MyRobot.Robot)   # => :kinematic (or nil)
+```
+
+The generated `MyRobot.Application` typically wires this to the `SIMULATE`
+environment variable via its `robot_opts/0`, so `SIMULATE=1 iex -S mix` boots
+in simulation.
+
+## What changes under simulation
+
+- **Actuators** are replaced by `BB.Sim.Actuator`, which publishes
+  `BeginMotion` messages timed from each joint's velocity limit.
+- **Controllers default to `simulation: :omit`** — a DSL-declared controller
+  does *not* start under simulation unless you set it to `:mock` or `:start`.
+  This is the single most common simulation surprise.
+- Open-loop position estimation still runs, so joint positions update and
+  forward kinematics work unchanged.
+
+## What does not change
+
+**The safety system still applies.** A simulated robot starts `:disarmed` and
+must be armed before it will accept motion commands — exactly like hardware.
+Simulation removes the hardware, not the state machine.
+
+See [Simulation Mode](https://hexdocs.pm/bb/10-simulation.html).


### PR DESCRIPTION
Closes #146. Implements [proposal 0007](https://github.com/beam-bots/proposals/blob/main/accepted/0007-usage-rules.md) for `bb` core.

Ships maintainer-curated usage rules so AI coding assistants get authoritative, token-budget-conscious guidance on BB's patterns and the anti-patterns they commonly get wrong.

## Structure

Follows the Ash split model rather than proposal 0007's monolithic single file — `bb`'s surface area (like Ash's) warrants topic separation:

- `usage-rules.md` — thin root: what BB is, four golden rules, a sub-rule index.
- `usage-rules/` — focused topic files: `dsl-topology`, `safety-and-commands`, `pubsub-and-sensors`, `actuators`, `kinematics`, `parameters`, `simulation`, `anti-patterns`.

Consumable via `mix usage_rules.sync <file> bb:all`.

## Packaging

- Adds `{:usage_rules, "~> 1.2", only: [:dev]}`.
- Adds an explicit `files:` list — `bb` previously relied on hex defaults, which exclude `usage-rules*`. The list preserves the current package contents and adds the rules. Verified with `mix hex.build --unpack` that all nine files land in the tarball.
- Adds `test/usage_rules_test.exs` asserting the rules exist, carry SPDX headers, and are included in the package `files` (the "CI check" from the proposal's open questions, as a test rather than a workflow step since CI is delegated to the shared `beam-bots/.github` workflow).

## Notes

- Content is written from the current API (bb 0.22.1) and a real robot definition, not the proposal's illustrative example (which had drifted). House DSL style applied: bracket-free calls, keyword-form entities unless nested DSL needs a block; unit names pointed at `localize` as the authority.
- `bb.install` is left untouched — `usage_rules` consumption is consumer-driven (matching Ash, whose installer doesn't wire it either).

Per proposal 0007, the satellite packages (`bb_liveview`, `bb_kino`, `bb_reactor`, IK solvers, servo drivers) follow as per-package issues now this establishes the house style.