### PR TITLE
feat!: unify actuator command delivery behind `handle_command/2`

### DIFF
--- a/documentation/how-to/integrate-servo-driver.md
+++ b/documentation/how-to/integrate-servo-driver.md
@@ -94,22 +94,11 @@ defmodule MyServo.Actuator do
   end
 
   @impl BB.Actuator
-  def handle_cast({:command, %Message{payload: %Command.Position{} = cmd}}, state) do
-    if BB.Safety.armed?(state.bb.robot) do
-      do_set_position(cmd, state)
-    else
-      {:noreply, state}
-    end
+  def handle_command(%Message{payload: %Command.Position{} = cmd}, state) do
+    do_set_position(cmd, state)
   end
 
-  @impl BB.Actuator
-  def handle_info({:bb, _path, %Message{payload: %Command.Position{} = cmd}}, state) do
-    if BB.Safety.armed?(state.bb.robot) do
-      do_set_position(cmd, state)
-    else
-      {:noreply, state}
-    end
-  end
+  def handle_command(%Message{}, state), do: {:noreply, state}
 
   defp do_set_position(%Command.Position{} = cmd, state) do
     target = clamp(cmd.position, state.motor_profile)
@@ -328,7 +317,6 @@ defmodule MyServo.ActuatorTest do
   end
 
   test "publishes BeginMotion with motor-space values" do
