### PR TITLE
fix: discard an already-delivered tick in `BB.Loop.cancel/1`

### DIFF
--- a/lib/bb/loop.ex
+++ b/lib/bb/loop.ex
@@ -265,14 +265,28 @@ defmodule BB.Loop do
   @doc """
   Cancel any pending tick.
 
-  Call from `terminate/2`. A no-op on an externally-clocked loop, or one that
-  was never armed.
+  Call from `terminate/2`, and before replacing a running loop with one at a
+  different rate. A no-op on an externally-clocked loop, or one that was never
+  armed.
+
+  If the timer had already fired, the delivered `:tick` is discarded too.
+  Leaving it queued would make the next `arm/1` deliver a tick immediately with
+  a delta of roughly zero - the exact thing this module exists to keep out of a
+  control loop - and would leave a second timer in flight that a later
+  `cancel/1` could not clean up.
   """
   @spec cancel(t()) :: t()
   def cancel(%__MODULE__{tick_ref: nil} = loop), do: loop
 
   def cancel(%__MODULE__{tick_ref: tick_ref} = loop) do
-    Process.cancel_timer(tick_ref)
+    if Process.cancel_timer(tick_ref) == false do
+      receive do
+        @tick_message -> :ok
+      after
+        0 -> :ok
+      end
+    end
+
     %{loop | tick_ref: nil}
   end
 

--- a/test/bb/loop_test.exs
+++ b/test/bb/loop_test.exs
@@ -281,6 +281,30 @@ defmodule BB.LoopTest do
       assert Loop.cancel(loop) == loop
     end
 
+    test "discards a tick that had already been delivered" do
+      loop = Loop.arm(rate_loop())
+      Process.sleep(3 * @period_ms)
+
+      # The timer has fired and :tick is sitting in the mailbox. Left there, the
+      # next arm/1 would give the loop two independent tick chains.
+      Loop.cancel(loop)
+
+      refute_receive :tick, 50
+    end
+
+    test "a re-armed loop does not tick immediately" do
+      armed = Loop.arm(rate_loop())
+      Process.sleep(3 * @period_ms)
+
+      armed
+      |> Loop.cancel()
+      |> Loop.arm()
+
+      # Without the discard, the stale tick would be waiting already.
+      refute_receive :tick, 2
+      assert_receive :tick, @receive_timeout
+    end
+
     test "is a no-op for an external clock" do
       loop = external_loop()
 


### PR DESCRIPTION
Follow-up to #212. This commit was written while that PR was open but never made it onto the branch before the squash merge, so `main` has `BB.Loop` without it.

## What's missing

`Process.cancel_timer/1` does not remove a message the timer has already delivered, so cancelling a loop whose tick was in flight leaves `:tick` sitting in the mailbox.

`terminate/2` doesn't care — the process is going away. Re-arming does: the next `arm/1` is followed immediately by that stale tick at a delta of roughly zero, which is the exact thing `BB.Loop` exists to keep out of a control loop. It also leaves a second timer in flight that a later `cancel/1` can't reach.

## Why it matters now

Rebuilding a loop at a new rate is the case that hits this — a component reacting to a parameter change cancels and re-arms in the same callback. `bb_sensor_ina219`'s `handle_options/2` does exactly that, which is how it was found.

Without this, any satellite that retunes a loop rate at runtime gets one bogus near-zero-delta tick per rate change.

## Note on the earlier claim

The commit message on the original version of this said the leaked timer caused a *doubled* tick rate. That was wrong, and a mutation test disproved it: `deadline_ns` lives in the struct and advances exactly one period per `tick/1` regardless of how many timers are outstanding, so the rate stays correct. The real symptom is the spurious immediate tick plus the unreachable timer. The message and docs here say that instead.

## Testing

Two tests, both verified to fail with the flush removed and `cancel_timer/1` left in place:

- `cancel/1 discards a tick that had already been delivered`
- `cancel/1 a re-armed loop does not tick immediately`

`mix test test/bb/loop_test.exs` — 29 passed.