### PR TITLE
fix: export `locals_without_parens` from `.formatter.exs`

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -136,6 +136,6 @@ spark_locals_without_parens = [
   plugins: [Spark.Formatter],
   locals_without_parens: spark_locals_without_parens,
   export: [
-    locals_without_parems: spark_locals_without_parens
+    locals_without_parens: spark_locals_without_parens
   ]
 ]


### PR DESCRIPTION
Fixes #202.

The `export` key in `.formatter.exs` was spelled `locals_without_parems`, so
every downstream package with `import_deps: [:bb]` resolved an empty list and
`mix format` added brackets to every DSL call.

The top-level `locals_without_parens` was spelled correctly, so formatting
inside this repo was never affected — which is why it went unnoticed.

## Verification

Tested against `bb_servo_pca9685` (which already sets `import_deps: [:bb]`) by
swapping the fixed and published `.formatter.exs` into its `deps/bb` and
clearing `cached_dot_formatter` between runs:

| `deps/bb/.formatter.exs` | paren-less `type :revolute` after `mix format` |
|---|---|
| as published in v0.25.0 | rewritten to `type(:revolute)` |
| with this fix | left as `type :revolute` |

The satellite's resolved `locals_without_parens` goes from 0 to 126 entries.

`mix check --no-retry` passes, including `mix spark.formatter --check` — the
Spark task only rewrites the `spark_locals_without_parens` list, so it doesn't
reintroduce the typo.

## Note on scope

The issue's description implies the fix lets a satellite strip existing
brackets. It doesn't: the Elixir formatter only refrains from *adding* parens
for `locals_without_parens` entries, and preserves parens already present in
the source. Confirmed in this repo, where `type(:revolute)` survives
`mix format` despite the correct top-level key.

So satellites carrying already-bracketed DSL (e.g. `bb_servo_pca9685`'s
`test/support/pan_tilt_robot.ex`) need a one-off pass to strip them once they
pick up a release with this fix. This PR only stops the formatter fighting
paren-less code from here on.