### PR TITLE
docs: correct sensor tutorial for callback API

### DIFF
--- a/documentation/tutorials/03-sensors-and-pubsub.md
+++ b/documentation/tutorials/03-sensors-and-pubsub.md
@@ -199,7 +199,8 @@ Start it with `MySensorSubscriber.start_link(MyRobot.Robot)`. If a process subsc
 
 ## Message Structure
 
-Messages have a standard envelope structure:
+Messages have a standard envelope structure. An IMU message's semantic values
+can be represented as:
 
 ```elixir
 %BB.Message{
@@ -208,24 +209,9 @@ Messages have a standard envelope structure:
   node: :nonode@nohost,
   frame_id: :imu,
   payload: %BB.Message.Sensor.Imu{
-    orientation: %BB.Math.Quaternion{
-      tensor: #Nx.Tensor<
-        f64[4]
-        [1.0, 0.0, 0.0, 0.0]
-      >
-    },
-    angular_velocity: %BB.Math.Vec3{
-      tensor: #Nx.Tensor<
-        f64[3]
-        [0.0, 0.0, 0.0]
-      >
-    },
-    linear_acceleration: %BB.Math.Vec3{
-      tensor: #Nx.Tensor<
-        f64[3]
-        [0.0, 0.0, 9.81]
-      >
-    },
+    orientation: BB.Math.Quaternion.identity(),
+    angular_velocity: BB.Math.Vec3.zero(),
+    linear_acceleration: BB.Math.Vec3.new(0.0, 0.0, 9.81),
     orientation_covariance: nil,
     angular_velocity_covariance: nil,
     linear_acceleration_covariance: nil

--- a/documentation/tutorials/03-sensors-and-pubsub.md
+++ b/documentation/tutorials/03-sensors-and-pubsub.md
@@ -14,7 +14,7 @@ Complete [Starting and Stopping](02-starting-and-stopping.md). You should have a
 
 ## Adding a Sensor to the DSL
 
-Sensors are processes that publish data. Add one to your robot:
+Sensors are supervised components that publish data. Add one to your robot:
 
 ```elixir
 defmodule MyRobot.Robot do
@@ -34,75 +34,92 @@ end
 
 The sensor declaration takes:
 - A name (`:imu`)
-- A child spec (`MyImuSensor` or `{MyImuSensor, options}`)
+- A `BB.Sensor` callback module (`MyImuSensor`) or a callback module with options (`{MyImuSensor, options}`)
 
 Sensors can be attached at three levels:
 - **Robot level** - in a `sensors do ... end` block
 - **Link level** - inside a link definition
 - **Joint level** - inside a joint definition
 
-## Implementing a Sensor Process
+## Implementing a Sensor
 
-A sensor is a GenServer that publishes messages. Here's a simple IMU sensor:
+A sensor implementation is a `BB.Sensor` callback module. `BB.Sensor.Server` owns the GenServer process and delegates callbacks to your module, so the implementation does not define `start_link/1` or `use GenServer`.
+
+Here's a simple IMU sensor. Its generated reading represents a stationary, upright sensor; replace `read_sensor/1` with the call to your hardware driver:
 
 ```elixir
 defmodule MyImuSensor do
-  use GenServer
+  use BB.Sensor,
+    options_schema: [
+      bus: [type: :atom, default: :i2c1, doc: "Hardware bus"],
+      sample_rate: [
+        type: {:in, 1..1000},
+        default: 10,
+        doc: "Samples per second"
+      ]
+    ]
 
+  alias BB.Math.{Quaternion, Vec3}
   alias BB.Message.Sensor.Imu
-  alias BB.Message.{Vec3, Quaternion}
-  alias BB.PubSub
 
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts)
-  end
-
-  @impl GenServer
+  @impl BB.Sensor
   def init(opts) do
-    # BB passes robot context in opts
-    robot = Keyword.fetch!(opts, :robot)
-    path = Keyword.fetch!(opts, :path)
+    bb = Keyword.fetch!(opts, :bb)
+    sample_rate = Keyword.fetch!(opts, :sample_rate)
 
-    # Schedule periodic readings
-    :timer.send_interval(100, :read_sensor)
+    state = %{
+      bb: bb,
+      bus: Keyword.fetch!(opts, :bus),
+      sample_interval_ms: div(1000, sample_rate)
+    }
 
-    {:ok, %{robot: robot, path: path}}
+    schedule_read(state.sample_interval_ms)
+    {:ok, state}
   end
 
-  @impl GenServer
+  @impl BB.Sensor
   def handle_info(:read_sensor, state) do
-    # Create an IMU message
-    {:ok, message} = Imu.new(:imu,
-      orientation: Quaternion.identity(),
-      angular_velocity: Vec3.zero(),
-      linear_acceleration: Vec3.new(0.0, 0.0, 9.81)
+    {orientation, angular_velocity, linear_acceleration} = read_sensor(state.bus)
+
+    {:ok, message} = Imu.new(List.last(state.bb.path),
+      orientation: orientation,
+      angular_velocity: angular_velocity,
+      linear_acceleration: linear_acceleration
     )
 
-    # Publish to subscribers
-    # Path format: [:sensor | location_path]
-    PubSub.publish(state.robot, [:sensor | state.path], message)
+    BB.publish(state.bb.robot, [:sensor | state.bb.path], message)
 
+    schedule_read(state.sample_interval_ms)
     {:noreply, state}
+  end
+
+  defp read_sensor(_bus) do
+    {Quaternion.identity(), Vec3.zero(), Vec3.new(0.0, 0.0, 9.81)}
+  end
+
+  defp schedule_read(interval_ms) do
+    Process.send_after(self(), :read_sensor, interval_ms)
   end
 end
 ```
 
 Key points:
 
