### PR TITLE
feat: let an actuator declare the command payloads it accepts

### DIFF
--- a/documentation/tutorials/12-writing-an-actuator.md
+++ b/documentation/tutorials/12-writing-an-actuator.md
@@ -183,11 +183,18 @@ end
 The skeleton above handles `Command.Position` and nothing else, which is fine
 for the commands a driver chooses not to model — with one exception.
 
-`Command.Stop` always reaches your driver. It bypasses the arm check, and
-`command_payloads/1` can't exclude it, because stopping is the fail-safe
-direction: a safety supervisor has to be able to stop a joint it neither owns
-nor armed. That guarantee only means something if you act on it, so give it its
-own clause before any catch-all:
+`Command.Stop` is a *motion* command: cease travelling and become passive. It's
+the counterpart to `Command.Hold`, which maintains position and actively resists
+external force. Its `:decelerate` mode makes the distinction plain — nothing
+that slows down smoothly is an emergency stop.
+
+Making hardware safe is `disarm/1`, which is robot-wide, runs without GenServer
+state, and leaves the robot unable to move until re-armed. Don't reach for
+`Stop` to do that job.
+
+The default `command_payloads/1` includes `Stop`, so unless you narrow it away
+your driver will receive it — and should act on it rather than let a catch-all
+swallow it:
 
 ```elixir
 @impl BB.Actuator
@@ -197,15 +204,9 @@ def handle_command(%Message{payload: %Command.Stop{}}, state) do
 end
 ```
 
-What "stop" means is yours to decide, and it's hardware-specific — cutting the
-drive signal, commanding the present position as the new goal, disabling torque.
-What it must not be is a silent no-op, because then a stop reports success while
-the joint keeps moving.
-
-`Stop` is not `disarm/1`. Disarm is robot-wide, runs without GenServer state
-(the process may have crashed), and leaves the robot unable to move until
-re-armed. `Stop` targets one actuator and leaves the robot armed and
-commandable.
+What "stop" means is hardware-specific — cutting the drive signal, commanding
+the present position as the new goal. What it must not be is a silent no-op,
+because then a stop reports success while the joint keeps moving.
 
 Notice what isn't in there:
 

