### PR TITLE
feat: address actuators by name or by full path

### DIFF
--- a/documentation/tutorials/12-writing-an-actuator.md
+++ b/documentation/tutorials/12-writing-an-actuator.md
@@ -53,9 +53,9 @@ This means each attachment can declare its own relationship to the joint indepen
 ### Inbound: joint-space → motor-space → driver
 
 ```
-BB.Actuator.set_position(MyRobot, [:base, :shoulder, :motor], 1.57)
+BB.Actuator.set_position(MyRobot, :motor, 1.57)
        │
-       │  message published to [:actuator | path]
+       │  name resolved to [:base, :shoulder, :motor], published to [:actuator | path]
        ▼
 BB.Actuator.Server  ───►  refuses the command unless the robot is armed
        │            ───►  applies transmission via BB.Transmission.apply_to_command

--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -124,10 +124,22 @@ defmodule BB.Actuator do
   is not something a driver has to know about, and choosing one cannot skip
   the checks `BB.Actuator.Server` applies on the way in.
 
+  ### Addressing
+
+  Every function accepts either the actuator's unique name or its full path
+  through the topology. Names are resolved against the robot with
+  `BB.Robot.actuator_path/2`, so the two are interchangeable:
+
+      BB.Actuator.set_position(MyRobot, :shoulder_servo, 1.57)
+      BB.Actuator.set_position(MyRobot, [:base_link, :shoulder, :shoulder_servo], 1.57)
+
+  Naming an actuator the robot doesn't have raises `ArgumentError` rather than
+  publishing to a topic nothing is listening on.
+
   ### Examples
 
       # Pubsub delivery (for kinematics/orchestration)
-      BB.Actuator.set_position(MyRobot, [:base_link, :shoulder, :servo], 1.57)
+      BB.Actuator.set_position(MyRobot, :shoulder_servo, 1.57)
 
       # Direct delivery (for time-critical control)
       BB.Actuator.set_position!(MyRobot, :shoulder_servo, 1.57)
@@ -324,8 +336,15 @@ defmodule BB.Actuator do
   alias BB.Message
   alias BB.Message.Actuator.BeginMotion
   alias BB.Message.Actuator.Command
+  alias BB.Robot
   alias BB.Transmission
   alias BB.Transmission.Resolver, as: TransmissionResolver
+
+  @typedoc """
+  How to address an actuator: its unique name, or its full path through the
+  topology. Every function below accepts either.
+  """
+  @type target :: atom() | [atom()]
 
   # ----------------------------------------------------------------------------
   # Outbound publishing
@@ -405,8 +424,9 @@ defmodule BB.Actuator do
       BB.Actuator.set_position(MyRobot, [:base_link, :shoulder, :servo], 1.57)
       BB.Actuator.set_position(MyRobot, [:shoulder, :servo], 1.57, velocity: 0.5)
   """
-  @spec set_position(module(), [atom()], number(), keyword()) :: :ok
-  def set_position(robot, path, position, opts \\ []) do
+  @spec set_position(module(), target(), number(), keyword()) :: :ok
+  def set_position(robot, target, position, opts \\ []) do
+    path = actuator_path!(robot, target)
     message = build_position_message(path, position, opts)
     BB.publish(robot, [:actuator | path], message)
   end
@@ -421,8 +441,9 @@ defmodule BB.Actuator do
 
   Same as `set_position/4`.
   """
-  @spec set_position!(module(), atom(), number(), keyword()) :: :ok
-  def set_position!(robot, actuator_name, position, opts \\ []) do
+  @spec set_position!(module(), target(), number(), keyword()) :: :ok
+  def set_position!(robot, target, position, opts \\ []) do
+    actuator_name = actuator_name!(robot, target)
     message = build_position_message(actuator_name, position, opts)
     BB.cast(robot, actuator_name, {:command, message})
   end
@@ -444,9 +465,10 @@ defmodule BB.Actuator do
   - `{:ok, :accepted, map()}` - Command accepted with additional info
   - `{:error, reason}` - Command rejected
   """
-  @spec set_position_sync(module(), atom(), number(), keyword(), timeout()) ::
+  @spec set_position_sync(module(), target(), number(), keyword(), timeout()) ::
           {:ok, :accepted | {:accepted, map()}} | {:error, term()}
-  def set_position_sync(robot, actuator_name, position, opts \\ [], timeout \\ 5000) do
+  def set_position_sync(robot, target, position, opts \\ [], timeout \\ 5000) do
+    actuator_name = actuator_name!(robot, target)
     message = build_position_message(actuator_name, position, opts)
     BB.call(robot, actuator_name, {:command, message}, timeout)
   end
@@ -474,8 +496,9 @@ defmodule BB.Actuator do
   - `:duration` - Duration (milliseconds), nil = until stopped
   - `:command_id` - Correlation ID for feedback tracking
   """
-  @spec set_velocity(module(), [atom()], number(), keyword()) :: :ok
-  def set_velocity(robot, path, velocity, opts \\ []) do
+  @spec set_velocity(module(), target(), number(), keyword()) :: :ok
+  def set_velocity(robot, target, velocity, opts \\ []) do
+    path = actuator_path!(robot, target)
     message = build_velocity_message(path, velocity, opts)
     BB.publish(robot, [:actuator | path], message)
   end
@@ -483,8 +506,9 @@ defmodule BB.Actuator do
   @doc """
   Send a velocity command directly to an actuator (bypasses pubsub).
   """
-  @spec set_velocity!(module(), atom(), number(), keyword()) :: :ok
-  def set_velocity!(robot, actuator_name, velocity, opts \\ []) do
+  @spec set_velocity!(module(), target(), number(), keyword()) :: :ok
+  def set_velocity!(robot, target, velocity, opts \\ []) do
+    actuator_name = actuator_name!(robot, target)
     message = build_velocity_message(actuator_name, velocity, opts)
     BB.cast(robot, actuator_name, {:command, message})
   end
@@ -492,9 +516,10 @@ defmodule BB.Actuator do
   @doc """
   Send a velocity command and wait for acknowledgement.
   """
-  @spec set_velocity_sync(module(), atom(), number(), keyword(), timeout()) ::
+  @spec set_velocity_sync(module(), target(), number(), keyword(), timeout()) ::
           {:ok, :accepted | {:accepted, map()}} | {:error, term()}
-  def set_velocity_sync(robot, actuator_name, velocity, opts \\ [], timeout \\ 5000) do
+  def set_velocity_sync(robot, target, velocity, opts \\ [], timeout \\ 5000) do
+    actuator_name = actuator_name!(robot, target)
     message = build_velocity_message(actuator_name, velocity, opts)
     BB.call(robot, actuator_name, {:command, message}, timeout)
   end
@@ -521,8 +546,9 @@ defmodule BB.Actuator do
   - `:duration` - Duration (milliseconds), nil = until stopped
   - `:command_id` - Correlation ID for feedback tracking
   """
-  @spec set_effort(module(), [atom()], number(), keyword()) :: :ok
-  def set_effort(robot, path, effort, opts \\ []) do
+  @spec set_effort(module(), target(), number(), keyword()) :: :ok
+  def set_effort(robot, target, effort, opts \\ []) do
+    path = actuator_path!(robot, target)
     message = build_effort_message(path, effort, opts)
     BB.publish(robot, [:actuator | path], message)
   end
@@ -530,8 +556,9 @@ defmodule BB.Actuator do
   @doc """
   Send an effort command directly to an actuator (bypasses pubsub).
   """
-  @spec set_effort!(module(), atom(), number(), keyword()) :: :ok
-  def set_effort!(robot, actuator_name, effort, opts \\ []) do
+  @spec set_effort!(module(), target(), number(), keyword()) :: :ok
+  def set_effort!(robot, target, effort, opts \\ []) do
+    actuator_name = actuator_name!(robot, target)
     message = build_effort_message(actuator_name, effort, opts)
     BB.cast(robot, actuator_name, {:command, message})
   end
@@ -539,9 +566,10 @@ defmodule BB.Actuator do
   @doc """
   Send an effort command and wait for acknowledgement.
   """
-  @spec set_effort_sync(module(), atom(), number(), keyword(), timeout()) ::
+  @spec set_effort_sync(module(), target(), number(), keyword(), timeout()) ::
           {:ok, :accepted | {:accepted, map()}} | {:error, term()}
-  def set_effort_sync(robot, actuator_name, effort, opts \\ [], timeout \\ 5000) do
+  def set_effort_sync(robot, target, effort, opts \\ [], timeout \\ 5000) do
+    actuator_name = actuator_name!(robot, target)
     message = build_effort_message(actuator_name, effort, opts)
     BB.call(robot, actuator_name, {:command, message}, timeout)
   end
@@ -576,8 +604,9 @@ defmodule BB.Actuator do
   - `:repeat` - Number of repetitions: positive integer or `:forever` (default 1)
   - `:command_id` - Correlation ID for feedback tracking
   """
-  @spec follow_trajectory(module(), [atom()], [keyword() | map()], keyword()) :: :ok
-  def follow_trajectory(robot, path, waypoints, opts \\ []) do
+  @spec follow_trajectory(module(), target(), [keyword() | map()], keyword()) :: :ok
+  def follow_trajectory(robot, target, waypoints, opts \\ []) do
+    path = actuator_path!(robot, target)
     message = build_trajectory_message(path, waypoints, opts)
     BB.publish(robot, [:actuator | path], message)
   end
@@ -585,8 +614,9 @@ defmodule BB.Actuator do
   @doc """
   Send a trajectory command directly to an actuator (bypasses pubsub).
   """
-  @spec follow_trajectory!(module(), atom(), [keyword() | map()], keyword()) :: :ok
-  def follow_trajectory!(robot, actuator_name, waypoints, opts \\ []) do
+  @spec follow_trajectory!(module(), target(), [keyword() | map()], keyword()) :: :ok
+  def follow_trajectory!(robot, target, waypoints, opts \\ []) do
+    actuator_name = actuator_name!(robot, target)
     message = build_trajectory_message(actuator_name, waypoints, opts)
     BB.cast(robot, actuator_name, {:command, message})
   end
@@ -594,9 +624,10 @@ defmodule BB.Actuator do
   @doc """
   Send a trajectory command and wait for acknowledgement.
   """
-  @spec follow_trajectory_sync(module(), atom(), [keyword() | map()], keyword(), timeout()) ::
+  @spec follow_trajectory_sync(module(), target(), [keyword() | map()], keyword(), timeout()) ::
           {:ok, :accepted | {:accepted, map()}} | {:error, term()}
-  def follow_trajectory_sync(robot, actuator_name, waypoints, opts \\ [], timeout \\ 5000) do
+  def follow_trajectory_sync(robot, target, waypoints, opts \\ [], timeout \\ 5000) do
+    actuator_name = actuator_name!(robot, target)
     message = build_trajectory_message(actuator_name, waypoints, opts)
     BB.call(robot, actuator_name, {:command, message}, timeout)
   end
@@ -635,8 +666,9 @@ defmodule BB.Actuator do
   - `:mode` - `:immediate` (default) or `:decelerate`
   - `:command_id` - Correlation ID for feedback tracking
   """
-  @spec stop(module(), [atom()], keyword()) :: :ok
-  def stop(robot, path, opts \\ []) do
+  @spec stop(module(), target(), keyword()) :: :ok
+  def stop(robot, target, opts \\ []) do
+    path = actuator_path!(robot, target)
     message = build_stop_message(path, opts)
     BB.publish(robot, [:actuator | path], message)
   end
@@ -644,8 +676,9 @@ defmodule BB.Actuator do
   @doc """
   Send a stop command directly to an actuator (bypasses pubsub).
   """
-  @spec stop!(module(), atom(), keyword()) :: :ok
-  def stop!(robot, actuator_name, opts \\ []) do
+  @spec stop!(module(), target(), keyword()) :: :ok
+  def stop!(robot, target, opts \\ []) do
+    actuator_name = actuator_name!(robot, target)
     message = build_stop_message(actuator_name, opts)
     BB.cast(robot, actuator_name, {:command, message})
   end
@@ -653,9 +686,10 @@ defmodule BB.Actuator do
   @doc """
   Send a stop command and wait for acknowledgement.
   """
-  @spec stop_sync(module(), atom(), keyword(), timeout()) ::
+  @spec stop_sync(module(), target(), keyword(), timeout()) ::
           {:ok, :accepted | {:accepted, map()}} | {:error, term()}
-  def stop_sync(robot, actuator_name, opts \\ [], timeout \\ 5000) do
+  def stop_sync(robot, target, opts \\ [], timeout \\ 5000) do
+    actuator_name = actuator_name!(robot, target)
     message = build_stop_message(actuator_name, opts)
     BB.call(robot, actuator_name, {:command, message}, timeout)
   end
@@ -682,8 +716,9 @@ defmodule BB.Actuator do
 
   - `:command_id` - Correlation ID for feedback tracking
   """
-  @spec hold(module(), [atom()], keyword()) :: :ok
-  def hold(robot, path, opts \\ []) do
+  @spec hold(module(), target(), keyword()) :: :ok
+  def hold(robot, target, opts \\ []) do
+    path = actuator_path!(robot, target)
     message = build_hold_message(path, opts)
     BB.publish(robot, [:actuator | path], message)
   end
@@ -691,8 +726,9 @@ defmodule BB.Actuator do
   @doc """
   Send a hold command directly to an actuator (bypasses pubsub).
   """
-  @spec hold!(module(), atom(), keyword()) :: :ok
-  def hold!(robot, actuator_name, opts \\ []) do
+  @spec hold!(module(), target(), keyword()) :: :ok
+  def hold!(robot, target, opts \\ []) do
+    actuator_name = actuator_name!(robot, target)
     message = build_hold_message(actuator_name, opts)
     BB.cast(robot, actuator_name, {:command, message})
   end
@@ -700,9 +736,10 @@ defmodule BB.Actuator do
   @doc """
   Send a hold command and wait for acknowledgement.
   """
-  @spec hold_sync(module(), atom(), keyword(), timeout()) ::
+  @spec hold_sync(module(), target(), keyword(), timeout()) ::
           {:ok, :accepted | {:accepted, map()}} | {:error, term()}
-  def hold_sync(robot, actuator_name, opts \\ [], timeout \\ 5000) do
+  def hold_sync(robot, target, opts \\ [], timeout \\ 5000) do
+    actuator_name = actuator_name!(robot, target)
     message = build_hold_message(actuator_name, opts)
     BB.call(robot, actuator_name, {:command, message}, timeout)
   end
@@ -711,4 +748,33 @@ defmodule BB.Actuator do
     frame_id = if is_list(frame_id), do: List.last(frame_id), else: frame_id
     Message.new!(Command.Hold, frame_id, command_id: opts[:command_id])
   end
+
+  # ----------------------------------------------------------------------------
+  # Addressing
+  # ----------------------------------------------------------------------------
+
+  # Pubsub delivery needs the actuator's full path, because that is the topic its
+  # server subscribes to. A bare name is resolved against the robot rather than
+  # passed through: `[:actuator | :servo]` is an improper list, which slips past
+  # `BB.publish/3`'s `is_list` guard and then dies inside `Enum.scan/3`.
+  @spec actuator_path!(module(), target()) :: [atom()]
+  defp actuator_path!(_robot, path) when is_list(path), do: path
+
+  defp actuator_path!(robot, name) when is_atom(name) do
+    case Robot.actuator_path(robot.robot(), name) do
+      nil ->
+        raise ArgumentError,
+              "#{inspect(robot)} has no actuator named #{inspect(name)}. " <>
+                "Known actuators: #{inspect(Map.keys(robot.robot().actuators))}"
+
+      path ->
+        path
+    end
+  end
+
+  # Direct and synchronous delivery go through the registry, which is keyed by
+  # the actuator's unique name.
+  @spec actuator_name!(module(), target()) :: atom()
+  defp actuator_name!(_robot, name) when is_atom(name), do: name
+  defp actuator_name!(_robot, path) when is_list(path), do: List.last(path)
 end

--- a/lib/bb/motion.ex
+++ b/lib/bb/motion.ex
@@ -412,7 +412,7 @@ defmodule BB.Motion do
   end
 
   defp send_position_to_actuator(robot_module, robot, actuator_name, position, :pubsub, opts) do
-    path = actuator_path(robot, actuator_name)
+    path = BB.Robot.actuator_path(robot, actuator_name)
     Actuator.set_position(robot_module, path, position, opts)
   end
 
@@ -424,19 +424,6 @@ defmodule BB.Motion do
     case Actuator.set_position_sync(robot_module, actuator_name, position, opts) do
       {:ok, _} -> :ok
       {:error, reason} -> raise "Actuator #{actuator_name} rejected position: #{inspect(reason)}"
-    end
-  end
-
-  defp actuator_path(robot, actuator_name) do
-    case Map.get(robot.actuators, actuator_name) do
-      nil ->
-        [actuator_name]
-
-      %{joint: joint_name} ->
-        case BB.Robot.path_to(robot, joint_name) do
-          nil -> [actuator_name]
-          joint_path -> joint_path ++ [actuator_name]
-        end
     end
   end
 end

--- a/lib/bb/robot.ex
+++ b/lib/bb/robot.ex
@@ -133,6 +133,30 @@ defmodule BB.Robot do
   end
 
   @doc """
+  Get the full path from root to an actuator.
+
+  Actuator names are unique per robot, so the path is derivable: an actuator
+  always hangs off a joint, and the joint's own path gives the links and joints
+  above it. The result matches the `:path` the framework injects into the
+  actuator's `:bb` option, and therefore the topic its commands are published
+  to — `[:actuator | actuator_path(robot, name)]`.
+
+  Returns `nil` if no actuator by that name exists.
+
+      BB.Robot.actuator_path(robot, :pan_servo)
+      #=> [:base, :pan, :pan_servo]
+  """
+  @spec actuator_path(t(), atom()) :: [atom()] | nil
+  def actuator_path(%__MODULE__{actuators: actuators} = robot, name) do
+    with %{joint: joint_name} <- Map.get(actuators, name),
+         joint_path when is_list(joint_path) <- path_to(robot, joint_name) do
+      joint_path ++ [name]
+    else
+      _ -> nil
+    end
+  end
+
+  @doc """
   Get all links in topological order (root first).
   """
   @spec links_in_order(t()) :: [Link.t()]

--- a/test/bb/actuator/addressing_test.exs
+++ b/test/bb/actuator/addressing_test.exs
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Actuator.AddressingTest do
+  use ExUnit.Case
+
+  alias BB.Message
+  alias BB.Message.Actuator.Command
+
+  defmodule Robot do
+    use BB
+
+    topology do
+      link :base do
+        joint :shoulder do
+          type :revolute
+
+          limit do
+            effort(~u(10 newton_meter))
+            velocity(~u(180 degree_per_second))
+          end
+
+          actuator :motor, BB.Test.RecordingActuator
+
+          link :arm do
+            joint :elbow do
+              type :revolute
+
+              limit do
+                effort(~u(10 newton_meter))
+                velocity(~u(180 degree_per_second))
+              end
+
+              actuator :forearm_motor, BB.Test.RecordingActuator
+
+              link :hand
+            end
+          end
+        end
+      end
+    end
+  end
+
+  setup do
+    :persistent_term.put({BB.Test.RecordingActuator, Robot}, self())
+    start_supervised!(Robot)
+    :ok = BB.Safety.arm(Robot)
+    on_exit(fn -> :persistent_term.erase({BB.Test.RecordingActuator, Robot}) end)
+    :ok
+  end
+
+  describe "BB.Robot.actuator_path/2" do
+    test "resolves an actuator directly under the root link's joint" do
+      assert BB.Robot.actuator_path(Robot.robot(), :motor) == [:base, :shoulder, :motor]
+    end
+
+    test "resolves an actuator nested deeper in the topology" do
+      assert BB.Robot.actuator_path(Robot.robot(), :forearm_motor) ==
+               [:base, :shoulder, :arm, :elbow, :forearm_motor]
+    end
+
+    test "returns nil for an unknown actuator" do
+      assert BB.Robot.actuator_path(Robot.robot(), :nonexistent) == nil
+    end
+
+    test "agrees with the path the framework injects into the driver" do
+      # The resolved path must equal the actuator's `bb.path`, since that is what
+      # its server derives its command topic from. If these ever diverge, pubsub
+      # commanding silently stops working — which is the bug this all came from.
+      :ok = BB.publish(Robot, [:actuator | [:base, :shoulder, :motor]], position(0.1))
+      assert_receive {:received, :command, %Message{payload: %Command.Position{}}}, 500
+    end
+  end
+
+  describe "addressing by name" do
+    test "set_position/4 accepts a bare actuator name" do
+      :ok = BB.Actuator.set_position(Robot, :motor, 0.5)
+
+      assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.5}}},
+                     500
+    end
+
+    test "a name resolves to the same actuator as its full path" do
+      :ok = BB.Actuator.set_position(Robot, :forearm_motor, 0.25)
+
+      assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.25}}},
+                     500
+    end
+
+    test "the full path still works" do
+      :ok = BB.Actuator.set_position(Robot, [:base, :shoulder, :motor], 0.75)
+
+      assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.75}}},
+                     500
+    end
+
+    test "stop/3 and hold/3 accept a name too" do
+      :ok = BB.Actuator.stop(Robot, :motor)
+      assert_receive {:received, :command, %Message{payload: %Command.Stop{}}}, 500
+
+      :ok = BB.Actuator.hold(Robot, :motor)
+      assert_receive {:received, :command, %Message{payload: %Command.Hold{}}}, 500
+    end
+  end
+
+  describe "addressing by path on the direct transports" do
+    test "set_position!/4 accepts a full path" do
+      :ok = BB.Actuator.set_position!(Robot, [:base, :shoulder, :motor], 0.5)
+
+      assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.5}}},
+                     500
+    end
+
+    test "set_position_sync/5 accepts a full path" do
+      assert {:ok, :accepted} =
+               BB.Actuator.set_position_sync(Robot, [:base, :shoulder, :motor], 0.5, [], 500)
+
+      assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.5}}},
+                     500
+    end
+  end
+
+  describe "unknown actuators" do
+    test "raise rather than publishing to a topic nothing listens on" do
+      assert_raise ArgumentError, ~r/has no actuator named :nonexistent/, fn ->
+        BB.Actuator.set_position(Robot, :nonexistent, 0.5)
+      end
+    end
+
+    test "the error names the actuators that do exist" do
+      error =
+        assert_raise ArgumentError, fn ->
+          BB.Actuator.set_position(Robot, :nonexistent, 0.5)
+        end
+
+      assert Exception.message(error) =~ ":motor"
+      assert Exception.message(error) =~ ":forearm_motor"
+    end
+  end
+
+  defp position(value), do: Message.new!(Command.Position, :motor, position: value)
+end

--- a/usage-rules/actuators.md
+++ b/usage-rules/actuators.md
@@ -11,20 +11,26 @@ first (see `bb:safety-and-commands`) — commands to a disarmed robot are
 ignored.
 
 ```elixir