-    stub(BB.Safety, :armed?, fn _ -> true end)
     stub(MyServo.Hardware, :write, fn _, _ -> :ok end)
 
     expect(BB.Actuator, :publish_begin_motion, fn _robot, _path, opts ->
@@ -345,7 +333,7 @@ defmodule MyServo.ActuatorTest do
 
     {:ok, state} = Actuator.init(opts)
     msg = %Message{payload: %Command.Position{position: 0.5}}
-    Actuator.handle_cast({:command, msg}, state)
+    Actuator.handle_command(msg, state)
   end
 end
 ```

--- a/documentation/tutorials/12-writing-an-actuator.md
+++ b/documentation/tutorials/12-writing-an-actuator.md
@@ -53,23 +53,26 @@ This means each attachment can declare its own relationship to the joint indepen
 ### Inbound: joint-space → motor-space → driver
 
 ```
-BB.Actuator.set_position(MyRobot, [:shoulder, :motor], 1.57)
+BB.Actuator.set_position(MyRobot, [:base, :shoulder, :motor], 1.57)
        │
        │  message published to [:actuator | path]
        ▼
-BB.Actuator.Server  ───►  applies transmission via BB.Transmission.apply_to_command
+BB.Actuator.Server  ───►  refuses the command unless the robot is armed
+       │            ───►  applies transmission via BB.Transmission.apply_to_command
        │
        │  driver receives motor-space command in its callback
        ▼
-MyDriver.handle_cast({:command, motor_space_message}, state)
+MyDriver.handle_command(motor_space_message, state)
 ```
+
+`set_position!/4` and `set_position_sync/5` take the same path — the server subscribes to the actuator's command topic itself and funnels all three transports into `handle_command/2`. Your driver never learns which one was used, and choosing one can't skip the checks.
 
 By the time a `Command.Position`, `Command.Velocity`, `Command.Effort`, or `Command.Trajectory` arrives in your driver's callback, every numeric value is already in motor-space. Your driver does no joint-to-motor maths.
 
 ### Outbound: driver-space (motor) → BB.Actuator → joint-space subscribers
 
 ```
-MyDriver.handle_cast(…, state)
+MyDriver.handle_command(…, state)
        │
        │  builds opts in motor-space, calls
        ▼
@@ -141,13 +144,11 @@ defmodule MyDriver do
   end
 
   @impl BB.Actuator
-  def handle_cast({:command, %Message{payload: %Command.Position{} = cmd}}, state) do
-    if BB.Safety.armed?(state.bb.robot) do
-      do_set_position(cmd, state)
-    else
-      {:noreply, state}
-    end
+  def handle_command(%Message{payload: %Command.Position{} = cmd}, state) do
+    do_set_position(cmd, state)
   end
+
+  def handle_command(%Message{}, state), do: {:noreply, state}
 
   defp do_set_position(cmd, state) do
     target = clamp(cmd.position, state.motor_profile)
@@ -182,6 +183,8 @@ Notice what isn't in there:
 - No call to `BB.Robot.get_joint/2`. The wrapper already looked up the joint.
 - No reference to `BB.Transmission`. The wrapper already applied it on the way in, and `publish_begin_motion/3` applies it on the way out.
 - No code special-casing `reverse?` or asymmetric joint centres. Both are properties of the transmission, which the wrapper handles.
+- No `BB.Safety.armed?/1` check. The wrapper refuses commands to a disarmed robot before they reach you, so a driver can't forget to.
+- No `BB.subscribe/2`. The wrapper owns the actuator's command topic. Subscribe only to topics of your own — those arrive at `handle_info/2` untouched.
 
 ## Validating the motor profile
 

--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -25,12 +25,14 @@ defmodule BB.Actuator do
   ### Required Callbacks
 
   - `init/1` - Initialise actuator state from resolved options
+  - `handle_command/2` - Act on an inbound command
   - `disarm/1` - Make hardware safe (called without GenServer state)
 
   ### Optional Callbacks
 
   - `handle_options/2` - React to parameter changes at runtime
-  - `handle_call/3`, `handle_cast/2`, `handle_info/2` - Standard GenServer-style callbacks
+  - `handle_call/3`, `handle_cast/2`, `handle_info/2` - Standard GenServer-style
+    callbacks, for the driver's own traffic
   - `handle_continue/2`, `terminate/2` - Lifecycle callbacks
   - `options_schema/0` - Define accepted configuration options
 
@@ -59,8 +61,8 @@ defmodule BB.Actuator do
         end
 
         @impl BB.Actuator
-        def handle_cast({:command, msg}, state) do
-          # Handle actuator commands
+        def handle_command(%BB.Message{payload: %Command.Position{} = cmd}, state) do
+          MyHardware.write(state.channel, cmd.position)
           {:noreply, state}
         end
       end
@@ -74,6 +76,9 @@ defmodule BB.Actuator do
         def init(opts) do
           {:ok, %{bb: opts[:bb]}}
         end
+
+        @impl BB.Actuator
+        def handle_command(_message, state), do: {:noreply, state}
 
         @impl BB.Actuator
         def disarm(_opts), do: :ok
@@ -107,14 +112,17 @@ defmodule BB.Actuator do
   ### Delivery Methods
 
   - **Pubsub** (`set_position/4`, etc.) - Commands published to `[:actuator | path]`.
-    Enables logging, replay, and multi-subscriber patterns. Actuators receive
-    commands via `handle_info/2`.
+    Enables logging, replay, and multi-subscriber patterns.
 
   - **Direct** (`set_position!/4`, etc.) - Commands sent directly via `BB.Process.cast`.
-    Lower latency for time-critical control. Actuators receive via `handle_cast/2`.
+    Lower latency for time-critical control.
 
   - **Synchronous** (`set_position_sync/5`, etc.) - Commands sent via `BB.Process.call`.
-    Returns acknowledgement or error. Actuators respond via `handle_call/3`.
+    Returns acknowledgement or error.
+
+  All three converge on `c:handle_command/2`. Which transport a caller chose
+  is not something a driver has to know about, and choosing one cannot skip
+  the checks `BB.Actuator.Server` applies on the way in.
 
   ### Examples
 
@@ -148,6 +156,36 @@ defmodule BB.Actuator do
               | :ignore
 
   @doc """
+  Act on an inbound command.
+
+  Called for every command that reaches this actuator, whichever transport
+  delivered it. By the time it arrives, `BB.Actuator.Server` has checked that
+  the robot is armed and translated the payload from joint-space into
+  motor-space, so the values are ready to write to hardware.
+
+  The reply is used only by the synchronous transport (`set_position_sync/5`
+  and friends); it is discarded for pubsub and direct delivery. Returning
+  `{:noreply, state}` replies `{:ok, :accepted}` to a synchronous caller.
+
+      @impl BB.Actuator
+      def handle_command(%BB.Message{payload: %Command.Position{} = cmd}, state) do
+        MyHardware.write(state.channel, cmd.position)
+        {:noreply, state}
+      end
+
+  Commands the driver doesn't implement should fall through to a catch-all
+  clause rather than crashing the actuator - a `Command.Trajectory` sent to a
+  position-only servo is a caller error, not a hardware fault.
+  """
+  @callback handle_command(command :: BB.Message.t(), state :: term()) ::
+              {:reply, reply :: term(), new_state :: term()}
+              | {:reply, reply :: term(), new_state :: term(),
+                 timeout() | :hibernate | {:continue, term()}}
+              | {:noreply, new_state :: term()}
+              | {:noreply, new_state :: term(), timeout() | :hibernate | {:continue, term()}}
+              | {:stop, reason :: term(), new_state :: term()}
+
+  @doc """
   Make the hardware safe.
 
   Called with the opts provided at registration. Must work without GenServer state.
@@ -167,9 +205,10 @@ defmodule BB.Actuator do
               {:ok, new_state :: term()} | {:stop, reason :: term()}
 
   @doc """
-  Handle synchronous calls.
+  Handle synchronous calls other than commands.
 
-  Same semantics as `c:GenServer.handle_call/3`.
+  Same semantics as `c:GenServer.handle_call/3`. Commands arrive at
+  `c:handle_command/2` regardless of transport.
   """
   @callback handle_call(request :: term(), from :: GenServer.from(), state :: term()) ::
               {:reply, reply :: term(), new_state :: term()}
@@ -181,9 +220,10 @@ defmodule BB.Actuator do
               | {:stop, reason :: term(), reply :: term(), new_state :: term()}
 
   @doc """
-  Handle asynchronous casts.
+  Handle asynchronous casts other than commands.
 
-  Same semantics as `c:GenServer.handle_cast/2`.
+  Same semantics as `c:GenServer.handle_cast/2`. Commands arrive at
+  `c:handle_command/2` regardless of transport.
   """
   @callback handle_cast(request :: term(), state :: term()) ::
               {:noreply, new_state :: term()}
@@ -193,7 +233,10 @@ defmodule BB.Actuator do
   @doc """
   Handle all other messages.
 
-  Same semantics as `c:GenServer.handle_info/2`.
+  Same semantics as `c:GenServer.handle_info/2`. Messages from topics the
+  driver subscribed to itself arrive here untouched - the server neither
+  transforms nor intercepts them. Commands addressed to this actuator arrive
+  at `c:handle_command/2` instead.
   """
   @callback handle_info(msg :: term(), state :: term()) ::
               {:noreply, new_state :: term()}

--- a/lib/bb/actuator/server.ex
+++ b/lib/bb/actuator/server.ex
@@ -9,31 +9,63 @@ defmodule BB.Actuator.Server do
   This module manages the lifecycle of user-defined actuator modules, handling:
   - Parameter reference resolution at startup
   - Subscription to parameter changes
+  - Subscription to the actuator's own command topic
   - Delegation of GenServer callbacks to user module
   - Automatic safety registration
 
   User modules implement the `BB.Actuator` behaviour and define callbacks.
   This server wraps them, providing the actual GenServer implementation.
+
+  ## The inbound command pipeline
+
+  Commands reach an actuator by three transports - published to
+  `[:actuator | path]`, cast via `BB.Process.cast/3`, or called via
+  `BB.Process.call/4`. All three converge here and pass through the same
+  checks before the driver sees them:
+
+  1. The robot must be armed. `BB.Message.Actuator.Command.Stop` is exempt,
+     since stopping is the fail-safe direction and a supervisor must be able
+     to stop a joint it didn't arm.
+  2. The payload is translated from joint-space into motor-space using the
+     joint's transmission.
+
+  The driver then receives it in `c:BB.Actuator.handle_command/2`, and its
+  reply is routed back to whichever transport delivered the command. Messages
+  from topics the driver subscribed to itself are not part of this pipeline -
+  they reach `c:BB.Actuator.handle_info/2` untouched.
   """
 
   use GenServer
 
   alias BB.Actuator.MotorProfile
   alias BB.Component.OptionsSchema
+  alias BB.Error.State.NotArmed
   alias BB.Message
+  alias BB.Message.Actuator.Command
   alias BB.Parameter.Changed, as: ParameterChanged
   alias BB.Robot
+  alias BB.Safety
   alias BB.Server.ParamResolution
   alias BB.Transmission
   alias BB.Transmission.Resolver, as: TransmissionResolver
 
   @framework_keys [:bb, :motor_profile]
 
+  @command_payloads [
+    Command.Effort,
+    Command.Hold,
+    Command.Position,
+    Command.Stop,
+    Command.Trajectory,
+    Command.Velocity
+  ]
+
   defstruct [
     :callback_module,
     :resolved_opts,
     :raw_opts,
     :param_subscriptions,
+    :command_topic,
     :transmission,
     :transmission_subscriptions,
     :joint,
@@ -48,6 +80,7 @@ defmodule BB.Actuator.Server do
           resolved_opts: keyword(),
           raw_opts: keyword(),
           param_subscriptions: %{[atom()] => atom()},
+          command_topic: [atom()],
           transmission: Transmission.t() | nil,
           transmission_subscriptions: %{atom() => [atom()]},
           joint: map() | nil,
@@ -56,6 +89,8 @@ defmodule BB.Actuator.Server do
           bb: %{robot: module(), path: [atom()]},
           user_state: term()
         }
+
+  @typep transport :: :call | :cast | :pubsub
 
   @doc false
   def start_link(init_arg) do
@@ -75,6 +110,9 @@ defmodule BB.Actuator.Server do
 
     {param_subscriptions, resolved_opts} =
       ParamResolution.resolve_and_subscribe(raw_opts, bb.robot)
+
+    command_topic = [:actuator | bb.path]
+    BB.PubSub.subscribe(bb.robot, command_topic, message_types: @command_payloads)
 
     actuator_name = List.last(bb.path)
     {joint, joint_name} = joint_for_actuator(bb)
@@ -99,6 +137,7 @@ defmodule BB.Actuator.Server do
           resolved_opts: resolved_opts,
           raw_opts: raw_opts,
           param_subscriptions: param_subscriptions,
+          command_topic: command_topic,
           transmission: transmission,
           transmission_subscriptions: transmission_subscriptions,
           joint: joint,
@@ -187,9 +226,12 @@ defmodule BB.Actuator.Server do
     end
   end
 
-  def handle_info({:bb, topic, %Message{} = message}, state) do
-    transformed = Transmission.apply_to_command(message, state.transmission)
-    delegate_handle_info({:bb, topic, transformed}, state)
+  def handle_info(
+        {:bb, topic, %Message{payload: %payload_module{}} = message},
+        %__MODULE__{command_topic: topic} = state
+      )
+      when payload_module in @command_payloads do
+    dispatch_command(message, :pubsub, state)
   end
 
   def handle_info(msg, state), do: delegate_handle_info(msg, state)
@@ -208,9 +250,8 @@ defmodule BB.Actuator.Server do
   end
 
   @impl GenServer
-  def handle_call({:command, %Message{} = message}, from, state) do
-    transformed = Transmission.apply_to_command(message, state.transmission)
-    delegate_handle_call({:command, transformed}, from, state)
+  def handle_call({:command, %Message{} = message}, _from, state) do
+    dispatch_command(message, :call, state)
   end
 
   def handle_call(request, from, state), do: delegate_handle_call(request, from, state)
@@ -239,8 +280,7 @@ defmodule BB.Actuator.Server do
 
   @impl GenServer
   def handle_cast({:command, %Message{} = message}, state) do
-    transformed = Transmission.apply_to_command(message, state.transmission)
-    delegate_handle_cast({:command, transformed}, state)
+    dispatch_command(message, :cast, state)
   end
 
   def handle_cast(request, state), do: delegate_handle_cast(request, state)
@@ -257,6 +297,92 @@ defmodule BB.Actuator.Server do
         {:stop, reason, %{state | user_state: new_user_state}}
     end
   end
+
+  @spec dispatch_command(Message.t(), transport(), t()) :: term()
+  defp dispatch_command(message, transport, state) do
+    case authorise(message, state) do
+      :ok ->
+        message
+        |> Transmission.apply_to_command(state.transmission)
+        |> delegate_handle_command(transport, state)
+
+      {:error, reason, error} ->
+        refuse(message, reason, error, transport, state)
+    end
+  end
+
+  defp authorise(%Message{payload: %Command.Stop{}}, _state), do: :ok
+
+  defp authorise(%Message{payload: %payload_module{}}, state) do
+    if Safety.armed?(state.bb.robot) do
+      :ok
+    else
+      {:error, :disarmed,
+       NotArmed.exception(
+         robot: state.bb.robot,
+         actuator: state.actuator_name,
+         command: payload_module
+       )}
+    end
+  end
+
+  defp refuse(message, reason, error, transport, state) do
+    :telemetry.execute(
+      [:bb, :actuator, :rejected],
+      %{count: 1},
+      %{
+        robot: state.bb.robot,
+        actuator: state.actuator_name,
+        transport: transport,
+        payload_module: message.payload.__struct__,
+        reason: reason
+      }
+    )
+
+    command_reply(transport, {:error, error}, state)
+  end
+
+  defp delegate_handle_command(message, transport, state) do
+    case state.callback_module.handle_command(message, state.user_state) do
+      {:reply, reply, new_user_state} ->
+        command_reply(transport, reply, %{state | user_state: new_user_state})
+
+      {:reply, reply, new_user_state, timeout_or_continue} ->
+        command_reply(
+          transport,
+          reply,
+          %{state | user_state: new_user_state},
+          timeout_or_continue
+        )
+
+      {:noreply, new_user_state} ->
+        command_reply(transport, {:ok, :accepted}, %{state | user_state: new_user_state})
+
+      {:noreply, new_user_state, timeout_or_continue} ->
+        command_reply(
+          transport,
+          {:ok, :accepted},
+          %{state | user_state: new_user_state},
+          timeout_or_continue
+        )
+
+      {:stop, reason, new_user_state} ->
+        {:stop, reason, %{state | user_state: new_user_state}}
+    end
+  end
+
+  # Only the synchronous transport has anywhere to put a reply; the others are
+  # fire-and-forget and the server is answering `handle_cast`/`handle_info`.
+  defp command_reply(transport, reply, state, timeout_or_continue \\ nil)
+  defp command_reply(:call, reply, state, nil), do: {:reply, reply, state}
+
+  defp command_reply(:call, reply, state, timeout_or_continue),
+    do: {:reply, reply, state, timeout_or_continue}
+
+  defp command_reply(_transport, _reply, state, nil), do: {:noreply, state}
+
+  defp command_reply(_transport, _reply, state, timeout_or_continue),
+    do: {:noreply, state, timeout_or_continue}
 
   @impl GenServer
   def handle_continue(continue_arg, state) do

--- a/lib/bb/error/state/not_armed.ex
+++ b/lib/bb/error/state/not_armed.ex
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.State.NotArmed do
+  @moduledoc """
+  Command refused because the robot is not armed.
+
+  `BB.Actuator.Server` checks `BB.Safety.armed?/1` before handing a command
+  to a driver, so no actuator can drive hardware while the robot is disarmed.
+  Stop commands are exempt and never produce this error.
+
+  This is a `:state` error rather than a `:safety` one: the safety system
+  working as intended is not a safety violation.
+  """
+  use BB.Error,
+    class: :state,
+    fields: [:robot, :actuator, :command]
+
+  @type t :: %__MODULE__{
+          robot: module() | nil,
+          actuator: atom(),
+          command: module()
+        }
+
+  defimpl BB.Error.Severity do
+    def severity(_), do: :error
+  end
+
+  def message(%{actuator: actuator, command: command}) do
+    "Actuator #{inspect(actuator)} refused #{inspect(command)}: robot is not armed"
+  end
+end

--- a/lib/bb/sim/actuator.ex
+++ b/lib/bb/sim/actuator.ex
@@ -9,7 +9,7 @@ defmodule BB.Sim.Actuator do
   This actuator is automatically used in place of real actuators when the robot
   is started with `simulation: :kinematic`. It:
 
-  - Receives position commands via pubsub, cast, and call
+  - Receives position commands from any transport via `handle_command/2`
   - Calculates motion timing from the motor profile's velocity and
     acceleration limits
   - Publishes `BeginMotion` messages (in joint-space, via
@@ -77,40 +77,11 @@ defmodule BB.Sim.Actuator do
   end
 
   @impl BB.Actuator
-  def handle_info({:bb, _path, %Message{payload: %Command.Position{} = cmd}}, state) do
+  def handle_command(%Message{payload: %Command.Position{} = cmd}, state) do
     {:noreply, do_set_position(cmd.position, cmd.command_id, state)}
   end
 
-  def handle_info({:bb, _path, %Message{payload: %Command.Stop{}}}, state) do
-    {:noreply, state}
-  end
-
-  def handle_info({:bb, _path, %Message{payload: %Command.Hold{}}}, state) do
-    {:noreply, state}
-  end
-
-  def handle_info({:bb, _path, _message}, state) do
-    {:noreply, state}
-  end
-
-  @impl BB.Actuator
-  def handle_cast({:command, %Message{payload: %Command.Position{} = cmd}}, state) do
-    {:noreply, do_set_position(cmd.position, cmd.command_id, state)}
-  end
-
-  def handle_cast({:command, _message}, state) do
-    {:noreply, state}
-  end
-
-  @impl BB.Actuator
-  def handle_call({:command, %Message{payload: %Command.Position{} = cmd}}, _from, state) do
-    new_state = do_set_position(cmd.position, cmd.command_id, state)
-    {:reply, {:ok, :accepted}, new_state}
-  end
-
-  def handle_call({:command, _message}, _from, state) do
-    {:reply, {:ok, :accepted}, state}
-  end
+  def handle_command(%Message{}, state), do: {:noreply, state}
 
   defp do_set_position(target_motor_position, command_id, state) do
     now = System.monotonic_time(:millisecond)

--- a/test/bb/actuator/server_command_pipeline_test.exs
+++ b/test/bb/actuator/server_command_pipeline_test.exs
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Actuator.ServerCommandPipelineTest do
+  use ExUnit.Case
+
+  alias BB.Error.State.NotArmed
+  alias BB.Message
+  alias BB.Message.Actuator.BeginMotion
+  alias BB.Message.Actuator.Command
+
+  defmodule ArmedRobot do
+    use BB
+
+    topology do
+      link :base do
+        joint :shoulder do
+          type :revolute
+
+          limit do
+            effort(~u(10 newton_meter))
+            velocity(~u(180 degree_per_second))
+          end
+
+          actuator :motor, BB.Test.RecordingActuator
+
+          link :arm
+        end
+      end
+    end
+  end
+
+  defmodule DisarmedRobot do
+    use BB
+
+    topology do
+      link :base do
+        joint :shoulder do
+          type :revolute
+
+          limit do
+            effort(~u(10 newton_meter))
+            velocity(~u(180 degree_per_second))
+          end
+
+          actuator :motor, BB.Test.RecordingActuator
+
+          link :arm
+        end
+      end
+    end
+  end
+
+  defmodule SubscribingRobot do
+    use BB
+
+    topology do
+      link :base do
+        joint :shoulder do
+          type :revolute
+
+          limit do
+            effort(~u(10 newton_meter))
+            velocity(~u(180 degree_per_second))
+          end
+
+          actuator :motor, {BB.Test.RecordingActuator, subscribe_to: [:sensor, :probe]} do
+            transmission do
+              reduction 50.0
+            end
+          end
+
+          link :arm
+        end
+      end
+    end
+  end
+
+  @actuator_topic [:actuator, :base, :shoulder, :motor]
+
+  defp start_robot(robot_module) do
+    :persistent_term.put({BB.Test.RecordingActuator, robot_module}, self())
+    start_supervised!(robot_module)
+    on_exit(fn -> :persistent_term.erase({BB.Test.RecordingActuator, robot_module}) end)
+  end
+
+  defp position(value), do: Message.new!(Command.Position, :motor, position: value)
+
+  describe "transports" do
+    setup do
+      start_robot(ArmedRobot)
+      :ok = BB.Safety.arm(ArmedRobot)
+      :ok
+    end
+
+    test "a published command reaches the driver, which never subscribed itself" do
+      :ok = BB.publish(ArmedRobot, @actuator_topic, position(0.5))
+
+      assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.5}}},
+                     500
+    end
+
+    test "set_position/4 reaches the driver via the actuator's full path" do
+      :ok = BB.Actuator.set_position(ArmedRobot, [:base, :shoulder, :motor], 0.25)
+
+      assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.25}}},
+                     500
+    end
+
+    test "a cast command reaches the driver" do
+      :ok = BB.cast(ArmedRobot, :motor, {:command, position(0.5)})
+
+      assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.5}}},
+                     500
+    end
+
+    test "a call command reaches the driver and is acknowledged" do
+      assert {:ok, :accepted} =
+               BB.call(ArmedRobot, :motor, {:command, position(0.5)}, 500)
+
+      assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.5}}},
+                     500
+    end
+
+    test "the actuator does not receive its own outbound BeginMotion" do
+      begin_motion =
+        Message.new!(BeginMotion, :shoulder,
+          initial_position: 0.0,
+          target_position: 1.0,
+          expected_arrival: System.monotonic_time(:millisecond) + 100
+        )
+
+      :ok = BB.publish(ArmedRobot, @actuator_topic, begin_motion)
+
+      refute_receive {:received, _kind, %Message{payload: %BeginMotion{}}}, 200
+    end
+  end
+
+  describe "arm gating" do
+    setup do
+      start_robot(DisarmedRobot)
+      :ok
+    end
+
+    test "a published command is dropped while disarmed" do
+      :ok = BB.publish(DisarmedRobot, @actuator_topic, position(0.5))
+
+      refute_receive {:received, :command, _message}, 200
+    end
+
+    test "a cast command is dropped while disarmed" do
+      :ok = BB.cast(DisarmedRobot, :motor, {:command, position(0.5)})
+
+      refute_receive {:received, :command, _message}, 200
+    end
+
+    test "a call command is refused with a structured error while disarmed" do
+      assert {:error, %NotArmed{actuator: :motor, command: Command.Position}} =
+               BB.call(DisarmedRobot, :motor, {:command, position(0.5)}, 500)
+
+      refute_receive {:received, :command, _message}, 200
+    end
+
+    test "Stop commands are exempt from the arm gate" do
+      :ok = BB.cast(DisarmedRobot, :motor, {:command, Message.new!(Command.Stop, :motor, [])})
+
+      assert_receive {:received, :command, %Message{payload: %Command.Stop{}}}, 500
+    end
+
+    test "Hold commands are not exempt from the arm gate" do
+      :ok = BB.cast(DisarmedRobot, :motor, {:command, Message.new!(Command.Hold, :motor, [])})
+
+      refute_receive {:received, :command, _message}, 200
+    end
+
+    test "commands flow once the robot is armed" do
+      :ok = BB.Safety.arm(DisarmedRobot)
+      :ok = BB.publish(DisarmedRobot, @actuator_topic, position(0.5))
+
+      assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.5}}},
+                     500
+    end
+
+    test "a rejected command emits telemetry" do
+      handler = {__MODULE__, :rejected, self()}
+
+      :telemetry.attach(
+        handler,
+        [:bb, :actuator, :rejected],
+        fn event, measurements, metadata, pid ->
+          send(pid, {:telemetry, event, measurements, metadata})
+        end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      :ok = BB.cast(DisarmedRobot, :motor, {:command, position(0.5)})
+
+      assert_receive {:telemetry, [:bb, :actuator, :rejected], %{count: 1}, metadata}, 500
+      assert metadata.actuator == :motor
+      assert metadata.transport == :cast
+      assert metadata.reason == :disarmed
+      assert metadata.payload_module == Command.Position
+    end
+  end
+
+  describe "the driver's own subscriptions" do
+    setup do
+      start_robot(SubscribingRobot)
+      :ok = BB.Safety.arm(SubscribingRobot)
+      :ok
+    end
+
+    test "arrive in handle_info/2 without the transmission applied" do
+      :ok = BB.publish(SubscribingRobot, [:sensor, :probe], position(0.5))
+
+      assert_receive {:received, :info, %Message{payload: %Command.Position{position: 0.5}}}, 500
+      refute_receive {:received, :command, _message}, 200
+    end
+
+    test "while commands on its own topic still get the transmission" do
+      :ok = BB.publish(SubscribingRobot, @actuator_topic, position(0.5))
+
+      assert_receive {:received, :command, %Message{payload: %Command.Position{} = cmd}}, 500
+      assert_in_delta cmd.position, 25.0, 1.0e-9
+    end
+  end
+end

--- a/test/bb/actuator/server_transmission_test.exs
+++ b/test/bb/actuator/server_transmission_test.exs
@@ -61,7 +61,11 @@ defmodule BB.Actuator.ServerTransmissionTest do
   defp start_robot(robot_module) do
     :persistent_term.put({BB.Test.RecordingActuator, robot_module}, self())
     start_supervised!(robot_module)
-    on_exit(fn -> :persistent_term.erase({BB.Test.RecordingActuator, robot_module}) end)
+    :ok = BB.Safety.arm(robot_module)
+
+    on_exit(fn ->
+      :persistent_term.erase({BB.Test.RecordingActuator, robot_module})
+    end)
   end
 
   describe "with a transmission" do
@@ -78,7 +82,7 @@ defmodule BB.Actuator.ServerTransmissionTest do
           Message.new!(Command.Position, :motor, position: :math.pi() / 4 + 0.01)
         )
 