--- a/documentation/tutorials/12-writing-an-actuator.md
+++ b/documentation/tutorials/12-writing-an-actuator.md
@@ -178,6 +178,35 @@ defmodule MyDriver do
 end
 ```
 
+## Stopping
+
+The skeleton above handles `Command.Position` and nothing else, which is fine
+for the commands a driver chooses not to model — with one exception.
+
+`Command.Stop` always reaches your driver. It bypasses the arm check, and
+`command_payloads/1` can't exclude it, because stopping is the fail-safe
+direction: a safety supervisor has to be able to stop a joint it neither owns
+nor armed. That guarantee only means something if you act on it, so give it its
+own clause before any catch-all:
+
+```elixir
+@impl BB.Actuator
+def handle_command(%Message{payload: %Command.Stop{}}, state) do
+  MyHardware.cut_drive(state.channel)
+  {:noreply, state}
+end
+```
+
+What "stop" means is yours to decide, and it's hardware-specific — cutting the
+drive signal, commanding the present position as the new goal, disabling torque.
+What it must not be is a silent no-op, because then a stop reports success while
+the joint keeps moving.
+
+`Stop` is not `disarm/1`. Disarm is robot-wide, runs without GenServer state
+(the process may have crashed), and leaves the robot unable to move until
+re-armed. `Stop` targets one actuator and leaves the robot armed and
+commandable.
+
 Notice what isn't in there:
 
 - No call to `BB.Robot.get_joint/2`. The wrapper already looked up the joint.

--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -188,6 +188,29 @@ defmodule BB.Actuator do
   Commands the driver doesn't implement should fall through to a catch-all
   clause rather than crashing the actuator - a `Command.Trajectory` sent to a
   position-only servo is a caller error, not a hardware fault.
+
+  > #### Always handle `Command.Stop` {: .warning}
+  >
+  > `BB.Message.Actuator.Command.Stop` is the one command that always reaches
+  > you. It bypasses the arm gate, and `c:command_payloads/1` cannot exclude it,
+  > because stopping is the fail-safe direction: a safety supervisor has to be
+  > able to stop a joint it neither owns nor armed.
+  >
+  > That guarantee is only worth anything if your driver acts on it. A catch-all
+  > clause that quietly returns `{:noreply, state}` will swallow it, and the
+  > stop will look like it succeeded while the hardware keeps driving. Give it
+  > its own clause and make the hardware safe:
+  >
+  > ```elixir
+  > def handle_command(%BB.Message{payload: %Command.Stop{}}, state) do
+  >   MyHardware.cut_drive(state.channel)
+  >   {:noreply, state}
+  > end
+  > ```
+  >
+  > `Stop` differs from `c:disarm/1`: disarm is robot-wide, runs without
+  > GenServer state, and ends with the robot unable to move until re-armed.
+  > `Stop` targets one actuator and leaves the robot armed and commandable.
   """
   @callback handle_command(command :: BB.Message.t(), state :: term()) ::
               {:reply, reply :: term(), new_state :: term()}

--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -281,7 +281,38 @@ defmodule BB.Actuator do
   """
   @callback options_schema() :: Spark.Options.t()
 
+  @doc """
+  The command payloads this actuator accepts.
+
+  Defaults to `default_command_payloads/0` — the six built-in
+  `BB.Message.Actuator.Command.*` types — which is right for almost every
+  driver. Override it to either end of the range:
+
+  - **Widen it.** A driver whose hardware speaks a command BB doesn't model can
+    name its own payload module here, and it will arrive through the same gated
+    pipeline as any other command. Without that it would have to subscribe to
+    `[:actuator | path]` itself, and those messages reach the driver having
+    skipped the arm check.
+  - **Narrow it.** A port that only ever accepts `Command.Effort` can say so,
+    and the framework refuses everything else before the driver sees it.
+
+  Called once at `init`, with the resolved options, because the answer isn't
+  always known at compile time — it may depend on a port or channel named in
+  the driver's own options.
+
+      @impl BB.Actuator
+      def command_payloads(opts) do
+        [opts |> Keyword.fetch!(:port) |> MyDriver.command_struct()]
+      end
+
+  The result is used for both the actuator's pubsub subscription and its
+  dispatch guard, so narrowing holds across all three transports rather than
+  only the published one.
+  """
+  @callback command_payloads(opts :: keyword()) :: [module()]
+
   @optional_callbacks [
+    command_payloads: 1,
     handle_options: 2,
     handle_call: 3,
     handle_cast: 2,
@@ -289,6 +320,25 @@ defmodule BB.Actuator do
     handle_continue: 2,
     terminate: 2
   ]
+
+  @default_command_payloads [
+    BB.Message.Actuator.Command.Effort,
+    BB.Message.Actuator.Command.Hold,
+    BB.Message.Actuator.Command.Position,
+    BB.Message.Actuator.Command.Stop,
+    BB.Message.Actuator.Command.Trajectory,
+    BB.Message.Actuator.Command.Velocity
+  ]
+
+  @doc """
+  The command payloads an actuator accepts unless it says otherwise.
+
+  These are the payload types `BB.Actuator`'s own API can produce, so they are
+  the set every driver is expected to understand — or at least to ignore
+  gracefully.
+  """
+  @spec default_command_payloads() :: [module()]
+  def default_command_payloads, do: @default_command_payloads
 
   alias BB.Component.OptionsSchema
 
@@ -300,6 +350,9 @@ defmodule BB.Actuator do
       @behaviour BB.Actuator
 
       # Default implementations - all overridable
+      @impl BB.Actuator
+      def command_payloads(_opts), do: BB.Actuator.default_command_payloads()
+
       @impl BB.Actuator
       def handle_options(_new_opts, state), do: {:ok, state}
 
@@ -318,7 +371,8 @@ defmodule BB.Actuator do
       @impl BB.Actuator
       def terminate(_reason, _state), do: :ok
 
-      defoverridable handle_options: 2,
+      defoverridable command_payloads: 1,
+                     handle_options: 2,
                      handle_call: 3,
                      handle_cast: 2,
                      handle_info: 2,

--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -308,6 +308,12 @@ defmodule BB.Actuator do
   The result is used for both the actuator's pubsub subscription and its
   dispatch guard, so narrowing holds across all three transports rather than
   only the published one.
+
+  `BB.Message.Actuator.Command.Stop` is always admitted regardless of what this
+  returns. It already bypasses the arm gate — stopping is the fail-safe
+  direction — and a driver shouldn't be able to opt out of being stopped. A
+  driver that doesn't model stopping just ignores it in
+  `c:handle_command/2`.
   """
   @callback command_payloads(opts :: keyword()) :: [module()]
 

--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -189,17 +189,20 @@ defmodule BB.Actuator do
   clause rather than crashing the actuator - a `Command.Trajectory` sent to a
   position-only servo is a caller error, not a hardware fault.
 
-  > #### Always handle `Command.Stop` {: .warning}
+  > #### `Command.Stop` is a motion command, not a safety one {: .info}
   >
-  > `BB.Message.Actuator.Command.Stop` is the one command that always reaches
-  > you. It bypasses the arm gate, and `c:command_payloads/1` cannot exclude it,
-  > because stopping is the fail-safe direction: a safety supervisor has to be
-  > able to stop a joint it neither owns nor armed.
+  > `Stop` means *cease travelling and become passive* — it's the counterpart to
+  > `Command.Hold`, which maintains position and resists external force. Its
+  > `:decelerate` mode makes that plain: nothing that slows down smoothly is an
+  > emergency stop.
   >
-  > That guarantee is only worth anything if your driver acts on it. A catch-all
-  > clause that quietly returns `{:noreply, state}` will swallow it, and the
-  > stop will look like it succeeded while the hardware keeps driving. Give it
-  > its own clause and make the hardware safe:
+  > Making hardware safe is `c:disarm/1`, which is robot-wide, runs without
+  > GenServer state, and leaves the robot unable to move until re-armed. Don't
+  > reach for `Stop` to do that job.
+  >
+  > If you declare `Stop` in `c:command_payloads/1` — and the default does —
+  > give it a clause that genuinely stops driving, rather than letting a
+  > catch-all swallow it and report success while the joint keeps moving:
   >
   > ```elixir
   > def handle_command(%BB.Message{payload: %Command.Stop{}}, state) do
