### PR TITLE
improvement: add semantic math inspection

### DIFF
--- a/lib/bb/math/quaternion.ex
+++ b/lib/bb/math/quaternion.ex
@@ -14,6 +14,9 @@ defmodule BB.Math.Quaternion do
 
   ## Examples
 
+      iex> BB.Math.Quaternion.new(1, 0, 0, 0)
+      BB.Math.Quaternion.new(1.0, 0.0, 0.0, 0.0)
+
       iex> q = BB.Math.Quaternion.identity()
       iex> BB.Math.Quaternion.w(q)
       1.0
@@ -31,6 +34,33 @@ defmodule BB.Math.Quaternion do
   defstruct [:tensor]
 
   @type t :: %__MODULE__{tensor: Nx.Tensor.t()}
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    @spec inspect(@for.t(), Inspect.Opts.t()) :: Inspect.Algebra.t()
+    def inspect(%@for{tensor: %Nx.Tensor{data: %Nx.BinaryBackend{}} = tensor}, opts) do
+      case Nx.shape(tensor) do
+        {4} ->
+          container_doc(
+            "BB.Math.Quaternion.new(",
+            Nx.to_flat_list(tensor),
+            ")",
+            opts,
+            &to_doc/2
+          )
+
+        _ ->
+          fallback(tensor, opts)
+      end
+    end
+
+    def inspect(%@for{tensor: tensor}, opts), do: fallback(tensor, opts)
+
+    defp fallback(tensor, opts) do
+      concat(["#BB.Math.Quaternion<", to_doc(tensor, opts), ">"])
+    end
+  end
 
   @doc """
   Creates a new quaternion from w, x, y, z components.

--- a/lib/bb/math/vec3.ex
+++ b/lib/bb/math/vec3.ex
@@ -11,6 +11,9 @@ defmodule BB.Math.Vec3 do
 
   ## Examples
 
+      iex> BB.Math.Vec3.new(1, 2, 3)
+      BB.Math.Vec3.new(1.0, 2.0, 3.0)
+
       iex> v = BB.Math.Vec3.new(1, 2, 3)
       iex> BB.Math.Vec3.x(v)
       1.0
@@ -25,6 +28,33 @@ defmodule BB.Math.Vec3 do
   defstruct [:tensor]
 
   @type t :: %__MODULE__{tensor: Nx.Tensor.t()}
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    @spec inspect(@for.t(), Inspect.Opts.t()) :: Inspect.Algebra.t()
+    def inspect(%@for{tensor: %Nx.Tensor{data: %Nx.BinaryBackend{}} = tensor}, opts) do
+      case Nx.shape(tensor) do
+        {3} ->
+          container_doc(
+            "BB.Math.Vec3.new(",
+            Nx.to_flat_list(tensor),
+            ")",
+            opts,
+            &to_doc/2
+          )
+
+        _ ->
+          fallback(tensor, opts)
+      end
+    end
+
+    def inspect(%@for{tensor: tensor}, opts), do: fallback(tensor, opts)
+
+    defp fallback(tensor, opts) do
+      concat(["#BB.Math.Vec3<", to_doc(tensor, opts), ">"])
+    end
+  end
 
   @doc """
   Creates a new vector from x, y, z components.

--- a/test/bb/math/quaternion_test.exs
+++ b/test/bb/math/quaternion_test.exs
@@ -10,6 +10,25 @@ defmodule BB.Math.QuaternionTest do
   @pi :math.pi()
   @tolerance 1.0e-6
 
+  describe "Inspect" do
+    test "uses WXYZ constructor syntax for concrete quaternions" do
+      assert inspect(Quaternion.identity()) ==
+               "BB.Math.Quaternion.new(1.0, 0.0, 0.0, 0.0)"
+    end
+
+    test "respects the inspection limit" do
+      assert inspect(Quaternion.identity(), limit: 2) ==
+               "BB.Math.Quaternion.new(1.0, 0.0, ...)"
+    end
+
+    test "falls back to typed tensor inspection for templates" do
+      inspected = inspect(%Quaternion{tensor: Nx.template({4}, :f64)})
+
+      assert inspected =~ "#BB.Math.Quaternion<#Nx.Tensor<"
+      assert inspected =~ "Nx.TemplateBackend"
+    end
+  end
+
   describe "new/4" do
     test "creates a normalised quaternion" do
       q = Quaternion.new(2, 0, 0, 0)

--- a/test/bb/math/vec3_test.exs
+++ b/test/bb/math/vec3_test.exs
@@ -8,6 +8,23 @@ defmodule BB.Math.Vec3Test do
 
   @tolerance 1.0e-6
 
+  describe "Inspect" do
+    test "uses constructor syntax for concrete vectors" do
+      assert inspect(Vec3.new(1, 2, 3)) == "BB.Math.Vec3.new(1.0, 2.0, 3.0)"
+    end
+
+    test "respects the inspection limit" do
+      assert inspect(Vec3.new(1, 2, 3), limit: 2) == "BB.Math.Vec3.new(1.0, 2.0, ...)"
+    end
+
+    test "falls back to typed tensor inspection for templates" do
+      inspected = inspect(%Vec3{tensor: Nx.template({3}, :f64)})
+
+      assert inspected =~ "#BB.Math.Vec3<#Nx.Tensor<"
+      assert inspected =~ "Nx.TemplateBackend"
+    end
+  end
+
   describe "new/3" do
     test "creates vector from components" do
       v = Vec3.new(1, 2, 3)


### PR DESCRIPTION
## Summary

- inspect host-backed `BB.Math.Vec3` and `BB.Math.Quaternion` values as reconstructable constructor calls
- preserve typed Nx inspection for symbolic, device-backed, and malformed-shape tensors without materialising semantic components
- document the IEx representation and test concrete output, inspection limits, and template fallback

Closes #190.

## Verification

- `mix test test/bb/math/vec3_test.exs test/bb/math/quaternion_test.exs` (86 tests)
- `mix check --no-retry` (1,117 tests including 31 doctests)