-      assert_receive {:received, :info, %Message{payload: %Command.Position{} = cmd}}, 500
+      assert_receive {:received, :command, %Message{payload: %Command.Position{} = cmd}}, 500
 
       expected = BB.Transmission.apply_position(:math.pi() / 4 + 0.01, @transmission)
       assert_in_delta cmd.position, expected, 1.0e-9
@@ -88,7 +92,7 @@ defmodule BB.Actuator.ServerTransmissionTest do
       message = Message.new!(Command.Position, :motor, position: :math.pi() / 4 + 0.01)
       :ok = BB.cast(WithTransmission, :motor, {:command, message})
 
-      assert_receive {:received, :cast, %Message{payload: %Command.Position{} = cmd}}, 500
+      assert_receive {:received, :command, %Message{payload: %Command.Position{} = cmd}}, 500
       expected = BB.Transmission.apply_position(:math.pi() / 4 + 0.01, @transmission)
       assert_in_delta cmd.position, expected, 1.0e-9
     end
@@ -97,7 +101,7 @@ defmodule BB.Actuator.ServerTransmissionTest do
       message = Message.new!(Command.Position, :motor, position: :math.pi() / 4 + 0.01)
       {:ok, :accepted} = BB.call(WithTransmission, :motor, {:command, message}, 500)
 