-- BB passes `:robot` and `:path` in the options
-- The path reflects where the sensor is in the topology (e.g., `[:base_link, :imu]`)
-- Publish with `[:sensor | path]` to identify it as a sensor message
+- `BB.Sensor.Server` receives the DSL options, validates them against `options_schema`, applies defaults, and injects `:bb` before calling `MyImuSensor.init/1`.
+- The injected value is `%{robot: module, path: [atom]}`. For this sensor, `bb.path` is `[:base_link, :imu]`.
+- `Process.send_after/3` schedules the next reading only after the current one has been handled, so readings do not accumulate if one takes longer than expected.
+- Publish to `[:sensor | bb.path]`, passing `bb.robot` explicitly as the first argument.
 
 > **For Roboticists:** This is similar to ROS publishers. The sensor publishes on a topic (path) and subscribers receive the messages asynchronously.
 
-> **For Elixirists:** The sensor is just a GenServer. BB starts it as part of the supervision tree and provides context about where it sits in the robot topology.
+> **For Elixirists:** `MyImuSensor` supplies GenServer-style callbacks but is not itself a GenServer. BB starts `BB.Sensor.Server` in the robot's supervision tree, and that wrapper delegates to the callback module with the sensor's resolved options and topology context.
 
 ## Subscribing to Messages
 
 Your robot is already running (it starts with your application), so subscribe to its sensor messages:
 
 ```elixir
-iex> BB.PubSub.subscribe(MyRobot.Robot, [:sensor])
+iex> BB.subscribe(MyRobot.Robot, [:sensor])
 {:ok, #PID<0.234.0>}
 ```
 
@@ -110,9 +127,11 @@ Now your IEx process receives sensor messages:
 
 ```elixir
 iex> flush()
-{:bb, [:sensor, :base_link, :imu], %BB.Message{...}}
-{:bb, [:sensor, :base_link, :imu], %BB.Message{...}}
+{:bb, [:sensor, :base_link, :imu], %BB.Message{robot: MyRobot.Robot, ...}}
+{:bb, [:sensor, :base_link, :imu], %BB.Message{robot: MyRobot.Robot, ...}}
 ```
+
+The delivery tuple contains the full topic path and message envelope. `BB.publish/3` stamps the publishing robot into `message.robot` before dispatching it.
 
 ## Subscription Patterns
 
@@ -120,16 +139,16 @@ The path you subscribe to determines which messages you receive:
 
 ```elixir
 # All sensor messages from anywhere
-BB.PubSub.subscribe(MyRobot.Robot, [:sensor])
+BB.subscribe(MyRobot.Robot, [:sensor])
 
 # Sensors under the base_link
-BB.PubSub.subscribe(MyRobot.Robot, [:sensor, :base_link])
+BB.subscribe(MyRobot.Robot, [:sensor, :base_link])
 
 # Only the specific IMU sensor
-BB.PubSub.subscribe(MyRobot.Robot, [:sensor, :base_link, :imu])
+BB.subscribe(MyRobot.Robot, [:sensor, :base_link, :imu])
 
 # All messages (sensors, actuators, everything)
-BB.PubSub.subscribe(MyRobot.Robot, [])
+BB.subscribe(MyRobot.Robot, [])
 ```
 
 ## Filtering by Message Type
