### PR TITLE
improvement: add `BB.Loop` for periodic component timing and health

### DIFF
--- a/lib/bb/loop.ex
+++ b/lib/bb/loop.ex
@@ -1,0 +1,329 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Loop do
+  @moduledoc """
+  Timing and health accounting for periodic components.
+
+  Components that run a periodic loop - controllers, policy runners, hardware
+  bus managers - each need the same three things: a tick that doesn't drift, a
+  measured time delta to hand to whatever algorithm they're driving, and some
+  way to tell an operator the loop isn't keeping up. `BB.Loop` is a struct you
+  embed in your component's state that provides all three.
+
+  It is deliberately *not* a behaviour or a process. Your component stays a
+  plain `BB.Controller` (or `GenServer`, or whatever); the loop is a value it
+  threads through its own callbacks.
+
+  ## Clock sources
+
+  A loop is clocked one of two ways, chosen at `new/2`:
+
+  - `{:rate, hertz}` - the loop schedules its own `:tick` messages. Use this
+    when output must be produced on a fixed cadence regardless of input.
+  - `:external` - something else decides when to step, typically the arrival of
+    a message. The loop does no scheduling and only does the delta and health
+    accounting. Use this when a loop's natural clock is its input; a control
+    loop fed by a sensor is almost always better clocked by that sensor than by
+    an independent timer.
+
+  ## Rate-clocked usage
+
+      def init(opts) do
+        bb = Keyword.fetch!(opts, :bb)
+        loop = BB.Loop.new(bb, clock: {:rate, ~u(100 hertz)})
+        {:ok, %{bb: bb, loop: BB.Loop.arm(loop)}}
+      end
+
+      def handle_info(:tick, state) do
+        {dt, skipped, loop} = BB.Loop.tick(state.loop)
+        {:noreply, step(%{state | loop: loop}, dt, skipped)}
+      end
+
+      def terminate(_reason, state) do
+        BB.Loop.cancel(state.loop)
+        :ok
+      end
+
+  `tick/1` re-arms the timer itself, so there is one call per tick rather than a
+  `tick`/`schedule` pair.
+
+  ## Externally-clocked usage
+
+  Call `observe/2` with the monotonic timestamp of whatever triggered the step -
+  for a `BB.Message`, its `:monotonic_time`, so that the delta reflects the
+  sensor's own sampling interval rather than when the message was dequeued:
+
+      def handle_info({:bb, _topic, %BB.Message{} = message}, state) do
+        {dt, _skipped, loop} = BB.Loop.observe(state.loop, message.monotonic_time)
+        {:noreply, step(%{state | loop: loop}, dt, 0)}
+      end
+
+  `arm/1` and `cancel/1` are no-ops on an externally-clocked loop, so components
+  supporting both clocks don't need to branch on which they were given.
+
+  ## The first delta, and deltas that don't advance
+
+  `dt` is `nil` on a loop's first tick, because there is no previous tick to
+  measure from. It is also `nil` when an `observe/2` timestamp doesn't advance
+  the clock, which is what a duplicate or reordered message looks like; the loop
+  keeps its previous timestamp in that case so the *next* message still measures
+  a correct interval.
+
+  Both cases mean "there is no valid interval here". Match on it and skip the
+  step - handing a `nil` or negative `dt` to an integrator or a derivative term
+  is exactly the kind of thing this module exists to prevent:
+
+      defp step(state, nil, _skipped), do: state
+      defp step(state, dt, _skipped), do: # ... real work
+
+  ## Missed deadlines
+
+  A rate-clocked loop schedules against an absolute monotonic deadline that
+  accumulates in nanoseconds, so a slow handler doesn't push the schedule later
+  and rounding doesn't compound.
+
+  When a handler overruns, whole missed periods are **skipped**, not queued.
+  This is the important part: re-arming to a deadline that has already passed
+  makes `Process.send_after/4` fire immediately, and a loop that has fallen ten
+  periods behind would otherwise deliver ten back-to-back ticks with a `dt` of
+  effectively zero. For anything with an integral or derivative term that is far
+  worse than missing the ticks outright.
+
+  The number of periods dropped is returned from `tick/1` and reported as the
+  `:skipped` telemetry measurement. It is the loop's overrun metric: a loop that
+  is consistently skipping is configured faster than the machine can actually
+  run it.
+
+  ## Achievable rates
+
+  `Process.send_after/4` has millisecond resolution, so a period below 1ms
+  cannot be represented and rates much above 1kHz will skip most of their
+  periods. Well below that ceiling the BEAM's scheduling tail dominates: on a
+  general-purpose kernel, tick latency has a floor of tens of milliseconds
+  regardless of the period asked for, so a loop nominally at 500Hz may deliver
+  half that. This is not a reason to avoid high rates, but it is a reason to
+  watch `:skipped` rather than trust the configured rate.
+
+  ## Telemetry
+
+  Each tick with a valid `dt` emits `[:bb, :loop, :tick]`:
+
+  - Measurements: `%{dt: float_seconds, skipped: integer, deadline_error: integer_ns}`
+  - Metadata: `%{robot: module, path: [atom], clock: {:rate, float} | :external}`
+
+  `:deadline_error` is how late the tick was against its scheduled deadline. It
+  and `:skipped` are always `0` for externally-clocked loops, which have no
+  deadline of their own. No event is emitted when `dt` is `nil`, since there is
+  no interval to report.
+
+  ## What this does not cover
+
+  `BB.Loop` answers "is this loop meeting its own deadline?". It knows nothing
+  about a component's inputs, so input freshness is not its job - a component
+  that must stop acting on a stale sensor reading owns that timeout itself, and
+  should report it separately via `BB.Diagnostic`.
+  """
+
+  alias BB.Robot.Units
+
+  @typedoc """
+  How a loop is clocked. Normalised to `{:rate, float}` in hertz, or `:external`.
+  """
+  @type clock :: {:rate, float()} | :external
+
+  @typedoc """
+  A `%{robot: module, path: [atom]}` map, as injected into component options.
+  """
+  @type bb :: %{robot: module(), path: [atom()]}
+
+  @type t :: %__MODULE__{
+          bb: bb(),
+          clock: clock(),
+          period_ns: pos_integer() | nil,
+          deadline_ns: integer(),
+          last_ns: integer() | nil,
+          tick_ref: reference() | nil,
+          ticks: non_neg_integer(),
+          skipped: non_neg_integer()
+        }
+
+  @enforce_keys [:bb, :clock, :deadline_ns]
+  defstruct [
+    :bb,
+    :clock,
+    :period_ns,
+    :deadline_ns,
+    :last_ns,
+    :tick_ref,
+    ticks: 0,
+    skipped: 0
+  ]
+
+  @tick_message :tick
+  @ns_per_second 1_000_000_000
+  @ns_per_millisecond 1_000_000
+
+  @doc """
+  Build a loop for a component.
+
+  `bb` is the `%{robot: _, path: _}` map injected into component options.
+
+  ## Options
+
+  - `:clock` (required) - `{:rate, hertz}` or `:external`. A rate may be given
+    as a `Localize.Unit` in any frequency unit (`~u(100 hertz)`) or as a plain
+    positive number of hertz.
+
+  Building a loop does not start it; call `arm/1` once the component is ready to
+  receive ticks.
+
+  ## Examples
+
+      BB.Loop.new(bb, clock: {:rate, ~u(100 hertz)})
+      BB.Loop.new(bb, clock: {:rate, 100})
+      BB.Loop.new(bb, clock: :external)
+  """
+  @spec new(bb(), keyword()) :: t()
+  def new(bb, opts) do
+    clock = Keyword.fetch!(opts, :clock)
+
+    %__MODULE__{
+      bb: bb,
+      clock: normalise_clock(clock),
+      period_ns: period_ns(clock),
+      deadline_ns: System.monotonic_time(:nanosecond)
+    }
+  end
+
+  @doc """
+  Schedule the loop's first tick.
+
+  Call once from `init/1`. Subsequent ticks are armed by `tick/1`. A no-op on an
+  externally-clocked loop.
+  """
+  @spec arm(t()) :: t()
+  def arm(%__MODULE__{clock: :external} = loop), do: loop
+
+  def arm(%__MODULE__{} = loop) do
+    {loop, _skipped} = schedule(loop, System.monotonic_time(:nanosecond))
+    loop
+  end
+
+  @doc """
+  Record a tick on a rate-clocked loop and schedule the next one.
+
+  Returns `{dt, skipped, loop}` where `dt` is the seconds elapsed since the
+  previous tick (`nil` on the first), and `skipped` is the number of whole
+  periods dropped because the loop had fallen behind.
+
+  Call this at the top of your `:tick` handler. The next deadline is absolute,
+  so arming before doing the tick's work is correct - the work's duration
+  doesn't move the schedule, and an overrun is reported by the following tick.
+  """
+  @spec tick(t()) :: {float() | nil, non_neg_integer(), t()}
+  def tick(%__MODULE__{clock: {:rate, _}} = loop) do
+    now = System.monotonic_time(:nanosecond)
+    dt = elapsed(loop.last_ns, now)
+    deadline_error = now - loop.deadline_ns
+
+    {loop, skipped} =
+      schedule(%{loop | last_ns: now, ticks: loop.ticks + 1}, now)
+
+    emit(loop, dt, skipped, deadline_error)
+    {dt, skipped, loop}
+  end
+
+  @doc """
+  Record a step on an externally-clocked loop at the given monotonic timestamp.
+
+  `at_ns` should be the monotonic nanosecond timestamp of whatever triggered the
+  step - for a `BB.Message`, its `:monotonic_time` field.
+
+  Returns `{dt, 0, loop}`. `dt` is `nil` for the first observation, and for any
+  timestamp that doesn't advance past the previous one; see the module docs.
+  """
+  @spec observe(t(), integer()) :: {float() | nil, 0, t()}
+  def observe(%__MODULE__{clock: :external, last_ns: nil} = loop, at_ns)
+      when is_integer(at_ns) do
+    {nil, 0, %{loop | last_ns: at_ns, ticks: loop.ticks + 1}}
+  end
+
+  def observe(%__MODULE__{clock: :external, last_ns: last_ns} = loop, at_ns)
+      when is_integer(at_ns) and at_ns > last_ns do
+    dt = (at_ns - last_ns) / @ns_per_second
+    loop = %{loop | last_ns: at_ns, ticks: loop.ticks + 1}
+    emit(loop, dt, 0, 0)
+    {dt, 0, loop}
+  end
+
+  def observe(%__MODULE__{clock: :external} = loop, at_ns) when is_integer(at_ns) do
+    {nil, 0, loop}
+  end
+
+  @doc """
+  Cancel any pending tick.
+
+  Call from `terminate/2`. A no-op on an externally-clocked loop, or one that
+  was never armed.
+  """
+  @spec cancel(t()) :: t()
+  def cancel(%__MODULE__{tick_ref: nil} = loop), do: loop
+
+  def cancel(%__MODULE__{tick_ref: tick_ref} = loop) do
+    Process.cancel_timer(tick_ref)
+    %{loop | tick_ref: nil}
+  end
+
+  defp schedule(%__MODULE__{period_ns: period_ns} = loop, now) do
+    {deadline_ns, skipped} = next_deadline(loop.deadline_ns + period_ns, now, period_ns, 0)
+
+    loop = %{
+      loop
+      | deadline_ns: deadline_ns,
+        skipped: loop.skipped + skipped,
+        tick_ref: Process.send_after(self(), @tick_message, ceil_ms(deadline_ns), abs: true)
+    }
+
+    {loop, skipped}
+  end
+
+  defp next_deadline(deadline_ns, now, period_ns, skipped) when deadline_ns <= now,
+    do: next_deadline(deadline_ns + period_ns, now, period_ns, skipped + 1)
+
+  defp next_deadline(deadline_ns, _now, _period_ns, skipped), do: {deadline_ns, skipped}
+
+  defp elapsed(nil, _now), do: nil
+  defp elapsed(last_ns, now), do: (now - last_ns) / @ns_per_second
+
+  defp emit(_loop, nil, _skipped, _deadline_error), do: :ok
+
+  defp emit(loop, dt, skipped, deadline_error) do
+    :telemetry.execute(
+      [:bb, :loop, :tick],
+      %{dt: dt, skipped: skipped, deadline_error: deadline_error},
+      %{robot: loop.bb.robot, path: loop.bb.path, clock: loop.clock}
+    )
+  end
+
+  defp normalise_clock(:external), do: :external
+  defp normalise_clock({:rate, rate}), do: {:rate, hertz(rate)}
+
+  defp period_ns(:external), do: nil
+  defp period_ns({:rate, rate}), do: round(@ns_per_second / hertz(rate))
+
+  defp hertz(%Localize.Unit{} = rate) do
+    rate
+    |> Localize.Unit.convert!("hertz")
+    |> Units.extract_float()
+    |> hertz()
+  end
+
+  defp hertz(rate) when is_number(rate) and rate > 0, do: rate / 1
+
+  # Erlang monotonic time is routinely a large negative integer, for which
+  # `div/2` truncates towards zero rather than flooring - so the obvious
+  # `div(ns + 999_999, 1_000_000)` rounds the wrong way for half the timeline.
+  defp ceil_ms(ns), do: -Integer.floor_div(-ns, @ns_per_millisecond)
+end