-      assert_receive {:received, :call, %Message{payload: %Command.Position{} = cmd}}, 500
+      assert_receive {:received, :command, %Message{payload: %Command.Position{} = cmd}}, 500
       expected = BB.Transmission.apply_position(:math.pi() / 4 + 0.01, @transmission)
       assert_in_delta cmd.position, expected, 1.0e-9
     end
@@ -108,7 +112,7 @@ defmodule BB.Actuator.ServerTransmissionTest do
 
       :ok = BB.cast(WithTransmission, :motor, {:command, message})
 
-      assert_receive {:received, :cast, %Message{payload: %Command.Position{} = cmd}}, 500
+      assert_receive {:received, :command, %Message{payload: %Command.Position{} = cmd}}, 500
       assert_in_delta cmd.velocity, -50.0 * 0.1, 1.0e-9
     end
 
@@ -116,7 +120,7 @@ defmodule BB.Actuator.ServerTransmissionTest do
       hold = Message.new!(Command.Hold, :motor, [])
       :ok = BB.cast(WithTransmission, :motor, {:command, hold})
 
-      assert_receive {:received, :cast, %Message{payload: %Command.Hold{}}}, 500
+      assert_receive {:received, :command, %Message{payload: %Command.Hold{}}}, 500
     end
   end
 