@@ -139,7 +158,7 @@ Subscribe only to specific message types:
 ```elixir
 alias BB.Message.Sensor.Imu
 
-BB.PubSub.subscribe(MyRobot.Robot, [:sensor],
+BB.subscribe(MyRobot.Robot, [:sensor],
   message_types: [Imu]
 )
 ```
@@ -148,34 +167,35 @@ This is useful when you have many sensors but only care about IMU data.
 
 ## Receiving Messages in a Process
 
-In a real application, you'll receive messages in a GenServer:
+In a real application, you might receive messages in a standalone GenServer. This process is not a robot component, so BB does not inject any options into it; its caller passes the robot module explicitly:
 
 ```elixir
-defmodule MyController do
+defmodule MySensorSubscriber do
   use GenServer
 
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts)
+  def start_link(robot) do
+    GenServer.start_link(__MODULE__, robot)
   end
 
   @impl GenServer
-  def init(opts) do
-    robot = Keyword.fetch!(opts, :robot)
+  def init(robot) do
+    {:ok, _pid} = BB.subscribe(robot, [:sensor])
 
-    # Subscribe to all sensor messages
-    BB.PubSub.subscribe(robot, [:sensor])
-
-    {:ok, %{robot: robot}}
+    {:ok, %{}}
   end
 
   @impl GenServer
-  def handle_info({:bb, path, message}, state) do
-    # Process the sensor message
-    IO.inspect(message.payload, label: "Received from #{inspect(path)}")
+  def handle_info({:bb, path, %BB.Message{} = message}, state) do
+    IO.inspect(message.payload,
+      label: "Received from #{inspect(message.robot)} at #{inspect(path)}"
+    )
+
     {:noreply, state}
   end
 end
 ```
+
+Start it with `MySensorSubscriber.start_link(MyRobot.Robot)`. If a process subscribes to more than one robot, `message.robot` identifies which robot published each delivery.
 
 ## Message Structure
 
@@ -188,10 +208,29 @@ Messages have a standard envelope structure:
   node: :nonode@nohost,
   frame_id: :imu,
   payload: %BB.Message.Sensor.Imu{
-    orientation: {:quaternion, 0.0, 0.0, 0.0, 1.0},
-    angular_velocity: {:vec3, 0.0, 0.0, 0.0},
-    linear_acceleration: {:vec3, 0.0, 0.0, 9.81}
-  }
+    orientation: %BB.Math.Quaternion{
+      tensor: #Nx.Tensor<
+        f64[4]
+        [1.0, 0.0, 0.0, 0.0]
+      >
+    },
+    angular_velocity: %BB.Math.Vec3{
+      tensor: #Nx.Tensor<
+        f64[3]
+        [0.0, 0.0, 0.0]
+      >
+    },
+    linear_acceleration: %BB.Math.Vec3{
+      tensor: #Nx.Tensor<
+        f64[3]
+        [0.0, 0.0, 9.81]
+      >
+    },
+    orientation_covariance: nil,
+    angular_velocity_covariance: nil,
+    linear_acceleration_covariance: nil
+  },
+  robot: MyRobot.Robot
 }
 ```
 
@@ -200,6 +239,7 @@ Messages have a standard envelope structure:
 - `node` - The BEAM node that produced the message. Useful in distributed deployments.
 - `frame_id` - Coordinate frame for the data (typically the sensor name).
 - `payload` - The actual sensor data struct (type depends on message type).
+- `robot` - The robot module supplied to `BB.publish/3`. This is `nil` until the message is published, then BB fills it before delivery.
 
 ## Available Message Types
 
@@ -274,35 +314,37 @@ Use your custom payload in a sensor:
 
 ```elixir
 defmodule MyTemperatureSensor do
-  use GenServer
+  use BB.Sensor
 
   alias MyApp.Message.Temperature
-  alias BB.PubSub
 
