### PR TITLE
docs: fix every robot definition in the documentation, and check them in CI

### DIFF
--- a/.check.exs
+++ b/.check.exs
@@ -5,6 +5,7 @@
 [
   tools: [
     {:credo, "mix credo --strict"},
+    {:verify_docs, "mix bb.verify_docs"},
     {:spark_formatter, "mix spark.formatter --check"},
     {:spark_cheat_sheets, "mix spark.cheat_sheets --check"},
     {:reuse, command: ["pipx", "run", "--spec", "reuse[charset-normalizer]", "reuse", "lint", "-q"]}

--- a/documentation/how-to/deploy-to-nerves.md
+++ b/documentation/how-to/deploy-to-nerves.md
@@ -85,19 +85,32 @@ defmodule MyRobotFirmware.Robot do
 
   topology do
     link :base do
-      joint :pan, type: :revolute do
-        limit lower: ~u(-90 degree), upper: ~u(90 degree), velocity: ~u(60 degree_per_second)
+      joint :pan do
+        type :revolute
 
-        # Add actuator and sensor for each joint
-        actuator :servo, {BB.Servo.PCA9685.Actuator, channel: 0, controller: :pca9685}
-        sensor :position, {BB.Sensor.OpenLoopPositionEstimator, actuator: :servo}
+        limit lower: ~u(-90 degree), upper: ~u(90 degree),
+              velocity: ~u(60 degree_per_second), effort: ~u(1 newton_meter)
+
+        # Add actuator and sensor for each joint. Names are unique across the
+        # whole robot, so they carry the joint.
+        actuator :pan_servo, {BB.Servo.PCA9685.Actuator, channel: 0, controller: :pca9685}
+        sensor :pan_position, {BB.Sensor.OpenLoopPositionEstimator, actuator: :pan_servo}
+
+        link :pan_link do
+        end
       end
 
-      joint :tilt, type: :revolute do
-        limit lower: ~u(-45 degree), upper: ~u(45 degree), velocity: ~u(60 degree_per_second)
+      joint :tilt do
+        type :revolute
 
-        actuator :servo, {BB.Servo.PCA9685.Actuator, channel: 1, controller: :pca9685}
-        sensor :position, {BB.Sensor.OpenLoopPositionEstimator, actuator: :servo}
+        limit lower: ~u(-45 degree), upper: ~u(45 degree),
+              velocity: ~u(60 degree_per_second), effort: ~u(1 newton_meter)
+
+        actuator :tilt_servo, {BB.Servo.PCA9685.Actuator, channel: 1, controller: :pca9685}
+        sensor :tilt_position, {BB.Sensor.OpenLoopPositionEstimator, actuator: :tilt_servo}
+
+        link :tilt_link do
+        end
       end
     end
   end

--- a/documentation/topics/supervision-architecture.md
+++ b/documentation/topics/supervision-architecture.md
@@ -110,8 +110,15 @@ defmodule MyRobot.Robot do
     # Joint-level processes
     link :base_link do
       joint :shoulder do
-        actuator :servo, {...}
-        sensor :position, {...}
+        type :revolute
+
+        limit effort: ~u(5 newton_meter), velocity: ~u(60 degree_per_second)
+
+        actuator :servo, {BB.Servo.PCA9685.Actuator, channel: 0, controller: :pca9685}
+        sensor :position, {BB.Sensor.OpenLoopPositionEstimator, actuator: :servo}
+
+        link :upper_arm do
+        end
       end
     end
   end

--- a/documentation/tutorials/01-first-robot.md
+++ b/documentation/tutorials/01-first-robot.md
@@ -106,6 +106,9 @@ defmodule MyRobot.Robot do
         axis do
         end
 
+        # Revolute joints must declare their limits — Step 3 covers these.
+        limit effort: ~u(5 newton_meter), velocity: ~u(60 degree_per_second)
+
         link :pan_link do
         end
       end

--- a/documentation/tutorials/03-sensors-and-pubsub.md
+++ b/documentation/tutorials/03-sensors-and-pubsub.md
@@ -23,10 +23,6 @@ defmodule MyRobot.Robot do
   topology do
     link :base_link do
       sensor :imu, MyImuSensor
-
-      joint :pan_joint do
-        # ... rest of robot
-      end
     end
   end
 end

--- a/documentation/tutorials/07-parameters.md
+++ b/documentation/tutorials/07-parameters.md
@@ -260,7 +260,9 @@ Controllers, sensors, and actuators can define inline parameters:
 ```elixir
 topology do
   link :base_link do
-    joint :shoulder, type: :revolute do
+    joint :shoulder do
+      type :revolute
+
       controller :position, {MyPIDController, []} do
         param :kp, type: :float, default: 1.0, min: 0.0
         param :ki, type: :float, default: 0.1, min: 0.0
@@ -408,12 +410,26 @@ defmodule TuneableRobot do
     link :base do
       sensor :lidar, MyLidarSensor
 
-      joint :left_wheel, type: :continuous do
-        actuator :motor, MyMotor
+      joint :left_wheel do
+        type :continuous
+
+        limit effort: ~u(5 newton_meter), velocity: ~u(60 degree_per_second)
+
+        actuator :left_motor, MyMotor
+
+        link :left_wheel_link do
+        end
       end
 
-      joint :right_wheel, type: :continuous do
-        actuator :motor, MyMotor
+      joint :right_wheel do
+        type :continuous
+
+        limit effort: ~u(5 newton_meter), velocity: ~u(60 degree_per_second)
+
+        actuator :right_motor, MyMotor
+
+        link :right_wheel_link do
+        end
       end
     end
   end

--- a/documentation/tutorials/13-state-estimation.md
+++ b/documentation/tutorials/13-state-estimation.md
@@ -35,7 +35,7 @@ defmodule MyRobot.Robot do
 
   topology do
     link :base_link do
-      sensor :imu, MyImuSensor, bus: "i2c-1", address: 0x68 do
+      sensor :imu, {MyImuSensor, bus: "i2c-1", address: 0x68} do
         estimator :tilt, {TiltSmoother, alpha: 0.95}
       end
     end

--- a/lib/mix/tasks/bb.verify_docs.ex
+++ b/lib/mix/tasks/bb.verify_docs.ex
@@ -2,22 +2,66 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Extracts every ```elixir block containing `use BB` from the given markdown
-# files and compiles it, so a robot definition in the docs can't silently rot.
-#
-#     mix run verify_docs.exs ../bb_servo_pca9685/documentation/tutorials/*.md
+defmodule Mix.Tasks.Bb.VerifyDocs do
+  @moduledoc """
+  Compiles every robot definition embedded in a set of markdown files.
 
-defmodule DocVerifier do
-  def run(paths) do
+  A documented robot that no longer compiles is worse than no example, and
+  nothing else in the build ever reads the docs — so this reads them.
+
+      mix bb.verify_docs                       # this package's docs
+      mix bb.verify_docs ../bb_servo_pigpio    # somebody else's
+
+  Given directories, every `.md` beneath them is searched. Only fenced
+  `elixir` blocks defining a module with `use BB` are considered, and only the
+  `defmodule … end` spans within them are compiled — a block that also shows
+  calls against the robot won't have those calls executed.
+
+  Examples referencing modules this package doesn't depend on (a servo driver,
+  say) still compile, but Spark can't run its behaviour and options checks over
+  them and says so on stderr. Those examples get the DSL's structural checks
+  only, which is still enough to catch a malformed topology.
+  """
+  @shortdoc "Compile the robot definitions embedded in the documentation"
+
+  use Mix.Task
+
+  @default_paths ["README.md", "documentation", "usage-rules"]
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    args
+    |> case do
+      [] -> @default_paths
+      paths -> paths
+    end
+    |> Enum.flat_map(&expand/1)
+    |> verify()
+  end
+
+  defp expand(path) do
+    cond do
+      File.dir?(path) -> path |> Path.join("**/*.md") |> Path.wildcard()
+      File.exists?(path) -> [path]
+      true -> []
+    end
+  end
+
+  defp verify(paths) do
     results = Enum.flat_map(paths, &check_file/1)
     {ok, bad} = Enum.split_with(results, &match?({:ok, _, _}, &1))
 
     Enum.each(bad, fn {:error, path, line, message} ->
-      IO.puts("\nFAIL #{path}:#{line}\n#{message}")
+      Mix.shell().error("\nFAIL #{path}:#{line}\n#{message}")
     end)
 
-    IO.puts("\n#{length(ok)} robot definitions compiled, #{length(bad)} failed")
-    if bad != [], do: System.halt(1)
+    Mix.shell().info("\n#{length(ok)} robot definitions compiled, #{length(bad)} failed")
+
+    if bad != [] do
+      Mix.raise("#{length(bad)} documented robot definition(s) failed to compile")
+    end
   end
 
   defp check_file(path) do
@@ -34,11 +78,17 @@ defmodule DocVerifier do
     |> String.split("\n")
     |> Enum.with_index(1)
     |> Enum.reduce({[], nil, []}, fn
-      {"```elixir", line}, {blocks, nil, _} -> {blocks, line, []}
+      {"```elixir", line}, {blocks, nil, _} ->
+        {blocks, line, []}
+
       {"```", _}, {blocks, start, acc} when is_integer(start) ->
         {[{start, acc |> Enum.reverse() |> Enum.join("\n")} | blocks], nil, []}
-      {text, _}, {blocks, start, acc} when is_integer(start) -> {blocks, start, [text | acc]}
-      _, state -> state
+
+      {text, _}, {blocks, start, acc} when is_integer(start) ->
+        {blocks, start, [text | acc]}
+
+      _, state ->
+        state
     end)
     |> elem(0)
     |> Enum.reverse()
@@ -81,5 +131,3 @@ defmodule DocVerifier do
     end
   end
 end
-
-DocVerifier.run(System.argv())

--- a/usage-rules/anti-patterns.md
+++ b/usage-rules/anti-patterns.md
@@ -33,9 +33,18 @@ BB.Safety.arm(MyRobot.Robot)
 ### Don't use bare numbers for physical quantities in the DSL
 
 ```elixir
-limit lower: -1.57, upper: 1.57                        # Bad — ambiguous units
-limit lower: ~u(-90 degree), upper: ~u(90 degree)      # Good
+# Bad — ambiguous units, and no effort/velocity
+limit lower: -1.57, upper: 1.57
+
+# Good
+limit lower: ~u(-90 degree),
+      upper: ~u(90 degree),
+      effort: ~u(5 newton_meter),
+      velocity: ~u(60 degree_per_second)
 ```
+
+`effort` and `velocity` are required on every `limit`; `lower`, `upper` and
+`acceleration` are optional. See `bb:dsl-topology`.
 
 ### Don't hand-roll supervision
 

--- a/usage-rules/dsl-topology.md
+++ b/usage-rules/dsl-topology.md
@@ -44,6 +44,24 @@ This is a Spark DSL — every entity is a macro. Follow the house style:
   - `entity <positional>, <options as a keyword list>`
   - `entity <positional> do <options as nested calls> end`
   - `entity do <positional and options as nested calls> end`
+- **Pick one form — you can't combine a keyword list with a block.**
+  `joint :pan, type: :revolute do … end` looks natural and is the most common
+  mistake, but Elixir reads it as `joint/3` and Spark only defines `/1` and
+  `/2`, so it fails with `undefined function joint/3`. Put `type` inside the
+  block instead:
+
+  ```elixir
+  # Bad — keyword options and a block together
+  joint :pan, type: :revolute do
+    limit effort: ~u(5 newton_meter), velocity: ~u(60 degree_per_second)
+  end
+
+  # Good
+  joint :pan do
+    type :revolute
+    limit effort: ~u(5 newton_meter), velocity: ~u(60 degree_per_second)
+  end
+  ```
 - **Prefer the keyword-list form** unless the entity contains *nested DSL* that
   needs a `do`/`end` block. So `limit lower: ~u(...), upper: ~u(...)` (plain
   options), but `link`/`joint` take a block because they nest other entities.
@@ -61,9 +79,13 @@ This is a Spark DSL — every entity is a macro. Follow the house style:
   `roll`/`pitch`/`yaw`, e.g. `axis roll: ~u(90 degree)`.
 - **Attach components as `{Module, opts}`** in an actuator/sensor slot:
   `actuator :servo, {MyDriver, servo_id: 1}`. A bare `Module` works when it
-  needs no options. Names must be unique across the whole robot — BB registers
-  each process under its name. Add a `do`/`end` block only to nest further DSL
-  such as `transmission`.
+  needs no options. Add a `do`/`end` block only to nest further DSL such as
+  `transmission`.
+- **Names must be unique across the whole robot**, and the namespace is shared
+  by *every* component kind — BB registers each process under its name. Two
+  joints can't both hold an `actuator :servo`, and a `controller :feetech`
+  rules out a `bridge :feetech`. Name them for what they are:
+  `:shoulder_servo`, `:elbow_servo`, `:feetech_params`.
 - **Per-attachment `transmission`** describes how *that* actuator/sensor maps
   joint-space to its hardware (`reversed?`, `offset`, gearing). It belongs on
   the attachment, not the joint, because several devices can share one joint.

--- a/verify_docs.exs
+++ b/verify_docs.exs
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Extracts every ```elixir block containing `use BB` from the given markdown
+# files and compiles it, so a robot definition in the docs can't silently rot.
+#
+#     mix run verify_docs.exs ../bb_servo_pca9685/documentation/tutorials/*.md
+
+defmodule DocVerifier do
+  def run(paths) do
+    results = Enum.flat_map(paths, &check_file/1)
+    {ok, bad} = Enum.split_with(results, &match?({:ok, _, _}, &1))
+
+    Enum.each(bad, fn {:error, path, line, message} ->
+      IO.puts("\nFAIL #{path}:#{line}\n#{message}")
+    end)
+
+    IO.puts("\n#{length(ok)} robot definitions compiled, #{length(bad)} failed")
+    if bad != [], do: System.halt(1)
+  end
+
+  defp check_file(path) do
+    path
+    |> File.read!()
+    |> extract_blocks()
+    |> Enum.map(fn {line, code} -> compile(path, line, code) end)
+  end
+
+  # Only blocks that define a module using BB — snippets of bare DSL fragments
+  # can't compile standalone and aren't claiming to.
+  defp extract_blocks(source) do
+    source
+    |> String.split("\n")
+    |> Enum.with_index(1)
+    |> Enum.reduce({[], nil, []}, fn
+      {"```elixir", line}, {blocks, nil, _} -> {blocks, line, []}
+      {"```", _}, {blocks, start, acc} when is_integer(start) ->
+        {[{start, acc |> Enum.reverse() |> Enum.join("\n")} | blocks], nil, []}
+      {text, _}, {blocks, start, acc} when is_integer(start) -> {blocks, start, [text | acc]}
+      _, state -> state
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+    |> Enum.filter(fn {_line, code} ->
+      Regex.match?(~r/^\s*use BB(\.Robot)?\s*$/m, code) and String.contains?(code, "defmodule")
+    end)
+  end
+
+  # A block often shows a module *and* then calls against it. `Code.compile_string`
+  # would execute those calls against a robot that isn't running, so keep only the
+  # top-level `defmodule … end` spans — the part that has to compile.
+  defp module_definitions(code) do
+    code
+    |> String.split("\n")
+    |> Enum.reduce({[], false}, fn
+      line, {acc, false} ->
+        if String.starts_with?(line, "defmodule "), do: {[line | acc], true}, else: {acc, false}
+
+      line, {acc, true} ->
+        {[line | acc], line != "end"}
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+    |> Enum.join("\n")
+  end
+
+  defp compile(path, line, code) do
+    code = module_definitions(code)
+
+    # Each block gets a unique module namespace so repeated `MyRobot` examples
+    # across files don't collide.
+    suffix = "_DocCheck#{:erlang.phash2({path, line})}"
+    code = Regex.replace(~r/defmodule ([A-Z][A-Za-z0-9_.]*)/, code, "defmodule \\1#{suffix}")
+
+    try do
+      Code.compile_string(code, path)
+      {:ok, path, line}
+    rescue
+      e -> {:error, path, line, Exception.message(e)}
+    end
+  end
+end
+
+DocVerifier.run(System.argv())


### PR DESCRIPTION
Nothing in the build had ever compiled the robot definitions in our documentation. Six of the twenty-five didn't compile.

This fixes them and adds `mix bb.verify_docs` to `mix check` so it can't happen again.

## How this surfaced

While rewriting the servo drivers' docs I found that **every** robot definition in **every** servo package failed to compile — 15 of 15. Tracing the pattern back, the origin is here: `usage-rules/anti-patterns.md` showed

```elixir
limit lower: ~u(-90 degree), upper: ~u(90 degree)      # Good
```

as the good example, omitting the required `effort` and `velocity` — directly contradicting `usage-rules/dsl-topology.md`, which correctly states both are required. The satellites copied the shorter form. The file agents are told to read first disagreed with the file that was right.

## What was broken here

| File | Problem |
|---|---|
| `tutorials/01-first-robot.md` | revolute joint with no `limit` |
| `tutorials/03-sensors-and-pubsub.md` | joint with no child link, `# ... rest of robot` inside a complete module |
| `tutorials/07-parameters.md` | `joint/3`; duplicate `:motor` across both wheels |
| `tutorials/13-state-estimation.md` | `sensor :imu, MyImuSensor, bus: …, address: … do … end` — that's `sensor/4`; the options belong in the child-spec tuple |
| `topics/supervision-architecture.md` | `{...}` placeholders inside a complete module |
| `how-to/deploy-to-nerves.md` | `joint/3`; duplicate `:servo` and `:position` across joints |

Step 2 of the first-robot tutorial is the one I'd most want fixed: it presents a complete module and introduces limits in *step 3*, so a reader following along hits `Limits must be present for revolute joints` at their second example. It now declares them with a forward reference — the pedagogy and the validator disagreed, and the validator wins.

## Two rules added to usage-rules

**Entity forms are mutually exclusive.** `dsl-topology.md` listed the three forms but never said you can't combine them, so `joint :pan, type: :revolute do … end` reads as obviously correct. It isn't — Elixir makes that `joint/3` and Spark defines only `/1` and `/2`. This is the single most common mistake in the ecosystem's docs; it's now called out with a good/bad pair.

**Name uniqueness spans component kinds.** Already documented, but not that the namespace is shared across *every* kind — so a `controller :feetech` rules out a `bridge :feetech`, which `bb_servo_feetech`'s own integration example was recommending.

## `mix bb.verify_docs`

Extracts each fenced `elixir` block defining a module with `use BB`, keeps only the `defmodule … end` spans (so blocks that also show calls against the robot don't execute them), and compiles each under a unique namespace. Defaults to `README.md`, `documentation/` and `usage-rules/`; takes paths or directories, so it works against the satellites too.

One documented limitation: examples referencing modules `bb` doesn't depend on — a servo driver — compile and get the DSL's structural checks, but Spark can't run its behaviour and options checks and warns on stderr. Structural checking is what caught all six failures here.

`mix check --no-retry` green, 25/25 compiling.