@@ -130,7 +134,7 @@ defmodule BB.Actuator.ServerTransmissionTest do
       message = Message.new!(Command.Position, :motor, position: 1.23)
       :ok = BB.cast(WithoutTransmission, :motor, {:command, message})
 
-      assert_receive {:received, :cast, %Message{payload: %Command.Position{position: p}}}, 500
+      assert_receive {:received, :command, %Message{payload: %Command.Position{position: p}}}, 500
       assert p == 1.23
     end
   end

--- a/test/bb/integration/child_spec_param_ref_test.exs
+++ b/test/bb/integration/child_spec_param_ref_test.exs
@@ -55,6 +55,9 @@ defmodule BB.Integration.ChildSpecParamRefTest do
       StateTracker.record({:actuator_handle_options, new_max_effort})
       {:ok, %{state | max_effort: new_max_effort}}
     end
+
+    @impl BB.Actuator
+    def handle_command(_message, state), do: {:noreply, state}
   end
 
   defmodule ParamTrackingSensor do

--- a/test/bb/supervisor_test.exs
+++ b/test/bb/supervisor_test.exs
@@ -38,6 +38,9 @@ defmodule BB.SupervisorTest do
     end
 
     @impl BB.Actuator
+    def handle_command(_message, state), do: {:noreply, state}
+
+    @impl BB.Actuator
     def handle_call(:get_state, _from, state) do
       {:reply, state, state}
     end