-  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
-
-  @impl GenServer
+  @impl BB.Sensor
   def init(opts) do
-    robot = Keyword.fetch!(opts, :robot)
-    path = Keyword.fetch!(opts, :path)
+    bb = Keyword.fetch!(opts, :bb)
 
-    :timer.send_interval(1000, :read_temperature)
-
-    {:ok, %{robot: robot, path: path}}
+    schedule_read()
+    {:ok, %{bb: bb}}
   end
 
-  @impl GenServer
+  @impl BB.Sensor
   def handle_info(:read_temperature, state) do
-    # Read from actual hardware here
     celsius = 23.5 + :rand.uniform() * 2
+    sensor_name = List.last(state.bb.path)
 
-    {:ok, message} = Temperature.new(:thermal_sensor, :temp_1, celsius)
-    PubSub.publish(state.robot, [:sensor | state.path], message)
+    {:ok, message} = Temperature.new(sensor_name, sensor_name, celsius)
+    BB.publish(state.bb.robot, [:sensor | state.bb.path], message)
 
+    schedule_read()
     {:noreply, state}
+  end
+
+  defp schedule_read do
+    Process.send_after(self(), :read_temperature, 1000)
   end
 end
 ```
+
+The random value keeps the example runnable without hardware; replace it with the temperature driver's read call in a real sensor.
 
 The `Spark.Options` schema validates attributes when creating messages. If validation fails, `BB.Message.new/3` returns `{:error, reason}` with details about what went wrong.
 
@@ -311,7 +353,7 @@ The `Spark.Options` schema validates attributes when creating messages. If valid
 Stop receiving messages:
 
 ```elixir
-BB.PubSub.unsubscribe(MyRobot.Robot, [:sensor])
+BB.unsubscribe(MyRobot.Robot, [:sensor])
 ```
 
 ## Debugging Subscriptions
@@ -325,7 +367,7 @@ iex> BB.PubSub.subscribers(MyRobot.Robot, [:sensor])
 
 ## Sensors with Options
 
-Pass configuration to your sensor:
+The IMU's `options_schema` declares every user option that its wrapper accepts. You can therefore override the defaults in the DSL:
 
 ```elixir
 topology do
@@ -335,18 +377,26 @@ topology do
 end
 ```
 
-Your sensor receives these in `start_link/1`:
+Before `init/1` runs, `BB.Sensor.Server` validates these values, applies any schema defaults, and merges in the framework-owned `:bb` and `:sensor_profile` options. The callback reads the validated values directly:
 
 ```elixir
 def init(opts) do
-  robot = Keyword.fetch!(opts, :robot)
-  path = Keyword.fetch!(opts, :path)
-  sample_rate = Keyword.get(opts, :sample_rate, 100)
-  bus = Keyword.get(opts, :bus, :i2c1)
+  bb = Keyword.fetch!(opts, :bb)
+  bus = Keyword.fetch!(opts, :bus)
+  sample_rate = Keyword.fetch!(opts, :sample_rate)
 
-  # ...
+  state = %{
+    bb: bb,
+    bus: bus,
+    sample_interval_ms: div(1000, sample_rate)
+  }
+
+  schedule_read(state.sample_interval_ms)
+  {:ok, state}
 end
 ```
+
+Do not add `:bb` or `:sensor_profile` to `options_schema`; they are injected by the wrapper. Unknown user options and values outside the schema, such as a sample rate above 1000 Hz in this example, prevent the sensor from starting with a validation error.
 
 ## Robot-Level Sensors
 


### PR DESCRIPTION
## Summary

- rewrite the IMU and temperature examples as `BB.Sensor` callback modules wrapped by `BB.Sensor.Server`
- document validated option schemas and the framework-injected `:bb` context
- use the current `BB.Math` types, self-rescheduling sensor loop, publish paths, subscription envelope, and robot attribution
- pass the robot explicitly to standalone subscribers instead of implying BB injects arbitrary GenServer options
- align every later sensor/options example in the tutorial with the current runtime contract

Closes #185.

## Verification

- `mix docs`
- `mix test test/bb/sensor_test.exs test/bb/supervisor_test.exs` (19 tests)
- disposable runtime exercise of both example sensors, option validation, PubSub paths, and math payloads
- `mix check --no-retry` (1,111 tests and 31 doctests)