@@ -208,9 +211,6 @@ defmodule BB.Actuator do
   > end
   > ```
   >
-  > `Stop` differs from `c:disarm/1`: disarm is robot-wide, runs without
-  > GenServer state, and ends with the robot unable to move until re-armed.
-  > `Stop` targets one actuator and leaves the robot armed and commandable.
   """
   @callback handle_command(command :: BB.Message.t(), state :: term()) ::
               {:reply, reply :: term(), new_state :: term()}
@@ -332,11 +332,9 @@ defmodule BB.Actuator do
   dispatch guard, so narrowing holds across all three transports rather than
   only the published one.
 
-  `BB.Message.Actuator.Command.Stop` is always admitted regardless of what this
-  returns. It already bypasses the arm gate — stopping is the fail-safe
-  direction — and a driver shouldn't be able to opt out of being stopped. A
-  driver that doesn't model stopping just ignores it in
-  `c:handle_command/2`.
+  Nothing is admitted outside this list, `Stop` included. A driver is never
+  handed a payload it didn't declare, so it can't be crashed by one it has no
+  clause for.
   """
   @callback command_payloads(opts :: keyword()) :: [module()]
 

--- a/lib/bb/actuator/server.ex
+++ b/lib/bb/actuator/server.ex
@@ -23,10 +23,11 @@ defmodule BB.Actuator.Server do
   `BB.Process.call/4`. All three converge here and pass through the same
   checks before the driver sees them:
 
-  1. The robot must be armed. `BB.Message.Actuator.Command.Stop` is exempt,
-     since stopping is the fail-safe direction and a supervisor must be able
-     to stop a joint it didn't arm.
-  2. The payload is translated from joint-space into motor-space using the
+  1. The actuator must accept the payload — see
+     `c:BB.Actuator.command_payloads/1`. A driver is never handed a command it
+     didn't declare, so it can't be crashed by one it has no clause for.
+  2. The robot must be armed.
+  3. The payload is translated from joint-space into motor-space using the
      joint's transmission.
 
   The driver then receives it in `c:BB.Actuator.handle_command/2`, and its
@@ -42,7 +43,6 @@ defmodule BB.Actuator.Server do
   alias BB.Error.State.NotArmed
   alias BB.Error.State.UnsupportedCommand
   alias BB.Message
-  alias BB.Message.Actuator.Command
   alias BB.Parameter.Changed, as: ParameterChanged
   alias BB.Robot
   alias BB.Safety
@@ -129,13 +129,7 @@ defmodule BB.Actuator.Server do
         # payloads from its own options. The same list gates every transport,
         # so narrowing holds for cast and call too, not just the published path.
         #
-        # `Stop` is always admitted, whatever the driver says. It already
-        # bypasses the arm gate because stopping is the fail-safe direction, and
-        # a driver being able to opt out of the stop command isn't a property
-        # this framework should have. A driver that doesn't model stopping can
-        # ignore it in `handle_command/2`, as it would have before.
-        command_payloads =
-          [Command.Stop | callback_module.command_payloads(resolved_opts)] |> Enum.uniq()
+        command_payloads = callback_module.command_payloads(resolved_opts)
 
         BB.PubSub.subscribe(bb.robot, command_topic, message_types: command_payloads)
 
@@ -345,8 +339,6 @@ defmodule BB.Actuator.Server do
        )}
     end
   end
-
-  defp authorise_armed(%Message{payload: %Command.Stop{}}, _state), do: :ok
 
   defp authorise_armed(%Message{payload: %payload_module{}}, state) do
     if Safety.armed?(state.bb.robot) do

--- a/lib/bb/actuator/server.ex
+++ b/lib/bb/actuator/server.ex
@@ -40,6 +40,7 @@ defmodule BB.Actuator.Server do
   alias BB.Actuator.MotorProfile
   alias BB.Component.OptionsSchema
   alias BB.Error.State.NotArmed
+  alias BB.Error.State.UnsupportedCommand
   alias BB.Message
   alias BB.Message.Actuator.Command
   alias BB.Parameter.Changed, as: ParameterChanged
@@ -51,21 +52,13 @@ defmodule BB.Actuator.Server do
 
   @framework_keys [:bb, :motor_profile]
 
-  @command_payloads [
-    Command.Effort,
-    Command.Hold,
-    Command.Position,
-    Command.Stop,
-    Command.Trajectory,
-    Command.Velocity
-  ]
-
   defstruct [
     :callback_module,
     :resolved_opts,
     :raw_opts,
     :param_subscriptions,
     :command_topic,
+    :command_payloads,
     :transmission,
     :transmission_subscriptions,
     :joint,
@@ -81,6 +74,7 @@ defmodule BB.Actuator.Server do
           raw_opts: keyword(),
           param_subscriptions: %{[atom()] => atom()},
           command_topic: [atom()],
+          command_payloads: [module()],
           transmission: Transmission.t() | nil,
           transmission_subscriptions: %{atom() => [atom()]},
           joint: map() | nil,
@@ -112,7 +106,6 @@ defmodule BB.Actuator.Server do
       ParamResolution.resolve_and_subscribe(raw_opts, bb.robot)
 
     command_topic = [:actuator | bb.path]
-    BB.PubSub.subscribe(bb.robot, command_topic, message_types: @command_payloads)
 
     actuator_name = List.last(bb.path)
     {joint, joint_name} = joint_for_actuator(bb)
@@ -132,12 +125,20 @@ defmodule BB.Actuator.Server do
         {:stop, error}
 
       {:ok, resolved_opts} ->
+        # Asked after validation, because a driver may derive its accepted
+        # payloads from its own options. The same list gates every transport,
+        # so narrowing holds for cast and call too, not just the published path.
+        command_payloads = callback_module.command_payloads(resolved_opts)
+
+        BB.PubSub.subscribe(bb.robot, command_topic, message_types: command_payloads)
+
         base = %__MODULE__{
           callback_module: callback_module,
           resolved_opts: resolved_opts,
           raw_opts: raw_opts,
           param_subscriptions: param_subscriptions,
           command_topic: command_topic,
+          command_payloads: command_payloads,
           transmission: transmission,
           transmission_subscriptions: transmission_subscriptions,
           joint: joint,
@@ -227,11 +228,14 @@ defmodule BB.Actuator.Server do
   end
 
   def handle_info(
-        {:bb, topic, %Message{payload: %payload_module{}} = message},
+        {:bb, topic, %Message{} = message} = msg,
         %__MODULE__{command_topic: topic} = state
-      )
-      when payload_module in @command_payloads do
-    dispatch_command(message, :pubsub, state)
+      ) do
+    if command?(message, state) do
+      dispatch_command(message, :pubsub, state)
+    else
+      delegate_handle_info(msg, state)
+    end
   end
 
   def handle_info(msg, state), do: delegate_handle_info(msg, state)
@@ -252,6 +256,10 @@ defmodule BB.Actuator.Server do
   @impl GenServer
   def handle_call({:command, %Message{} = message}, _from, state) do
     dispatch_command(message, :call, state)
+  end
+
+  def handle_call({:command, _other}, _from, state) do
+    {:reply, {:error, :not_a_command}, state}
   end
 
   def handle_call(request, from, state), do: delegate_handle_call(request, from, state)
@@ -298,6 +306,12 @@ defmodule BB.Actuator.Server do
     end
   end
 
+  # Only payloads this actuator accepts are commands. Anything else on the topic
+  # is somebody else's traffic and belongs to the driver's `handle_info/2`.
+  @spec command?(Message.t(), t()) :: boolean()
+  defp command?(%Message{payload: %payload_module{}}, state),
+    do: payload_module in state.command_payloads
+
   @spec dispatch_command(Message.t(), transport(), t()) :: term()
   defp dispatch_command(message, transport, state) do
     case authorise(message, state) do
@@ -311,9 +325,23 @@ defmodule BB.Actuator.Server do
     end
   end
 
-  defp authorise(%Message{payload: %Command.Stop{}}, _state), do: :ok
+  defp authorise(%Message{payload: %payload_module{}} = message, state) do
+    if payload_module in state.command_payloads do
+      authorise_armed(message, state)
+    else
+      {:error, :unsupported_command,
+       UnsupportedCommand.exception(
+         robot: state.bb.robot,
+         actuator: state.actuator_name,
+         command: payload_module,
+         supported: state.command_payloads
+       )}
+    end
+  end
 
-  defp authorise(%Message{payload: %payload_module{}}, state) do
+  defp authorise_armed(%Message{payload: %Command.Stop{}}, _state), do: :ok
+
+  defp authorise_armed(%Message{payload: %payload_module{}}, state) do
     if Safety.armed?(state.bb.robot) do
       :ok
     else

--- a/lib/bb/actuator/server.ex
+++ b/lib/bb/actuator/server.ex
@@ -128,7 +128,14 @@ defmodule BB.Actuator.Server do
         # Asked after validation, because a driver may derive its accepted
         # payloads from its own options. The same list gates every transport,
         # so narrowing holds for cast and call too, not just the published path.
-        command_payloads = callback_module.command_payloads(resolved_opts)
+        #
+        # `Stop` is always admitted, whatever the driver says. It already
+        # bypasses the arm gate because stopping is the fail-safe direction, and
+        # a driver being able to opt out of the stop command isn't a property
+        # this framework should have. A driver that doesn't model stopping can
+        # ignore it in `handle_command/2`, as it would have before.
+        command_payloads =
+          [Command.Stop | callback_module.command_payloads(resolved_opts)] |> Enum.uniq()
 
         BB.PubSub.subscribe(bb.robot, command_topic, message_types: command_payloads)
 

--- a/lib/bb/error/state/unsupported_command.ex
+++ b/lib/bb/error/state/unsupported_command.ex
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.State.UnsupportedCommand do
+  @moduledoc """
+  Command refused because the actuator doesn't accept that payload.
+
+  An actuator declares what it accepts with `c:BB.Actuator.command_payloads/1`,
+  defaulting to the six built-in `BB.Message.Actuator.Command` types. A driver
+  that narrows the list — a port that only speaks effort, say — gets everything
+  else refused here rather than handed to it to misinterpret.
+
+  Published commands are filtered out by the subscription and never reach the
+  actuator at all; this error is what the direct and synchronous transports see,
+  since they bypass pubsub.
+  """
+  use BB.Error,
+    class: :state,
+    fields: [:robot, :actuator, :command, :supported]
+
+  @type t :: %__MODULE__{
+          robot: module() | nil,
+          actuator: atom(),
+          command: module(),
+          supported: [module()]
+        }
+
+  defimpl BB.Error.Severity do
+    def severity(_), do: :error
+  end
+
+  def message(%{actuator: actuator, command: command, supported: supported}) do
+    "Actuator #{inspect(actuator)} does not accept #{inspect(command)}. " <>
+      "Accepts: #{inspect(supported)}"
+  end
+end

--- a/lib/bb/message/actuator/command/effort.ex
+++ b/lib/bb/message/actuator/command/effort.ex
@@ -42,12 +42,12 @@ defmodule BB.Message.Actuator.Command.Effort do
         doc: "Target effort (Nm or N)"
       ],
       duration: [
-        type: :pos_integer,
+        type: {:or, [nil, :pos_integer]},
         required: false,
         doc: "Duration (milliseconds), nil = until stopped"
       ],
       command_id: [
-        type: :reference,
+        type: {:or, [nil, :reference]},
         required: false,
         doc: "Correlation ID for feedback"
       ]

--- a/lib/bb/message/actuator/command/trajectory.ex
+++ b/lib/bb/message/actuator/command/trajectory.ex
@@ -81,7 +81,7 @@ defmodule BB.Message.Actuator.Command.Trajectory do
         doc: "Number of times to repeat (positive integer or :forever)"
       ],
       command_id: [
-        type: :reference,
+        type: {:or, [nil, :reference]},
         required: false,
         doc: "Correlation ID for feedback"
       ]

--- a/lib/bb/message/actuator/command/velocity.ex
+++ b/lib/bb/message/actuator/command/velocity.ex
@@ -42,12 +42,12 @@ defmodule BB.Message.Actuator.Command.Velocity do
         doc: "Target velocity (rad/s or m/s)"
       ],
       duration: [
-        type: :pos_integer,
+        type: {:or, [nil, :pos_integer]},
         required: false,
         doc: "Duration (milliseconds), nil = until stopped"
       ],
       command_id: [
-        type: :reference,
+        type: {:or, [nil, :reference]},
         required: false,
         doc: "Correlation ID for feedback"
       ]

--- a/test/bb/actuator/command_payloads_test.exs
+++ b/test/bb/actuator/command_payloads_test.exs
@@ -168,20 +168,16 @@ defmodule BB.Actuator.CommandPayloadsTest do
       assert Exception.message(error) =~ "Command.Effort"
     end
 
-    test "Stop is admitted even though the driver didn't list it" do
+    test "Stop is refused too — nothing is exempt from the declared list" do
+      # Stop is a motion command, not a safety mechanism, so it has no special
+      # standing here. A driver that never declared it can't be handed it.
       :ok = BB.Actuator.stop(Robot, :narrow)
-      assert_receive {:commanded, %Command.Stop{}}, 500
+      refute_receive {:commanded, _}, 200
     end
 
-    test "Stop is admitted on the direct transport too" do
-      :ok = BB.Actuator.stop!(Robot, :narrow)
-      assert_receive {:commanded, %Command.Stop{}}, 500
-    end
-
-    test "Stop still reaches a narrowed actuator while disarmed" do
-      :ok = BB.Safety.disarm(Robot)
-      :ok = BB.Actuator.stop(Robot, :narrow)
-      assert_receive {:commanded, %Command.Stop{}}, 500
+    test "and is refused on the direct transport with a structured error" do
+      assert {:error, %UnsupportedCommand{command: Command.Stop}} =
+               BB.Actuator.stop_sync(Robot, :narrow, [], 500)
     end
 
     test "refusal is observable" do

--- a/test/bb/actuator/command_payloads_test.exs
+++ b/test/bb/actuator/command_payloads_test.exs
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Actuator.CommandPayloadsTest do
+  use ExUnit.Case
+
+  alias BB.Error.State.UnsupportedCommand
+  alias BB.Message
+  alias BB.Message.Actuator.Command
+
+  defmodule Bespoke do
+    @moduledoc false
+    defstruct [:pattern]
+
+    use BB.Message,
+      schema: [
+        pattern: [type: :atom, required: true, doc: "Which canned pattern to run"]
+      ]
+  end
+
+  # A driver whose hardware speaks a command BB doesn't model. Without
+  # `command_payloads/1` it would have to subscribe to its own command topic,
+  # and the message would arrive having skipped the arm check.
+  defmodule WidenedActuator do
+    @moduledoc false
+    use BB.Actuator, options_schema: []
+
+    @impl BB.Actuator
+    def command_payloads(_opts),
+      do: [BB.Actuator.CommandPayloadsTest.Bespoke | BB.Actuator.default_command_payloads()]
+
+    @impl BB.Actuator
+    def init(opts) do
+      bb = Keyword.fetch!(opts, :bb)
+      {:ok, %{recipient: :persistent_term.get({__MODULE__, bb.robot}, nil)}}
+    end
+
+    @impl BB.Actuator
+    def disarm(_opts), do: :ok
+
+    @impl BB.Actuator
+    def handle_command(%Message{} = message, state) do
+      if state.recipient, do: send(state.recipient, {:commanded, message.payload})
+      {:noreply, state}
+    end
+  end
+
+  # A port that only speaks effort. Everything else is refused by the framework
+  # rather than handed to the driver to misinterpret.
+  defmodule NarrowedActuator do
+    @moduledoc false
+    use BB.Actuator, options_schema: []
+
+    @impl BB.Actuator
+    def command_payloads(_opts), do: [Command.Effort]
+
+    @impl BB.Actuator
+    def init(opts) do
+      bb = Keyword.fetch!(opts, :bb)
+      {:ok, %{recipient: :persistent_term.get({__MODULE__, bb.robot}, nil)}}
+    end
+
+    @impl BB.Actuator
+    def disarm(_opts), do: :ok
+
+    @impl BB.Actuator
+    def handle_command(%Message{} = message, state) do
+      if state.recipient, do: send(state.recipient, {:commanded, message.payload})
+      {:noreply, state}
+    end
+  end
+
+  defmodule Robot do
+    @moduledoc false
+    use BB
+
+    topology do
+      link :base do
+        joint :shoulder do
+          type :revolute
+
+          limit effort: ~u(10 newton_meter), velocity: ~u(180 degree_per_second)
+
+          actuator :wide, BB.Actuator.CommandPayloadsTest.WidenedActuator
+          actuator :narrow, BB.Actuator.CommandPayloadsTest.NarrowedActuator
+
+          link :arm do
+          end
+        end
+      end
+    end
+  end
+
+  setup do
+    :persistent_term.put({WidenedActuator, Robot}, self())
+    :persistent_term.put({NarrowedActuator, Robot}, self())
+    start_supervised!(Robot)
+    :ok = BB.Safety.arm(Robot)
+
+    on_exit(fn ->
+      :persistent_term.erase({WidenedActuator, Robot})
+      :persistent_term.erase({NarrowedActuator, Robot})
+    end)
+
+    :ok
+  end
+
+  describe "the default" do
+    test "is the six built-in command payloads" do
+      assert BB.Actuator.default_command_payloads() == [
+               Command.Effort,
+               Command.Hold,
+               Command.Position,
+               Command.Stop,
+               Command.Trajectory,
+               Command.Velocity
+             ]
+    end
+  end
+
+  describe "widening" do
+    test "a bespoke payload reaches handle_command/2 through the pipeline" do
+      message = Message.new!(Bespoke, :wide, pattern: :wave)
+      :ok = BB.publish(Robot, [:actuator, :base, :shoulder, :wide], message)
+
+      assert_receive {:commanded, %Bespoke{pattern: :wave}}, 500
+    end
+
+    test "and is refused while disarmed, like any other command" do
+      :ok = BB.Safety.disarm(Robot)
+
+      message = Message.new!(Bespoke, :wide, pattern: :wave)
+      :ok = BB.publish(Robot, [:actuator, :base, :shoulder, :wide], message)
+
+      refute_receive {:commanded, _}, 200
+    end
+
+    test "the built-ins still work alongside it" do
+      :ok = BB.Actuator.set_position(Robot, :wide, 0.5)
+      assert_receive {:commanded, %Command.Position{position: 0.5}}, 500
+    end
+  end
+
+  describe "narrowing" do
+    test "an accepted payload gets through" do
+      :ok = BB.Actuator.set_effort(Robot, :narrow, 1.5)
+      assert_receive {:commanded, %Command.Effort{}}, 500
+    end
+
+    test "a published payload outside the list never arrives" do
+      :ok = BB.Actuator.set_position(Robot, :narrow, 0.5)
+      refute_receive {:commanded, _}, 200
+    end
+
+    test "narrowing holds on the direct transport, not just the published one" do
+      :ok = BB.Actuator.set_position!(Robot, :narrow, 0.5)
+      refute_receive {:commanded, _}, 200
+    end
+
+    test "the synchronous transport gets a structured error" do
+      assert {:error, %UnsupportedCommand{actuator: :narrow, command: Command.Position}} =
+               BB.Actuator.set_position_sync(Robot, :narrow, 0.5, [], 500)
+    end
+
+    test "the error names what the actuator does accept" do
+      {:error, error} = BB.Actuator.set_position_sync(Robot, :narrow, 0.5, [], 500)
+      assert Exception.message(error) =~ "Command.Effort"
+    end
+
+    test "refusal is observable" do
+      handler = {__MODULE__, :unsupported, self()}
+
+      :telemetry.attach(
+        handler,
+        [:bb, :actuator, :rejected],
+        fn _event, _measurements, metadata, pid -> send(pid, {:telemetry, metadata}) end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      :ok = BB.Actuator.set_position!(Robot, :narrow, 0.5)
+
+      assert_receive {:telemetry, %{reason: :unsupported_command, actuator: :narrow}}, 500
+    end
+  end
+end

--- a/test/bb/actuator/command_payloads_test.exs
+++ b/test/bb/actuator/command_payloads_test.exs
@@ -168,6 +168,22 @@ defmodule BB.Actuator.CommandPayloadsTest do
       assert Exception.message(error) =~ "Command.Effort"
     end
 
+    test "Stop is admitted even though the driver didn't list it" do
+      :ok = BB.Actuator.stop(Robot, :narrow)
+      assert_receive {:commanded, %Command.Stop{}}, 500
+    end
+
+    test "Stop is admitted on the direct transport too" do
+      :ok = BB.Actuator.stop!(Robot, :narrow)
+      assert_receive {:commanded, %Command.Stop{}}, 500
+    end
+
+    test "Stop still reaches a narrowed actuator while disarmed" do
+      :ok = BB.Safety.disarm(Robot)
+      :ok = BB.Actuator.stop(Robot, :narrow)
+      assert_receive {:commanded, %Command.Stop{}}, 500
+    end
+
     test "refusal is observable" do
       handler = {__MODULE__, :unsupported, self()}
 

--- a/test/bb/actuator/server_command_pipeline_test.exs
+++ b/test/bb/actuator/server_command_pipeline_test.exs
@@ -162,13 +162,16 @@ defmodule BB.Actuator.ServerCommandPipelineTest do
       refute_receive {:received, :command, _message}, 200
     end
 
-    test "Stop commands are exempt from the arm gate" do
+    test "Stop is refused while disarmed, like every other command" do
+      # Stop means "cease travelling and go passive", not "make the hardware
+      # safe" — that's `disarm`. A disarmed actuator isn't being driven, so
+      # there's nothing for it to do, and no reason to exempt it from the gate.
       :ok = BB.cast(DisarmedRobot, :motor, {:command, Message.new!(Command.Stop, :motor, [])})
 
-      assert_receive {:received, :command, %Message{payload: %Command.Stop{}}}, 500
+      refute_receive {:received, :command, _message}, 200
     end
 
-    test "Hold commands are not exempt from the arm gate" do
+    test "Hold is refused while disarmed too" do
       :ok = BB.cast(DisarmedRobot, :motor, {:command, Message.new!(Command.Hold, :motor, [])})
 
       refute_receive {:received, :command, _message}, 200

--- a/usage-rules/actuators.md
+++ b/usage-rules/actuators.md
@@ -69,10 +69,18 @@ for the other two transports.
 Don't check `BB.Safety.armed?/1` in a driver — `BB.Actuator.Server` refuses
 commands to a disarmed robot before they reach you.
 
-**`Command.Stop` is the exception, and you must handle it.** It bypasses the arm
-check and can't be excluded by `command_payloads/1`, because stopping is the
-fail-safe direction. That guarantee is worthless if your driver drops it, so
-give it its own clause rather than letting a catch-all swallow it:
+A command only reaches your driver if you declared it in `command_payloads/1`
+**and** the robot is armed. Nothing is exempt, so a driver can't be handed a
+payload it has no clause for.
+
+`Command.Stop` is a *motion* command — cease travelling and go passive — and the
+counterpart to `Command.Hold`, which maintains position and resists force. Its
+`:decelerate` mode is the giveaway: nothing that slows smoothly is an emergency
+stop. Making hardware safe is `disarm/1`, which is robot-wide and leaves the
+robot unable to move until re-armed.
+
+The default payload list includes `Stop`, so unless you narrow it, give it a
+clause that actually stops driving rather than letting a catch-all swallow it:
 
 ```elixir
 def handle_command(%BB.Message{payload: %Command.Stop{}}, state) do