--- a/test/support/failing_actuator.ex
+++ b/test/support/failing_actuator.ex
@@ -29,4 +29,7 @@ defmodule BB.Test.FailingActuator do
 
     {:ok, %{}}
   end
+
+  @impl BB.Actuator
+  def handle_command(_message, state), do: {:noreply, state}
 end

--- a/test/support/mock_actuator.ex
+++ b/test/support/mock_actuator.ex
@@ -17,19 +17,7 @@ defmodule BB.Test.MockActuator do
   end
 
   @impl BB.Actuator
-  def handle_cast({:command, _message}, state) do
-    {:noreply, state}
-  end
-
-  @impl BB.Actuator
-  def handle_call({:command, _message}, _from, state) do
-    {:reply, {:ok, :accepted}, state}
-  end
-
-  @impl BB.Actuator
-  def handle_info({:bb, _path, _message}, state) do
-    {:noreply, state}
-  end
+  def handle_command(_message, state), do: {:noreply, state}
 end
 
 # Aliases for various test module names
@@ -46,6 +34,9 @@ defmodule ServoMotor do
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+
+  @impl BB.Actuator
+  def handle_command(_message, state), do: {:noreply, state}
 end
 
 defmodule MainMotor do
@@ -57,6 +48,9 @@ defmodule MainMotor do
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+
+  @impl BB.Actuator
+  def handle_command(_message, state), do: {:noreply, state}
 end
 
 defmodule BrakeActuator do