--- a/lib/bb/loop.ex
+++ b/lib/bb/loop.ex
@@ -186,7 +186,7 @@ defmodule BB.Loop do
       BB.Loop.new(bb, clock: :external)
   """
   @spec new(bb(), keyword()) :: t()
-  def new(bb, opts) do
+  def new(%{robot: _, path: _} = bb, opts) do
     clock = Keyword.fetch!(opts, :clock)
 
     %__MODULE__{

--- a/mix.exs
+++ b/mix.exs
@@ -206,6 +206,7 @@ defmodule BB.MixProject do
       {:nx, "~> 0.10"},
       {:spark, "~> 2.3"},
       {:splode, "~> 0.2"},
+      {:telemetry, "~> 1.0"},
 
       # dev/test
       {:benchee, "~> 1.5", only: [:dev, :test], runtime: false},

--- a/test/bb/loop_test.exs
+++ b/test/bb/loop_test.exs
@@ -1,0 +1,336 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.LoopTest do
+  use ExUnit.Case, async: true
+
+  import BB.Unit
+
+  alias BB.Loop
+
+  @bb %{robot: BB.LoopTest.Robot, path: [:base_link, :test_loop]}
+
+  # These tests drive real timers, so they are sensitive to scheduler load. The
+  # period is kept well above the BEAM's scheduling tail and receive timeouts
+  # well above that again, so that a loaded CI machine fails them only for real
+  # regressions. Assertions are on structural properties (a period is either
+  # ticked or skipped; a delta matches wall time) rather than on hitting the
+  # nominal rate, which is not something the VM guarantees.
+  @rate_hz 50
+  @period_ms 20
+  @receive_timeout 2_000
+
+  defp rate_loop(hertz \\ @rate_hz), do: Loop.new(@bb, clock: {:rate, hertz})
+  defp external_loop, do: Loop.new(@bb, clock: :external)
+
+  defp attach_telemetry(context) do
+    handler_id = "loop-test-#{inspect(context.test)}"
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      [:bb, :loop, :tick],
+      fn event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    :ok
+  end
+
+  describe "new/2" do
+    test "accepts a rate as a unit" do
+      loop = Loop.new(@bb, clock: {:rate, ~u(100 hertz)})
+
+      assert loop.clock == {:rate, 100.0}
+      assert loop.period_ns == 10_000_000
+    end
+
+    test "accepts a rate as a plain number of hertz" do
+      assert Loop.new(@bb, clock: {:rate, 100}).clock == {:rate, 100.0}
+      assert Loop.new(@bb, clock: {:rate, 2.5}).period_ns == 400_000_000
+    end
+
+    test "rejects a non-positive rate" do
+      assert_raise FunctionClauseError, fn -> Loop.new(@bb, clock: {:rate, 0}) end
+      assert_raise FunctionClauseError, fn -> Loop.new(@bb, clock: {:rate, -1}) end
+    end
+
+    test "an external clock has no period" do
+      loop = external_loop()
+
+      assert loop.clock == :external
+      assert loop.period_ns == nil
+    end
+
+    test "does not schedule anything" do
+      _loop = rate_loop()
+
+      refute_receive :tick, 50
+    end
+  end
+
+  describe "arm/1" do
+    test "schedules the first tick" do
+      Loop.arm(rate_loop())
+
+      assert_receive :tick, @receive_timeout
+    end
+
+    test "is a no-op for an external clock" do
+      loop = external_loop()
+
+      assert Loop.arm(loop) == loop
+      refute_receive :tick, 50
+    end
+  end
+
+  describe "tick/1" do
+    test "has no delta on the first tick" do
+      loop = Loop.arm(rate_loop())
+      assert_receive :tick, @receive_timeout
+
+      assert {nil, _skipped, _loop} = Loop.tick(loop)
+    end
+
+    test "measures the delta between ticks" do
+      loop = Loop.arm(rate_loop())
+      assert_receive :tick, @receive_timeout
+      {nil, _skipped, loop} = Loop.tick(loop)
+
+      # Compare against wall time rather than the nominal period: scheduling
+      # latency is unbounded, but the reported deltas must add up to the real
+      # interval. Measuring across several ticks keeps the endpoint error from
+      # dominating the tolerance.
+      before = System.monotonic_time(:nanosecond)
+
+      {deltas, _loop} =
+        Enum.map_reduce(1..5, loop, fn _, loop ->
+          assert_receive :tick, @receive_timeout
+          {dt, _skipped, loop} = Loop.tick(loop)
+          {dt, loop}
+        end)
+
+      measured = (System.monotonic_time(:nanosecond) - before) / 1_000_000_000
+
+      assert_in_delta Enum.sum(deltas), measured, 0.02
+    end
+
+    test "re-arms the next tick" do
+      loop = Loop.arm(rate_loop())
+      assert_receive :tick, @receive_timeout
+      {nil, _skipped, _loop} = Loop.tick(loop)
+
+      assert_receive :tick, @receive_timeout
+    end
+
+    test "counts ticks" do
+      loop = Loop.arm(rate_loop())
+
+      loop =
+        Enum.reduce(1..3, loop, fn _, loop ->
+          assert_receive :tick, @receive_timeout
+          {_dt, _skipped, loop} = Loop.tick(loop)
+          loop
+        end)
+
+      assert loop.ticks == 3
+    end
+  end
+
+  describe "tick/1 when the handler overruns" do
+    test "skips whole missed periods rather than queueing them" do
+      loop = Loop.arm(rate_loop())
+      assert_receive :tick, @receive_timeout
+      {nil, _skipped, loop} = Loop.tick(loop)
+
+      # Twenty periods' worth of work in one handler.
+      Process.sleep(20 * @period_ms)
+
+      assert_receive :tick, @receive_timeout
+      {dt, skipped, _loop} = Loop.tick(loop)
+
+      assert dt >= 0.02 * 20 * 0.9,
+             "expected the measured delta to reflect the overrun, got #{dt}"
+
+      assert skipped >= 10, "expected missed periods to be reported, got #{skipped}"
+    end
+
+    test "does not deliver a burst of catch-up ticks" do
+      loop = Loop.arm(rate_loop())
+      assert_receive :tick, @receive_timeout
+      {nil, _skipped, loop} = Loop.tick(loop)
+
+      Process.sleep(20 * @period_ms)
+
+      assert_receive :tick, @receive_timeout
+      {_dt, _skipped, loop} = Loop.tick(loop)
+
+      # The next five ticks span five real periods. A loop that caught up by
+      # firing its missed deadlines would deliver them back-to-back, summing to
+      # roughly nothing - which is the failure absolute deadlines alone do *not*
+      # prevent, since a deadline already in the past fires immediately.
+      #
+      # The sum is asserted rather than each delta: one short interval is
+      # legitimate, because skipping forward resynchronises to the deadline grid
+      # and can land the next deadline just after the current tick. Load can
+      # only push this total up, never down.
+      {deltas, _loop} =
+        Enum.map_reduce(1..5, loop, fn _, loop ->
+          assert_receive :tick, @receive_timeout
+          {dt, _skipped, loop} = Loop.tick(loop)
+          {dt, loop}
+        end)
+
+      assert Enum.sum(deltas) >= 4 * @period_ms / 1000,
+             "expected five ticks to span five periods, got #{inspect(deltas)}"
+    end
+
+    test "accounts for every period as either a tick or a skip" do
+      run_ms = 50 * @period_ms
+      loop = Loop.arm(rate_loop())
+
+      started = System.monotonic_time(:millisecond)
+      loop = drain_until(loop, started + run_ms)
+      elapsed = System.monotonic_time(:millisecond) - started
+
+      # The deadline advances by exactly one period per tick-or-skip, so this
+      # holds regardless of how badly the machine is keeping up. Only the
+      # partial period either side of the run is unaccounted for.
+      periods = elapsed / @period_ms
+      accounted = loop.ticks + loop.skipped
+
+      assert_in_delta accounted, periods, 3
+    end
+  end
+
+  describe "observe/2" do
+    test "has no delta on the first observation" do
+      assert {nil, 0, loop} = Loop.observe(external_loop(), 1_000_000)
+      assert loop.ticks == 1
+    end
+
+    test "measures the delta between observations" do
+      {nil, 0, loop} = Loop.observe(external_loop(), 1_000_000)
+
+      assert {dt, 0, _loop} = Loop.observe(loop, 3_000_000)
+      assert dt == 0.002
+    end
+
+    test "never reports a skip" do
+      {nil, 0, loop} = Loop.observe(external_loop(), 1_000_000)
+      {_dt, skipped, _loop} = Loop.observe(loop, 100_000_000)
+
+      assert skipped == 0
+    end
+
+    test "ignores a timestamp that does not advance" do
+      {nil, 0, loop} = Loop.observe(external_loop(), 1_000_000)
+      {_dt, 0, loop} = Loop.observe(loop, 2_000_000)
+
+      assert {nil, 0, unchanged} = Loop.observe(loop, 2_000_000)
+      assert unchanged == loop
+
+      assert {nil, 0, unchanged} = Loop.observe(loop, 1_500_000)
+      assert unchanged == loop
+    end
+
+    test "measures the next delta from the last advancing timestamp" do
+      {nil, 0, loop} = Loop.observe(external_loop(), 1_000_000)
+      {_dt, 0, loop} = Loop.observe(loop, 2_000_000)
+      {nil, 0, loop} = Loop.observe(loop, 1_500_000)
+
+      assert {dt, 0, _loop} = Loop.observe(loop, 3_000_000)
+      assert dt == 0.001
+    end
+
+    test "does not schedule anything" do
+      {nil, 0, loop} = Loop.observe(external_loop(), 1_000_000)
+      {_dt, 0, _loop} = Loop.observe(loop, 2_000_000)
+
+      refute_receive :tick, 50
+    end
+  end
+
+  describe "cancel/1" do
+    test "cancels a pending tick" do
+      loop = Loop.arm(rate_loop())
+
+      assert %{tick_ref: nil} = Loop.cancel(loop)
+      refute_receive :tick, 50
+    end
+
+    test "is a no-op on an unarmed loop" do
+      loop = rate_loop()
+
+      assert Loop.cancel(loop) == loop
+    end
+
+    test "is a no-op for an external clock" do
+      loop = external_loop()
+
+      assert Loop.cancel(loop) == loop
+    end
+  end
+
+  describe "telemetry" do
+    setup :attach_telemetry
+
+    test "emits a tick event with measurements and metadata" do
+      loop = Loop.arm(rate_loop())
+      assert_receive :tick, @receive_timeout
+      {nil, _skipped, loop} = Loop.tick(loop)
+
+      assert_receive :tick, @receive_timeout
+      {_dt, _skipped, _loop} = Loop.tick(loop)
+
+      assert_receive {:telemetry, [:bb, :loop, :tick], measurements, metadata}
+
+      assert %{dt: dt, skipped: skipped, deadline_error: deadline_error} = measurements
+      assert is_float(dt)
+      assert is_integer(skipped)
+      assert is_integer(deadline_error)
+
+      assert metadata == %{
+               robot: BB.LoopTest.Robot,
+               path: [:base_link, :test_loop],
+               clock: {:rate, @rate_hz / 1}
+             }
+    end
+
+    test "does not emit when there is no interval to report" do
+      loop = Loop.arm(rate_loop())
+      assert_receive :tick, @receive_timeout
+      {nil, _skipped, _loop} = Loop.tick(loop)
+
+      refute_receive {:telemetry, [:bb, :loop, :tick], _measurements, _metadata}, 50
+    end
+
+    test "emits for an externally-clocked loop" do
+      {nil, 0, loop} = Loop.observe(external_loop(), 1_000_000)
+      {_dt, 0, _loop} = Loop.observe(loop, 3_000_000)
+
+      assert_receive {:telemetry, [:bb, :loop, :tick], measurements, metadata}
+
+      assert measurements == %{dt: 0.002, skipped: 0, deadline_error: 0}
+      assert metadata.clock == :external
+    end
+  end
+
+  defp drain_until(loop, until_ms) do
+    if System.monotonic_time(:millisecond) >= until_ms do
+      loop
+    else
+      receive do
+        :tick ->
+          {_dt, _skipped, loop} = Loop.tick(loop)
+          drain_until(loop, until_ms)
+      after
+        @receive_timeout -> loop
+      end
+    end
+  end
+end

--- a/test/bb/loop_test.exs
+++ b/test/bb/loop_test.exs
@@ -59,6 +59,18 @@ defmodule BB.LoopTest do
       assert_raise FunctionClauseError, fn -> Loop.new(@bb, clock: {:rate, -1}) end
     end
 
+    test "rejects a bb map missing robot or path" do
+      # Caught here rather than on the first tick, where the telemetry metadata
+      # would otherwise be the first thing to notice. Built with Map.delete/2
+      # so the type checker can't narrow it: a real `bb` comes out of
+      # `Keyword.fetch!/2` at runtime, where it can't be checked statically.
+      for key <- [:robot, :path] do
+        bb = Map.delete(@bb, key)
+
+        assert_raise FunctionClauseError, fn -> Loop.new(bb, clock: :external) end
+      end
+    end
+
     test "an external clock has no period" do
       loop = external_loop()
 


### PR DESCRIPTION
Adds `BB.Loop`, a struct that periodic components embed in their state to get drift-free tick scheduling, a measured time delta, and overrun reporting. Nothing is migrated to it here — this PR changes no behaviour.

Groundwork for beam-bots/bb_pid_controller#43, which asks for a rate/health contract shared by loop-runners.

## Why

Every periodic component in the ecosystem hand-rolls its own tick loop, and each gets the timing wrong differently:

| Component | Scheme | Problem |
|---|---|---|
| `BB.PID.Controller`, `bb_policy` runner | fixed `send_after` delay, re-armed after the work | handler duration *and* scheduler latency both push the schedule later |
| feetech, robotis controllers | delay minus handler elapsed | closer, but ignores scheduler latency and re-rounds to ms every period |

Measured over 300 ticks at a nominal 10ms, the first scheme drifts **13%** — a "100Hz" loop actually running at ~88Hz.

## Design notes

**Absolute deadlines accumulated in nanoseconds.** Neither a slow handler nor millisecond rounding moves the schedule.

**Missed periods are skipped, not queued.** This is the non-obvious part. Re-arming to a deadline that has already passed makes `Process.send_after/4` fire *immediately*, so absolute deadlines **alone** still produce a burst — measured at 19 consecutive sub-millisecond ticks after a 200ms stall, identical to what `:timer.send_interval/2` produces via mailbox backlog:

| scheme | max mailbox | ticks <1ms apart | periods skipped |
|---|---|---|---|
| `:timer.send_interval/2` | 19 | 19 | 0 |
| `send_after` `abs: true` | 0 | **19** | 0 |
| `send_after` `abs: true` + skip | 0 | 0 | 20 |

For anything carrying an integral or derivative term, a burst of zero-`dt` steps is worse than missing the ticks outright. The skip count doubles as the loop's overrun metric.

(`:timer.send_interval/2` was considered and is better than its reputation — since OTP 25 it spawns a helper process per timer rather than funnelling through `timer_server`, and it is already drift-free by the same absolute-deadline mechanism. It loses on the burst above, on unbounded mailbox growth during a long block, and on costing a process plus a message hop per loop.)

**Externally-clocked loops are supported directly.** `observe/2` does the delta and telemetry accounting with no scheduling, taking the triggering message's monotonic timestamp so the delta reflects the sensor's sampling interval rather than when the message was dequeued. A control loop fed by a sensor is usually better clocked by that sensor than by an independent timer.

**Ceiling division uses `Integer.floor_div/2`,** not the obvious `div(ns + 999_999, 1_000_000)` — Erlang monotonic time is routinely a large negative integer (`-5.76e17` ns on my machine) and `div/2` truncates towards zero.

## Scope

`BB.Loop` answers "is this loop meeting its own deadline?". It knows nothing about a component's inputs, so input freshness is deliberately not its job — a component that must stop acting on a stale reading owns that timeout itself.

## Testing

26 tests. They drive real timers, so assertions are on structural invariants (every period is either ticked or skipped; reported deltas sum to real wall time) rather than on hitting the nominal rate, which the VM does not guarantee. Verified 10/10 green with all cores saturated as well as idle — an earlier revision passed 12/12 idle and failed 4–6 tests per run under load.

`mix check --no-retry` passes.

## Also here

`:telemetry` is declared as a direct dependency. `bb` calls it from six modules — including `BB.Telemetry`, whose entire purpose is wrapping it — but only received the app transitively via `nx` and `finch`. `~> 1.0` is compatible with both transitive requirements, so `mix.lock` is unchanged.