@@ -80,10 +88,6 @@ def handle_command(%BB.Message{payload: %Command.Stop{}}, state) do
   {:noreply, state}
 end
 ```
-
-`Stop` is not `disarm/1`: disarm is robot-wide, runs without GenServer state,
-and leaves the robot unable to move until re-armed. `Stop` targets one actuator
-and leaves the robot armed.
 
 `handle_info/2`, `handle_cast/2` and `handle_call/3` remain available for the
 driver's own traffic (bus replies, timers, topics it subscribed to itself).

--- a/usage-rules/actuators.md
+++ b/usage-rules/actuators.md
@@ -67,8 +67,23 @@ Return `{:reply, reply, state}` to answer a `set_position_sync/5` caller;
 for the other two transports.
 
 Don't check `BB.Safety.armed?/1` in a driver — `BB.Actuator.Server` refuses
-commands to a disarmed robot before they reach you. `Command.Stop` is the one
-exception and is always delivered.
+commands to a disarmed robot before they reach you.
+
+**`Command.Stop` is the exception, and you must handle it.** It bypasses the arm
+check and can't be excluded by `command_payloads/1`, because stopping is the
+fail-safe direction. That guarantee is worthless if your driver drops it, so
+give it its own clause rather than letting a catch-all swallow it:
+
+```elixir
+def handle_command(%BB.Message{payload: %Command.Stop{}}, state) do
+  cut_drive(state)
+  {:noreply, state}
+end
+```
+
+`Stop` is not `disarm/1`: disarm is robot-wide, runs without GenServer state,
+and leaves the robot unable to move until re-armed. `Stop` targets one actuator
+and leaves the robot armed.
 
 `handle_info/2`, `handle_cast/2` and `handle_call/3` remain available for the
 driver's own traffic (bus replies, timers, topics it subscribed to itself).


### PR DESCRIPTION
Phase 2a of [Proposal 0021](https://github.com/beam-bots/proposals/pull/53). Arbitration (#148) is deliberately **not** here — deferred until there's a concrete case.

## The gap

`BB.Actuator.Server` filtered its subscription against a hardcoded list of the six built-in command types. That's the right default and the wrong hard limit.

The failure mode is what makes it worth fixing. A payload outside the list isn't rejected — it simply isn't delivered, so a driver's only recourse is to subscribe to `[:actuator | path]` itself. That message then fails the narrowed `handle_info` guard, goes straight to the driver, and arrives having **skipped the arm check**. The extension point exists so bespoke command vocabularies route *through* the pipeline rather than around it.

Found while migrating [lostbean/bb_mcuhub](https://github.com/lostbean/bb_mcuhub/pull/12), whose value-types name their own command struct via a `command_message/0` seam. Every one it ships today happens to name a BB built-in, so nothing is broken — but the seam is more general than our filter.

## The callback

```elixir
@callback command_payloads(opts :: keyword()) :: [module()]
```

Optional, defaulting to `BB.Actuator.default_command_payloads/0`. It takes the resolved options rather than being zero-arity because the set isn't always known at compile time — `bb_mcuhub` derives it from a hub and port named in its own options. The subscription moved later in `init/1` so the callback sees validated opts.

The result feeds **both** the `message_types` filter and the dispatch guard. Both are needed: `message_types` only governs pubsub, so a callback feeding only the subscription would leave a narrowed driver still receiving everything through `set_position!/4`.

So one callback serves both directions — widening for a bespoke struct, narrowing for a port that only speaks one thing. Narrowing subsumes a filter such packages otherwise hand-roll inside `handle_command/2`.

## Three unrelated bugs it turned up

Writing the narrowing test with `set_effort/4` raised, and it wasn't the test's fault:

- `Command.Effort` and `Command.Velocity` declare `duration: [type: :pos_integer]` with no nil — while `BB.Actuator` documents `:duration` as *"nil = until stopped"* and `build_effort_message/3` always passes it. **`set_effort/4` and `set_velocity/4` raised whenever a duration was omitted.**
- `command_id` was non-nullable on effort, velocity and trajectory, always passed, same result.

`Command.Position` had both right, which is why the position path never hit it. Nothing else caught this because no driver implements effort, velocity or trajectory, so nothing has ever called those functions.

I've folded the fix in here rather than splitting it, since it's what the new tests exercise — happy to separate it if you'd rather.

## Tests

Ten new cases covering both directions. The one that matters most asserts a bespoke payload reaches `handle_command/2` **and** is refused while disarmed — i.e. that widening puts it through the gate rather than around it. Plus narrowing holding on cast and call, the structured error, and the telemetry.

`mix check --no-retry` green, 1154 tests.

## Follow-up

The four servo drivers should narrow to what they actually implement — Position for pca9685, pigpio and robotis; Position and Trajectory for feetech. Needs this released first.

`BB.Sim.Actuator` should keep the default: it stands in for *any* actuator under simulation, so narrowing it would make a simulated robot refuse commands its real driver accepts.