-# By full path within the topology ([link, joint, actuator]), value in radians:
+# By the actuator's unique name, value in radians:
+BB.Actuator.set_position(MyRobot.Robot, :servo, 0.785)
+
+# Or by its full path through the topology ([link, joint, actuator]):
 BB.Actuator.set_position(MyRobot.Robot, [:base_link, :pan_joint, :servo], 0.785)
 
-# By the actuator's unique name (raises on error):
+# Bypassing pubsub, for time-critical control:
 BB.Actuator.set_position!(MyRobot.Robot, :servo, 0.785)
 ```
 
 The DSL takes `~u` sigil values; the runtime command functions take plain
 numbers in SI base units (radians here).
 
-- `set_position/4` takes the **full path** (a list) to the actuator — every
-  link and joint from the root, not just the joint. `set_position!/4` takes
-  just the actuator's unique **name**. `set_velocity` and `set_effort` follow
-  the same pair.
+- Every function accepts **either** the actuator's unique name or its full
+  path — a name is resolved with `BB.Robot.actuator_path/2`. Naming an
+  actuator the robot doesn't have raises rather than publishing to a topic
+  nothing listens on. A full path must be complete: every link and joint from
+  the root, not just the joint.
+- `set_position/4` publishes via pubsub; `set_position!/4` bypasses it for
+  lower latency. `set_velocity` and `set_effort` follow the same pair.
 - Positions are in **radians**, velocities in rad/s — SI base units, the same
   units the compiled robot struct uses.
 - Use `set_position_sync/5` when you need to wait for acknowledgement rather


### PR DESCRIPTION
Completes the addressing half of Phase 3 of [Proposal 0021](https://github.com/beam-bots/proposals/pull/53). Additive — no breaking changes.

## The bug

`set_position/4` and its five pubsub siblings took a path only. Passing a bare name built `[:actuator | :servo]`, an **improper list** — which satisfies `BB.publish/3`'s `is_list` guard and then raises inside `Enum.scan/3`:

```
FunctionClauseError - no function clause matching in Enum.scan_list/3
```

That's an easy mistake to make, because the direct and synchronous variants *do* take a name. Sitting side by side in the docs, the two forms invite exactly the generalisation that crashes:

```elixir
BB.Actuator.set_position(MyRobot, [:base, :shoulder, :servo], 0.5)  # path
BB.Actuator.set_position!(MyRobot, :servo, 0.5)                     # name
```

It's already in the wild: `bb_servo_pca9685` and `bb_servo_pigpio`'s basic-usage tutorials both call `set_position(MyRobot, :servo, …)` six times each.

## The change

All eighteen functions now accept `atom() | [atom()]`. Names resolve through the new public `BB.Robot.actuator_path/2`, promoted from `BB.Motion`'s private copy — which was the one place in the ecosystem that built the topic correctly.

Naming an actuator the robot doesn't have raises `ArgumentError` listing the ones it does, rather than publishing to a topic nothing is listening on. Silent delivery to nowhere is the failure mode this whole line of work exists to remove; it shouldn't be reintroduced by a typo.

I also made the direct and synchronous variants accept a *path*, which the proposal didn't ask for. The asymmetry was itself part of the trap — with all three transports taking either form there's nothing left to get wrong.

## A deliberate deletion

`BB.Motion`'s private version fell back to `[actuator_name]` when an actuator couldn't be resolved. That was unreachable — `send_positions/3` only ever passes actuators taken from the robot struct — and a plausible-looking wrong path is worse than an error. Gone.

## Tests

12 new cases in `test/bb/actuator/addressing_test.exs`, on a two-joint robot so nesting is actually exercised. One asserts that `BB.Robot.actuator_path/2` agrees with the `bb.path` the framework injects into the driver — if those ever diverge, pubsub commanding silently dies again, which is [#201](https://github.com/beam-bots/bb/issues/201) all over.

1144 tests, `mix check --no-retry` green.

## Why now

This unblocks the servo-driver documentation rewrites that started this whole thread. Their tutorials want to write `set_position(MyRobot, :servo, 0.0)` — the natural thing — so it should be the correct thing before those docs are rewritten, rather than rewriting them twice.