@@ -68,6 +62,9 @@ defmodule BrakeActuator do
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+
+  @impl BB.Actuator
+  def handle_command(_message, state), do: {:noreply, state}
 end
 
 defmodule ShoulderMotor do
@@ -79,6 +76,9 @@ defmodule ShoulderMotor do
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+
+  @impl BB.Actuator
+  def handle_command(_message, state), do: {:noreply, state}
 end
 
 defmodule ElbowMotor do
@@ -90,6 +90,9 @@ defmodule ElbowMotor do
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+
+  @impl BB.Actuator
+  def handle_command(_message, state), do: {:noreply, state}
 end
 
 defmodule MyMotor do
@@ -101,6 +104,9 @@ defmodule MyMotor do
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+
+  @impl BB.Actuator
+  def handle_command(_message, state), do: {:noreply, state}
 end
 
 defmodule TestActuator do
@@ -116,4 +122,7 @@ defmodule TestActuator do
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
+
+  @impl BB.Actuator
+  def handle_command(_message, state), do: {:noreply, state}
 end

--- a/test/support/recording_actuator.ex
+++ b/test/support/recording_actuator.ex
@@ -11,10 +11,25 @@ defmodule BB.Test.RecordingActuator do
       :persistent_term.put({BB.Test.RecordingActuator, MyRobot}, self())
 
   The actuator looks up the recipient at init and sends
