### PR TITLE
improvement: support runtime robot parameter defaults

### DIFF
--- a/lib/bb/igniter.ex
+++ b/lib/bb/igniter.ex
@@ -106,20 +106,31 @@ if Code.ensure_loaded?(Igniter) do
     a leaf (rather than the whole opts list) lets independent installers each
     contribute their own defaults without clobbering one another.
 
+    Pass `config_file: "runtime.exs"` to write runtime configuration instead.
+    Values may be `{:code, ast}` for expressions that must be evaluated from the
+    generated configuration file.
+
     The robot's child spec in the application module is rewritten to
     `{<robot_module>, Application.get_env(<app>, <robot_module>, [])}`. If the
     existing child opts are already a non-literal expression — e.g. a
     `robot_opts()` helper call inserted by a composing installer — they're left
     untouched so that switch logic is preserved.
     """
-    @spec set_robot_param_default(Igniter.t(), module(), [atom(), ...], term()) :: Igniter.t()
-    def set_robot_param_default(igniter, robot_module, param_path, value)
+    @spec set_robot_param_default(
+            Igniter.t(),
+            module(),
+            [atom(), ...],
+            term(),
+            Keyword.t()
+          ) :: Igniter.t()
+    def set_robot_param_default(igniter, robot_module, param_path, value, opts \\ [])
         when is_list(param_path) and param_path != [] do
       app_name = Igniter.Project.Application.app_name(igniter)
+      config_file = Keyword.get(opts, :config_file, "config.exs")
 
       igniter
       |> Config.configure(
-        "config.exs",
+        config_file,
         app_name,
         [robot_module, :params | param_path],
         value

--- a/test/bb/igniter_test.exs
+++ b/test/bb/igniter_test.exs
@@ -104,13 +104,29 @@ defmodule BB.IgniterTest do
     end
   end
 
-  describe "set_robot_param_default/4" do
+  describe "set_robot_param_default" do
     test "writes the default as a config leaf under the robot module" do
       project_with_robot()
       |> BB.Igniter.set_robot_param_default(Test.Robot, [:config, :widget, :speed], 100)
       |> assert_creates("config/config.exs", """
       import Config
       config :test, Test.Robot, params: [config: [widget: [speed: 100]]]
+      """)
+    end
+
+    test "writes runtime code to a custom config file" do
+      device = Sourceror.parse_string!(~s|System.get_env("WIDGET_DEVICE", "/dev/widget0")|)
+
+      project_with_robot()
+      |> BB.Igniter.set_robot_param_default(
+        Test.Robot,
+        [:config, :widget, :device],
+        {:code, device},
+        config_file: "runtime.exs"
+      )
+      |> assert_has_patch("config/runtime.exs", """
+      + |config :test, Test.Robot,
+      + |  params: [config: [widget: [device: System.get_env("WIDGET_DEVICE", "/dev/widget0")]]]
       """)
     end
 


### PR DESCRIPTION
## Summary

- allow `BB.Igniter.set_robot_param_default` to target a configurable config file
- support runtime expressions through Igniter's existing `{:code, ast}` value form
- preserve the `/4` API and `config/config.exs` default

## Test plan

- `mix test --no-deps-check test/bb/igniter_test.exs` (19 tests)
- formatter, Credo, and Dialyzer