-  `{:received, kind, message}` for each incoming command. `kind` is one of
-  `:info`, `:cast`, or `:call`.
+  `{:received, :command, message}` for each command, whichever transport
+  delivered it - a driver can't tell, and shouldn't need to.
+
+  It deliberately does not subscribe to its own command topic: the framework
+  owns that subscription, and a double that subscribed for itself would pass
+  the tests whether or not the framework did its job.
+
+  Pass `subscribe_to:` to have it subscribe to some other topic. Messages
+  arriving there are forwarded as `{:received, :info, message}`, which is how
+  the tests check that the server leaves a driver's own subscriptions alone.
   """
-  use BB.Actuator, options_schema: []
+  use BB.Actuator,
+    options_schema: [
+      subscribe_to: [
+        type: {:list, :atom},
+        required: false,
+        doc: "An additional pubsub topic for the actuator to subscribe to itself"
+      ]
+    ]
 
   @impl BB.Actuator
   def disarm(_opts), do: :ok
@@ -23,8 +38,19 @@ defmodule BB.Test.RecordingActuator do
   def init(opts) do
     bb = Keyword.fetch!(opts, :bb)
     recipient = :persistent_term.get({__MODULE__, bb.robot}, nil)
-    BB.subscribe(bb.robot, [:actuator | bb.path])
+
+    case Keyword.get(opts, :subscribe_to) do
+      nil -> :ok
+      topic -> BB.subscribe(bb.robot, topic)
+    end
+
     {:ok, %{recipient: recipient}}
+  end
+
+  @impl BB.Actuator
+  def handle_command(%BB.Message{} = message, state) do
+    forward(state.recipient, :command, message)
+    {:noreply, state}
   end
 
   @impl BB.Actuator
@@ -34,18 +60,6 @@ defmodule BB.Test.RecordingActuator do
   end
 
   def handle_info(_msg, state), do: {:noreply, state}
-
-  @impl BB.Actuator
-  def handle_cast({:command, %BB.Message{} = message}, state) do
-    forward(state.recipient, :cast, message)
-    {:noreply, state}
-  end
-
-  @impl BB.Actuator
-  def handle_call({:command, %BB.Message{} = message}, _from, state) do
-    forward(state.recipient, :call, message)
-    {:reply, {:ok, :accepted}, state}
-  end
 
   defp forward(nil, _kind, _message), do: :ok
   defp forward(pid, kind, message), do: send(pid, {:received, kind, message})

--- a/usage-rules/actuators.md
+++ b/usage-rules/actuators.md
@@ -11,8 +11,8 @@ first (see `bb:safety-and-commands`) — commands to a disarmed robot are
 ignored.
 
 ```elixir
-# By full path within the topology ([joint, actuator]), value in radians:
-BB.Actuator.set_position(MyRobot.Robot, [:pan_joint, :servo], 0.785)
+# By full path within the topology ([link, joint, actuator]), value in radians:
+BB.Actuator.set_position(MyRobot.Robot, [:base_link, :pan_joint, :servo], 0.785)
 
 # By the actuator's unique name (raises on error):
 BB.Actuator.set_position!(MyRobot.Robot, :servo, 0.785)
@@ -21,9 +21,10 @@ BB.Actuator.set_position!(MyRobot.Robot, :servo, 0.785)
 The DSL takes `~u` sigil values; the runtime command functions take plain
 numbers in SI base units (radians here).
 
-- `set_position/4` takes the **full path** (a list) to the actuator;
-  `set_position!/4` takes just the actuator's unique **name**. `set_velocity`
-  and `set_effort` follow the same pair.
+- `set_position/4` takes the **full path** (a list) to the actuator — every
+  link and joint from the root, not just the joint. `set_position!/4` takes
+  just the actuator's unique **name**. `set_velocity` and `set_effort` follow
+  the same pair.
 - Positions are in **radians**, velocities in rad/s — SI base units, the same
   units the compiled robot struct uses.
 - Use `set_position_sync/5` when you need to wait for acknowledgement rather
@@ -39,19 +40,33 @@ in motor-space — the driver does no joint-to-motor maths.
 
 ## Writing an actuator
 
-`use BB.Actuator`, define `init/1`, the GenServer callbacks, and the
-**required** `disarm/1`. Handle command messages in `handle_cast/2`:
+`use BB.Actuator`, define `init/1`, the **required** `handle_command/2`, and
+the **required** `disarm/1`. Every command arrives at `handle_command/2`
+whichever of the three functions above sent it — a driver can't tell, and
+doesn't need to:
 
 ```elixir
 alias BB.Message.Actuator.Command
 
-def handle_cast({:command, %BB.Message{payload: %Command.Position{} = cmd}}, state) do
+def handle_command(%BB.Message{payload: %Command.Position{} = cmd}, state) do
   drive_hardware(cmd, state)
   {:noreply, state}
 end
 
 def disarm(opts), do: cut_power(opts)   # must work without GenServer state
 ```
+
+Return `{:reply, reply, state}` to answer a `set_position_sync/5` caller;
+`{:noreply, state}` replies `{:ok, :accepted}` for you. The reply is discarded
+for the other two transports.
+
+Don't check `BB.Safety.armed?/1` in a driver — `BB.Actuator.Server` refuses
+commands to a disarmed robot before they reach you. `Command.Stop` is the one
+exception and is always delivered.
+
+`handle_info/2`, `handle_cast/2` and `handle_call/3` remain available for the
+driver's own traffic (bus replies, timers, topics it subscribed to itself).
+Those messages are passed through untouched.
 
 To report position back in joint-space, either let BB publish for you
 (`BB.Actuator.publish_begin_motion/3`) or translate with


### PR DESCRIPTION
Implements Phase 1 and Phase 3 of [Proposal 0021](https://github.com/beam-bots/proposals/pull/53).

Fixes #201. Lays the groundwork for #148 — the single choke point an ownership model needs — but does **not** implement arbitration; that's Phase 2.

## What was broken

`BB.Actuator.Server` never subscribed to `[:actuator | path]`, so the entire pubsub command path was a no-op. That's wider than `set_position/4`: `BB.Motion.move_to/4`, `move_to_multi/3` and `send_positions/3` all default to `delivery: :pubsub`, so the inverse-kinematics API silently did nothing on its default transport. `bb_pid_controller`'s output topic and `bb_policy`'s actuator effect were dead for the same reason.

It survived because the only test covering pubsub delivery used a support module that subscribed *itself*, with the correct path — so the test passed while testing the double.

## What this changes

**One inbound callback.** All three transports (pubsub, cast, call) now converge on a required `handle_command/2`. Drivers were implementing the same command logic once per transport — roughly eighteen clauses across five implementations, differing only in how the framework chose to deliver. Replies are routed back per transport; `{:noreply, state}` answers `{:ok, :accepted}` to a synchronous caller.

**The server owns the subscription**, filtered to the six `Command.*` payloads. The filter matters: `publish_begin_motion/3` publishes to the same topic, so an unfiltered subscription would hand every actuator its own outbound traffic.

**Arm state is enforced centrally.** Previously each driver was expected to call `BB.Safety.armed?/1` and three of five didn't — so `set_position!/4` on a disarmed robot wrote PWM to real PCA9685 and pigpio hardware. `Command.Stop` is exempt (stopping is the fail-safe direction); `Command.Hold` is not (it energises). Refusals return `BB.Error.State.NotArmed` to synchronous callers and emit `[:bb, :actuator, :rejected]` telemetry.

**The catch-all `{:bb, _topic, %Message{}}` clause is narrowed** to the actuator's own command topic. It previously applied *this* actuator's transmission to any message the driver subscribed to itself — so a follower tracking a leader arm would have had the command silently rescaled.

## Breaking change

`BB.Actuator` implementations must define `handle_command/2`, and should drop their per-transport command clauses, any `BB.subscribe/2` on their own command topic, and any `BB.Safety.armed?/1` checks. Elixir's required-callback warning names every module that needs it.

Migrations for `bb_servo_feetech`, `bb_servo_robotis`, `bb_servo_pca9685`, `bb_servo_pigpio` and `bb_ik_fabrik` are ready and passing locally, but can't be opened until 0.23.0 is on hex — their CI resolves `bb` from there. Verified end to end with `BB_VERSION=local`: all 15 workspace packages green, 2028 tests.

## Docs

Tutorial 12, `documentation/how-to/integrate-servo-driver.md` and `usage-rules/actuators.md` all taught the old contract. The usage-rules path example was also wrong in exactly the way that caused this bug — `[:pan_joint, :servo]`, omitting the link segment — which is the same mistake two of the five drivers made.