### PR TITLE
feat!: implement multi-DoF (`:planar` and `:floating`) joints

### DIFF
--- a/documentation/dsls/DSL-BB.md
+++ b/documentation/dsls/DSL-BB.md
@@ -986,7 +986,7 @@ A kinematic joint between a parent link and a child link.
 
 | Name | Type | Default | Docs |
 |------|------|---------|------|
-| [`type`](#topology-joint-type){: #topology-joint-type } | `:revolute \| :continuous \| :prismatic \| :fixed \| :floating \| :planar` |  | Specifies the type of joint |
+| [`type`](#topology-joint-type){: #topology-joint-type } | `:revolute \| :continuous \| :prismatic \| :fixed \| :floating \| :planar` |  | Specifies the type of joint, which determines its degrees of freedom: `:fixed` has none, `:revolute`, `:continuous` and `:prismatic` have one, `:planar` has three (two in-plane translations and a rotation about the plane normal), and `:floating` has all six. See `BB.Robot.State` for the configuration shape each type carries. |
 
 
 ### topology.joint.origin
@@ -1022,7 +1022,13 @@ Target: `BB.Dsl.Origin`
 ### topology.joint.axis
 
 
-The joint axis specified in the joint frame. This is the axis of rotation for revolute joints, the axis of translation for prismatic joints, and the surface normal for planar joints. The axis is specified in the joint frame of reference. Fixed and floating joints do not use the axis field
+The joint axis specified in the joint frame.
+
+What it means depends on the joint type:
+
+- `:revolute` and `:continuous` rotate about it; `:prismatic` translates along it. Optional for all three, defaulting to Z.
+- `:planar` uses it as the **surface normal** of the plane the joint moves in, so it is **required** — an empty `axis` block gives the horizontal plane a ground vehicle wants.
+- `:fixed` and `:floating` do not use it, and providing one is an error. A floating joint has all six degrees of freedom and no distinguished direction, so there would be nothing for an axis to describe.
 
 
 

--- a/documentation/reference/error-types.md
+++ b/documentation/reference/error-types.md
@@ -222,6 +222,72 @@ Near kinematic singularity.
 
 **Severity:** `:warning`
 
+### NoParentJoint
+
+A link has no parent joint because it is the root of the kinematic tree.
+
+Distinct from `UnknownLink` so a caller walking up the tree gets a termination
+signal to match on rather than being told its valid root link doesn't exist.
+
+**Module:** `BB.Error.Kinematics.NoParentJoint`
+
+**Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `link` | `atom` | The root link |
+
+**Severity:** `:error`
+
+### NotAnAncestor
+
+A source link does not sit above a target link in the kinematic tree.
+
+Returned by `BB.Robot.path_between/3`. `common_ancestor` is always populated and
+names the link the caller should have passed as the source.
+
+**Module:** `BB.Error.Kinematics.NotAnAncestor`
+
+**Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `source_link` | `atom` | The link given as the source |
+| `target_link` | `atom` | The link given as the target |
+| `common_ancestor` | `atom` | Their nearest common ancestor |
+
+**Severity:** `:error`
+
+### UnknownActuator
+
+Referenced actuator not found.
+
+**Module:** `BB.Error.Kinematics.UnknownActuator`
+
+**Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `actuator` | `atom` | Unknown actuator name |
+| `robot` | `atom` | Robot name, if known |
+
+**Severity:** `:error`
+
+### UnknownJoint
+
+Referenced joint not found.
+
+**Module:** `BB.Error.Kinematics.UnknownJoint`
+
+**Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `joint` | `atom` | Unknown joint name |
+| `robot` | `atom` | Robot name, if known |
+
+**Severity:** `:error`
+
 ### UnknownLink
 
 Referenced link not found.
@@ -233,6 +299,8 @@ Referenced link not found.
 | Field | Type | Description |
 |-------|------|-------------|
 | `link` | `atom` | Unknown link name |
+| `role` | `:source \| :target` | Which parameter was at fault, for lookups taking both ends of a chain; `nil` otherwise |
+| `robot` | `atom` | Robot name, if known |
 
 **Severity:** `:error`
 

--- a/documentation/reference/message-types.md
+++ b/documentation/reference/message-types.md
@@ -36,9 +36,22 @@ State of one or more joints.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `names` | `[atom]` | Yes | Joint names |
-| `positions` | `[float]` | No | Positions in radians (revolute) or metres (prismatic) |
-| `velocities` | `[float]` | No | Velocities in rad/s or m/s |
-| `efforts` | `[float]` | No | Efforts in Nm or N |
+| `positions` | `[configuration]` | No | Configurations, shaped to each joint's type |
+| `velocities` | `[velocity]` | No | Velocities, shaped to each joint's type |
+| `efforts` | `[effort]` | No | Efforts, shaped to each joint's type |
+
+Element types depend on the joint's degrees of freedom, and line up positionally
+with `names`:
+
+| Joint type | `positions` | `velocities` | `efforts` |
+|---|---|---|---|
+| single-DoF | `float` — radians (revolute) or metres (prismatic) | `float` — rad/s or m/s | `float` — Nm or N |
+| `:planar` | `BB.Math.Transform2D` | `BB.Message.Geometry.Twist2D` | `BB.Message.Geometry.Wrench2D` |
+| `:floating` | `BB.Math.Transform` | `BB.Message.Geometry.Twist` | `BB.Message.Geometry.Wrench` |
+
+Most consumers only ever see single-DoF joints, so their handling is unchanged in
+practice — but a consumer that pattern matches on a float, or does arithmetic on
+an element, should state which joint types it supports.
 
 **Published to:** `[:sensor, joint_name]`
 
@@ -48,6 +61,13 @@ JointState.new!(
   names: [:shoulder, :elbow],
   positions: [0.5, 1.2],
   velocities: [0.1, 0.0]
+)
+
+# A mobile base reports its whole pose in the same message as its mast, so a
+# consumer never has to correlate two topics to reconstruct one instant.
+JointState.new!(
+  names: [:base, :mast],
+  positions: [BB.Math.Transform2D.new(12.4, -3.1, 1.57), 0.5]
 )
 ```
 

--- a/documentation/tutorials/04-kinematics.md
+++ b/documentation/tutorials/04-kinematics.md
@@ -48,14 +48,14 @@ Positions are in **radians** for revolute joints and **metres** for prismatic jo
 
 ## Querying a Running Robot
 
-For a running robot, query the Runtime for current joint positions:
+For a running robot, query the Runtime for current joint configurations:
 
 ```elixir
-iex> positions = BB.Robot.Runtime.positions(MyRobot.Robot)
+iex> configurations = BB.Robot.Runtime.configurations(MyRobot.Robot)
 %{pan_joint: 0.0, tilt_joint: 0.0}
 
 iex> robot = MyRobot.Robot.robot()
-iex> {x, y, z} = Kinematics.link_position(robot, positions, :camera_link)
+iex> {x, y, z} = Kinematics.link_position(robot, configurations, :camera_link)
 ```
 
 The Runtime maintains joint positions based on sensor feedback. See [Commands and State Machine](05-commands.md) for how sensors update positions.

--- a/documentation/tutorials/05-commands.md
+++ b/documentation/tutorials/05-commands.md
@@ -151,11 +151,11 @@ defmodule MyMoveJointCommand do
     joint = Map.fetch!(goal, :joint)
     position = Map.fetch!(goal, :position)
 
-    # Update joint position
-    :ok = RobotState.set_joint_position(context.robot_state, joint, position)
+    # Update joint configuration
+    :ok = RobotState.set_configuration(context.robot_state, joint, position)
 
-    # Get the new position and store result
-    new_position = RobotState.get_joint_position(context.robot_state, joint)
+    # Get the new configuration and store result
+    {:ok, new_position} = RobotState.get_configuration(context.robot_state, joint)
     {:stop, :normal, %{state | result: {:ok, %{joint: joint, position: new_position}}}}
   end
 
@@ -249,7 +249,7 @@ end
 
 ## State vs Physical Movement
 
-**Important:** Calling `RobotState.set_joint_position/3` only updates Beam Bots' internal representation of where joints are. It does **not** move physical hardware.
+**Important:** Calling `RobotState.set_configuration/3` only updates Beam Bots' internal representation of where joints are. It does **not** move physical hardware.
 
 To actually move a robot, you need:
 
@@ -436,9 +436,9 @@ defmodule SimpleArm do
         |> Enum.into(%{})
         |> Map.take([:shoulder, :elbow])
 
-      :ok = RobotState.set_positions(context.robot_state, positions)
+      :ok = RobotState.set_configurations(context.robot_state, positions)
 
-      new_positions = RobotState.get_all_positions(context.robot_state)
+      new_positions = RobotState.get_all_configurations(context.robot_state)
       {:stop, :normal, %{state | result: {:ok, new_positions}}}
     end
 

--- a/documentation/tutorials/09-inverse-kinematics.md
+++ b/documentation/tutorials/09-inverse-kinematics.md
@@ -55,7 +55,7 @@ robot = MyRobot.Robot.robot()
 target = {0.3, 0.2, 0.1}
 
 # Solve for joint angles
-case FABRIK.solve(robot, state, :end_effector_link, target) do
+case FABRIK.solve(robot, state, :base_link, :end_effector_link, target) do
   {:ok, positions, meta} ->
     IO.puts("Solved in #{meta.iterations} iterations")
     IO.puts("Distance to target: #{Float.round(meta.residual * 1000, 2)}mm")
@@ -68,6 +68,57 @@ end
 ```
 
 > **Note:** This example just solves for joint angles. To actually move the robot, see the [Motion Integration](#motion-integration) section below.
+
+## Scoping the chain
+
+Every solve takes **both ends** of the chain: a `source_link` and a
+`target_link`. There is no default for the source, which is deliberate.
+
+For a fixed-base arm the root is always the right source, so requiring it looks
+like ceremony. It isn't, because the root is precisely the *wrong* source for a
+robot whose base moves. A legged robot solving for a foot wants the chain from its
+*body* — a chain of nothing but revolute joints. Start that solve at the root
+instead and it drags the 6-DoF floating base into a problem that has no business
+containing one:
+
+```elixir
+# Aim the head by rotating the mast only. The base is not part of this problem,
+# so the chain contains a single revolute joint.
+BB.Motion.move_to(robot, :sensor_head, target,
+  source_link: :chassis,
+  solver: BB.IK.FABRIK
+)
+
+# Reach the target by driving *and* rotating the mast, in one solve. Genuinely a
+# different problem, and one that needs a solver which handles a planar joint.
+BB.Motion.move_to(robot, :sensor_head, target,
+  source_link: BB.Robot.root_link(robot),
+  solver: BB.IK.DLS
+)
+```
+
+A default that is right for one class of robot and quietly wrong for another is
+worse than no default, so when you do mean the whole tree, say so with
+`BB.Robot.root_link(robot)`. The extra words are the feature: the call now records
+which chain was intended, so a reader can tell whether root-to-target was a
+decision or an accident.
+
+`source_link` must be an ancestor of `target_link`. Asking for two links that
+merely share an ancestor — one gripper to the other — reports
+`BB.Error.Kinematics.NotAnAncestor`, and the message names the link you should
+have passed instead.
+
+### Multi-DoF joints
+
+A chain can contain `:planar` and `:floating` joints, whose configurations are a
+`BB.Math.Transform2D` and a `BB.Math.Transform` rather than an angle. Not every
+algorithm copes: a Jacobian-based solver like `BB.IK.DLS` is dimension-agnostic
+and needs no special case, while FABRIK repositions joints along a chain and has
+no meaningful interpretation for a 6-DoF base.
+
+That asymmetry is a property of the **chain**, not the robot. A legged robot whose
+body floats is a perfectly good FABRIK problem when each leg is solved from body
+to foot — which is exactly what `source_link` lets you ask for.
 
 ## Understanding the Result
 
@@ -93,7 +144,7 @@ defmodule IKDemo do
 
   def check_reachability(robot, state, target_link, target) do
     # Solve IK
-    case FABRIK.solve(robot, state, target_link, target) do
+    case FABRIK.solve(robot, state, BB.Robot.root_link(robot), target_link, target) do
       {:ok, positions, meta} ->
         # Verify with forward kinematics
         {x, y, z} = Kinematics.link_position(robot, positions, target_link)
@@ -127,7 +178,7 @@ IKDemo.check_reachability(robot, state, :tip, {0.3, 0.2, 0.0})
 Fine-tune the solver behaviour with options:
 
 ```elixir
-FABRIK.solve(robot, state, :end_effector, target,
+FABRIK.solve(robot, state, :base_link, :end_effector, target,
   max_iterations: 100,    # Default: 50
   tolerance: 0.001,       # Default: 1.0e-4 (0.1mm)
   respect_limits: true    # Default: true
@@ -148,7 +199,7 @@ Not all targets can be reached. The solver handles this gracefully:
 # Target way beyond the robot's reach
 target = {10.0, 0.0, 0.0}
 
-case FABRIK.solve(robot, state, :tip, target) do
+case FABRIK.solve(robot, state, :base_link, :tip, target) do
   {:error, :unreachable, meta} ->
     # The solver stretched the arm as far as possible
     # meta.positions contains the best-effort joint angles
@@ -206,7 +257,8 @@ The `BB.Motion` module bridges IK solving with actuator commands, making it easy
 alias BB.Motion
 
 # Move the end-effector to a target position (your robot is already running)
-case Motion.move_to(MyRobot.Robot, :tip, {0.3, 0.2, 0.1}, solver: BB.IK.FABRIK) do
+case Motion.move_to(MyRobot.Robot, :tip, {0.3, 0.2, 0.1},
+       source_link: :base_link, solver: BB.IK.FABRIK) do
   {:ok, meta} ->
     IO.puts("Moved in #{meta.iterations} iterations")
 
@@ -247,7 +299,8 @@ targets = %{
   right_foot: {-0.1, 0.0, 0.0}
 }
 
-case Motion.move_to_multi(MyRobot.Robot, targets, solver: BB.IK.FABRIK) do
+case Motion.move_to_multi(MyRobot.Robot, targets,
+       source_link: :base_link, solver: BB.IK.FABRIK) do
   {:ok, results} ->
     Enum.each(results, fn {link, {:ok, _pos, meta}} ->
       IO.puts("#{link}: #{meta.iterations} iterations")
@@ -297,7 +350,8 @@ defmodule MyRobot.Commands.Reach do
 
   @impl true
   def handle_command(%{target: target}, context) do
-    case BB.Motion.move_to(context, :gripper, target, solver: BB.IK.FABRIK) do
+    case BB.Motion.move_to(context, :gripper, target,
+           source_link: :base_link, solver: BB.IK.FABRIK) do
       {:ok, meta} ->
         {:ok, %{residual: meta.residual, iterations: meta.iterations}}
 
@@ -332,8 +386,11 @@ The solver will clamp joint values to these limits, which may prevent reaching s
 To see the unconstrained solution:
 
 ```elixir
-{:ok, unconstrained, _} = FABRIK.solve(robot, state, :tip, target, respect_limits: false)
-{:ok, constrained, _} = FABRIK.solve(robot, state, :tip, target, respect_limits: true)
+{:ok, unconstrained, _} =
+  FABRIK.solve(robot, state, :base_link, :tip, target, respect_limits: false)
+
+{:ok, constrained, _} =
+  FABRIK.solve(robot, state, :base_link, :tip, target, respect_limits: true)
 
 # Compare the solutions
 IO.inspect(unconstrained, label: "Without limits")

--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -843,13 +843,13 @@ defmodule BB.Actuator do
 
   defp actuator_path!(robot, name) when is_atom(name) do
     case Robot.actuator_path(robot.robot(), name) do
-      nil ->
+      {:ok, path} ->
+        path
+
+      {:error, _} ->
         raise ArgumentError,
               "#{inspect(robot)} has no actuator named #{inspect(name)}. " <>
                 "Known actuators: #{inspect(Map.keys(robot.robot().actuators))}"
-
-      path ->
-        path
     end
   end
 

--- a/lib/bb/actuator/server.ex
+++ b/lib/bb/actuator/server.ex
@@ -168,8 +168,10 @@ defmodule BB.Actuator.Server do
     actuator_name = List.last(path)
     robot = robot_module.robot()
 
-    case Map.get(robot.actuators, actuator_name) do
-      %{joint: joint_name} -> {Robot.get_joint(robot, joint_name), joint_name}
+    with %{joint: joint_name} <- Map.get(robot.actuators, actuator_name),
+         {:ok, joint} <- Robot.get_joint(robot, joint_name) do
+      {joint, joint_name}
+    else
       _ -> {nil, nil}
     end
   end

--- a/lib/bb/command/move_to.ex
+++ b/lib/bb/command/move_to.ex
@@ -18,12 +18,14 @@ defmodule BB.Command.MoveTo do
   Required:
   - `target` - Target position as `BB.Vec3.t()` in metres
   - `target_link` - Name of the link to move (end-effector)
+  - `source_link` - Name of the link the chain starts at
   - `solver` - Module implementing `BB.IK.Solver` behaviour
 
   ### Multi-Target Mode
 
   Required:
   - `targets` - Map of link names to target positions: `%{link: BB.Vec3.t()}`
+  - `source_link` - Name of the link the chain starts at
   - `solver` - Module implementing `BB.IK.Solver` behaviour
 
   ### Optional (both modes)
@@ -42,6 +44,7 @@ defmodule BB.Command.MoveTo do
       {:ok, cmd} = MyRobot.move_to(%{
         target: Vec3.new(0.3, 0.2, 0.1),
         target_link: :gripper,
+        source_link: :base_link,
         solver: BB.IK.FABRIK
       })
       {:ok, meta} = BB.Command.await(cmd)
@@ -53,6 +56,7 @@ defmodule BB.Command.MoveTo do
           left_foot: Vec3.new(0.1, 0.0, 0.0),
           right_foot: Vec3.new(-0.1, 0.0, 0.0)
         },
+        source_link: :body,
         solver: BB.IK.FABRIK
       })
       {:ok, results} = BB.Command.await(cmd)
@@ -116,8 +120,9 @@ defmodule BB.Command.MoveTo do
   defp handle_single_target(goal, context) do
     with {:ok, target} <- fetch_required(goal, :target),
          {:ok, target_link} <- fetch_required(goal, :target_link),
-         {:ok, solver} <- fetch_required(goal, :solver) do
-      opts = build_opts(goal, solver)
+         {:ok, solver} <- fetch_required(goal, :solver),
+         {:ok, source_link} <- fetch_required(goal, :source_link) do
+      opts = build_opts(goal, source_link, solver)
       target = normalize_target(target)
 
       case Motion.move_to(context, target_link, target, opts) do
@@ -132,8 +137,9 @@ defmodule BB.Command.MoveTo do
 
   defp handle_multi_target(goal, context) do
     with {:ok, targets} <- fetch_required(goal, :targets),
-         {:ok, solver} <- fetch_required(goal, :solver) do
-      opts = build_opts(goal, solver)
+         {:ok, solver} <- fetch_required(goal, :solver),
+         {:ok, source_link} <- fetch_required(goal, :source_link) do
+      opts = build_opts(goal, source_link, solver)
 
       case Motion.move_to_multi(context, targets, opts) do
         {:ok, results} ->
@@ -160,9 +166,10 @@ defmodule BB.Command.MoveTo do
     end
   end
 
-  defp build_opts(goal, solver) do
+  defp build_opts(goal, source_link, solver) do
     [
       solver: solver,
+      source_link: source_link,
       max_iterations: Map.get(goal, :max_iterations),
       tolerance: Map.get(goal, :tolerance),
       respect_limits: Map.get(goal, :respect_limits),

--- a/lib/bb/dsl.ex
+++ b/lib/bb/dsl.ex
@@ -503,7 +503,13 @@ defmodule BB.Dsl do
         %{
           @axis
           | describe: """
-            The joint axis specified in the joint frame. This is the axis of rotation for revolute joints, the axis of translation for prismatic joints, and the surface normal for planar joints. The axis is specified in the joint frame of reference. Fixed and floating joints do not use the axis field
+            The joint axis specified in the joint frame.
+
+            What it means depends on the joint type:
+
+            - `:revolute` and `:continuous` rotate about it; `:prismatic` translates along it. Optional for all three, defaulting to Z.
+            - `:planar` uses it as the **surface normal** of the plane the joint moves in, so it is **required** — an empty `axis` block gives the horizontal plane a ground vehicle wants.
+            - `:fixed` and `:floating` do not use it, and providing one is an error. A floating joint has all six degrees of freedom and no distinguished direction, so there would be nothing for an axis to describe.
             """
         }
       ],
@@ -522,7 +528,13 @@ defmodule BB.Dsl do
       ],
       type: [
         type: {:in, [:revolute, :continuous, :prismatic, :fixed, :floating, :planar]},
-        doc: "Specifies the type of joint"
+        doc: """
+        Specifies the type of joint, which determines its degrees of freedom:
+        `:fixed` has none, `:revolute`, `:continuous` and `:prismatic` have one,
+        `:planar` has three (two in-plane translations and a rotation about the
+        plane normal), and `:floating` has all six. See `BB.Robot.State` for the
+        configuration shape each type carries.
+        """
       ]
     ]
   }

--- a/lib/bb/dsl/robot_transformer.ex
+++ b/lib/bb/dsl/robot_transformer.ex
@@ -66,8 +66,8 @@ defmodule BB.Dsl.RobotTransformer do
          ## Examples
 
              robot = #{unquote(module)}.robot()
-             link = BB.Robot.get_link(robot, :base_link)
-             joint = BB.Robot.get_joint(robot, :shoulder)
+             {:ok, link} = BB.Robot.get_link(robot, :base_link)
+             {:ok, joint} = BB.Robot.get_joint(robot, :shoulder)
 
          """
          @spec robot() :: BB.Robot.t()

--- a/lib/bb/dsl/topology_transformer.ex
+++ b/lib/bb/dsl/topology_transformer.ex
@@ -80,6 +80,25 @@ defmodule BB.Dsl.TopologyTransformer do
      )}
   end
 
+  defp recursive_transform(joint, dsl, path)
+       when is_struct(joint, Joint) and is_nil(joint.axis) and joint.type == :planar do
+    {:error,
+     DslError.exception(
+       module: Transformer.get_persisted(dsl, :module),
+       path: to_error_path([joint | [:joint | path]]),
+       message: """
+       An axis must be present for planar joints
+
+       A planar joint's axis is the surface normal of the plane it moves in, so
+       without one there is no plane to move in. The default axis points along Z,
+       so an empty `axis` block gives the horizontal plane a ground vehicle wants:
+
+           axis do
+           end
+       """
+     )}
+  end
+
   defp recursive_transform(joint, dsl, path) when is_struct(joint, Joint) do
     inner_path = [joint | [:joint | path]]
 
@@ -143,8 +162,25 @@ defmodule BB.Dsl.TopologyTransformer do
      DslError.exception(
        module: Transformer.get_persisted(dsl, :module),
        path: to_error_path([:axis | path]),
-       module: """
+       message: """
        Cannot set an axis when parent joint is fixed.
+       """
+     )}
+  end
+
+  defp recursive_transform(axis, dsl, [parent | _] = path)
+       when is_struct(axis, Axis) and parent.type == :floating do
+    {:error,
+     DslError.exception(
+       module: Transformer.get_persisted(dsl, :module),
+       path: to_error_path([:axis | path]),
+       message: """
+       Cannot set an axis when parent joint is floating.
+
+       A floating joint has all six degrees of freedom and no distinguished
+       direction, so there is nothing for an axis to describe. If you meant to
+       constrain the joint to a plane, use `type :planar` — there the axis is the
+       plane's surface normal.
        """
      )}
   end

--- a/lib/bb/error/kinematics/no_parent_joint.ex
+++ b/lib/bb/error/kinematics/no_parent_joint.ex
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Kinematics.NoParentJoint do
+  @moduledoc """
+  A link has no parent joint because it is the root of the kinematic tree.
+
+  Distinct from `BB.Error.Kinematics.UnknownLink` on purpose. The root link
+  having no parent joint is a true structural fact, not a typo, so a caller
+  walking up the tree gets a termination signal it can match on rather than
+  being told its perfectly valid root link doesn't exist:
+
+      defp ancestors(robot, link, acc) do
+        case BB.Robot.parent_joint(robot, link) do
+          {:ok, joint} -> ancestors(robot, joint.parent_link, [joint | acc])
+          {:error, %NoParentJoint{}} -> {:ok, acc}
+          {:error, reason} -> {:error, reason}
+        end
+      end
+  """
+  use BB.Error,
+    class: :kinematics,
+    fields: [:link]
+
+  @type t :: %__MODULE__{link: atom()}
+
+  defimpl BB.Error.Severity do
+    def severity(_), do: :error
+  end
+
+  def message(%{link: link}) do
+    "#{inspect(link)} has no parent joint; it is the root of the kinematic tree"
+  end
+end

--- a/lib/bb/error/kinematics/not_an_ancestor.ex
+++ b/lib/bb/error/kinematics/not_an_ancestor.ex
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Kinematics.NotAnAncestor do
+  @moduledoc """
+  A source link does not sit above a target link in the kinematic tree.
+
+  Returned by `BB.Robot.path_between/3`, which is restricted to chains that
+  descend from the source to the target.
+
+  `common_ancestor` is always populated, which turns the message from a
+  complaint into an instruction: it names the link the caller should have
+  passed as the source. There is no "disconnected" case to represent —
+  `BB.Dsl.TopologyTransformer` rejects any topology without exactly one root
+  link, and the DSL's nesting makes cycles structurally impossible, so any two
+  links in a robot share at least the root as a common ancestor.
+  """
+  use BB.Error,
+    class: :kinematics,
+    fields: [:source_link, :target_link, :common_ancestor]
+
+  @type t :: %__MODULE__{
+          source_link: atom(),
+          target_link: atom(),
+          common_ancestor: atom()
+        }
+
+  defimpl BB.Error.Severity do
+    def severity(_), do: :error
+  end
+
+  def message(%{source_link: source, target_link: target, common_ancestor: ancestor}) do
+    "#{inspect(source)} is not an ancestor of #{inspect(target)}; " <>
+      "their nearest common ancestor is #{inspect(ancestor)}"
+  end
+end

--- a/lib/bb/error/kinematics/unknown_actuator.ex
+++ b/lib/bb/error/kinematics/unknown_actuator.ex
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Kinematics.UnknownActuator do
+  @moduledoc """
+  Actuator not found in robot topology.
+
+  Returned when a lookup names an actuator the robot does not have.
+  """
+  use BB.Error,
+    class: :kinematics,
+    fields: [:actuator, :robot]
+
+  @type t :: %__MODULE__{
+          actuator: atom(),
+          robot: atom() | nil
+        }
+
+  defimpl BB.Error.Severity do
+    def severity(_), do: :error
+  end
+
+  def message(%{actuator: actuator, robot: robot}) do
+    robot_str = if robot, do: " in #{inspect(robot)}", else: ""
+    "Unknown actuator: #{inspect(actuator)} not found#{robot_str}"
+  end
+end

--- a/lib/bb/error/kinematics/unknown_joint.ex
+++ b/lib/bb/error/kinematics/unknown_joint.ex
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.Kinematics.UnknownJoint do
+  @moduledoc """
+  Joint not found in robot topology.
+
+  Returned when a lookup names a joint the robot does not have.
+  """
+  use BB.Error,
+    class: :kinematics,
+    fields: [:joint, :robot]
+
+  @type t :: %__MODULE__{
+          joint: atom(),
+          robot: atom() | nil
+        }
+
+  defimpl BB.Error.Severity do
+    def severity(_), do: :error
+  end
+
+  def message(%{joint: joint, robot: robot}) do
+    robot_str = if robot, do: " in #{inspect(robot)}", else: ""
+    "Unknown joint: #{inspect(joint)} not found#{robot_str}"
+  end
+end

--- a/lib/bb/error/kinematics/unknown_link.ex
+++ b/lib/bb/error/kinematics/unknown_link.ex
@@ -4,17 +4,24 @@
 
 defmodule BB.Error.Kinematics.UnknownLink do
   @moduledoc """
-  Target link not found in robot topology.
+  Link not found in robot topology.
 
-  Raised when attempting to solve inverse kinematics for a link
-  that does not exist in the robot's kinematic structure.
+  Returned when a lookup names a link the robot does not have.
+
+  `:role` says which parameter was at fault, so a lookup taking both ends of a
+  chain — `BB.Robot.path_between/3` — can report an unknown source as a source
+  rather than misattributing it to the target. It is `nil` for lookups that take
+  only one link.
   """
   use BB.Error,
     class: :kinematics,
-    fields: [:target_link, :robot]
+    fields: [:link, :role, :robot]
+
+  @type role :: :source | :target
 
   @type t :: %__MODULE__{
-          target_link: atom(),
+          link: atom(),
+          role: role() | nil,
           robot: atom() | nil
         }
 
@@ -22,8 +29,9 @@ defmodule BB.Error.Kinematics.UnknownLink do
     def severity(_), do: :error
   end
 
-  def message(%{target_link: link, robot: robot}) do
+  def message(%{link: link, role: role, robot: robot}) do
+    role_str = if role, do: "#{role} link", else: "link"
     robot_str = if robot, do: " in #{inspect(robot)}", else: ""
-    "Unknown link: #{inspect(link)} not found#{robot_str}"
+    "Unknown #{role_str}: #{inspect(link)} not found#{robot_str}"
   end
 end

--- a/lib/bb/ik/solver.ex
+++ b/lib/bb/ik/solver.ex
@@ -48,14 +48,34 @@ defmodule BB.IK.Solver do
 
   Solvers return structured errors from `BB.Error.Kinematics`:
 
-  - `%BB.Error.Kinematics.UnknownLink{}` - Target link not found in robot topology
+  - `%BB.Error.Kinematics.UnknownLink{}` - Source or target link not found in robot
+    topology; `:role` says which
+  - `%BB.Error.Kinematics.NotAnAncestor{}` - Source link does not sit above the
+    target link, carrying their nearest common ancestor
   - `%BB.Error.Kinematics.NoDofs{}` - Chain has no movable joints
   - `%BB.Error.Kinematics.Unreachable{}` - Target outside workspace
   - `%BB.Error.Kinematics.NoSolution{}` - Solver failed to converge
+
+  ## Multi-DoF joints
+
+  A chain may contain `:planar` and `:floating` joints, whose configurations are a
+  `BB.Math.Transform2D` and a `BB.Math.Transform` rather than a float — see
+  `BB.Robot.State`. Jacobian width is then the sum of degrees of freedom along the
+  chain, and `BB.Robot.Kinematics.jacobian_columns/2` maps each column back to its
+  joint and degree of freedom.
+
+  Not every algorithm can handle this. A Jacobian-based solver is
+  dimension-agnostic and needs no special case; a heuristic that repositions
+  joints along a chain has no meaningful interpretation for a 6-DoF base. A solver
+  that cannot should say so clearly rather than returning a wrong answer — and
+  since `source_link` lets the caller scope the chain, a floating-base robot is
+  still solvable by such a solver as long as the chain asked for excludes the
+  floating joint.
   """
 
   alias BB.Error.Kinematics.NoDofs
   alias BB.Error.Kinematics.NoSolution
+  alias BB.Error.Kinematics.NotAnAncestor
   alias BB.Error.Kinematics.UnknownLink
   alias BB.Error.Kinematics.Unreachable
   alias BB.Math.Quaternion
@@ -106,7 +126,11 @@ defmodule BB.IK.Solver do
         }
 
   @type kinematics_error ::
-          UnknownLink.t() | NoDofs.t() | Unreachable.t() | NoSolution.t()
+          UnknownLink.t()
+          | NotAnAncestor.t()
+          | NoDofs.t()
+          | Unreachable.t()
+          | NoSolution.t()
 
   @type solve_result ::
           {:ok, positions(), meta()}
@@ -118,21 +142,42 @@ defmodule BB.IK.Solver do
   ## Parameters
 
   - `robot` - The BB.Robot struct containing topology and joint information
-  - `state_or_positions` - Either a BB.Robot.State or a map of joint positions
+  - `state_or_configurations` - Either a BB.Robot.State or a map of joint configurations
+  - `source_link` - The link the chain starts at; must be an ancestor of `target_link`
   - `target_link` - The name of the link to position (end-effector)
   - `target` - Target position `{x, y, z}` or 4x4 pose transform
   - `opts` - Solver options
 
   ## Returns
 
-  - `{:ok, positions, meta}` - Successfully solved; positions map and metadata
+  - `{:ok, configurations, meta}` - Successfully solved; configurations map and metadata
   - `{:error, error}` - Failed to solve; error struct contains all metadata
 
   Error structs include `:positions` with best-effort joint values when applicable.
+
+  ## Why `source_link` has no default
+
+  Defaulting it to the root is right for a fixed-base arm and precisely wrong for
+  a robot whose base floats, where it silently drags a 6-DoF joint into a problem
+  that has no business containing one. A default that is correct for one class of
+  robot and quietly wrong for another is the footgun this parameter exists to
+  remove, so every solve states its own scope:
+
+      # The chain contains only revolute joints, so the floating base is simply
+      # not part of the problem.
+      solver.solve(robot, state, :body, :front_left_foot, target, opts)
+
+      # The whole tree, said out loud.
+      solver.solve(robot, state, BB.Robot.root_link(robot), :gripper, target, opts)
+
+  Derive the chain with `BB.Robot.path_between/3`, which reports an unknown
+  source, an unknown target, and a source that isn't above the target as three
+  distinct errors.
   """
   @callback solve(
               robot :: Robot.t(),
-              state_or_positions :: Robot.State.t() | positions(),
+              state_or_configurations :: Robot.State.t() | positions(),
+              source_link :: atom(),
               target_link :: atom(),
               target :: target(),
               opts :: opts()

--- a/lib/bb/math/transform2d.ex
+++ b/lib/bb/math/transform2d.ex
@@ -135,7 +135,7 @@ defmodule BB.Math.Transform2D do
   @spec to_transform(t(), Vec3.t()) :: Transform.t()
   def to_transform(%__MODULE__{} = t, %Vec3{} = normal) do
     n = Vec3.normalise(normal)
-    {u, v} = plane_basis(n)
+    {u, v} = basis(n)
 
     offset = Vec3.add(Vec3.scale(u, t.x), Vec3.scale(v, t.y))
 
@@ -144,11 +144,31 @@ defmodule BB.Math.Transform2D do
     |> Transform.compose(Transform.from_axis_angle(n, t.theta))
   end
 
-  # `{u, v, n}` is right-handed with `u × v == n`. The seed is whichever cardinal
-  # axis is least aligned with the normal, which keeps the cross product
-  # well-conditioned and makes the canonical `{0, 0, 1}` normal reduce to the XY
-  # plane with `u == x̂` and `v == ŷ`.
-  defp plane_basis(%Vec3{} = n) do
+  @doc """
+  The two in-plane axes for a given plane normal.
+
+  `{u, v, normal}` is right-handed with `u × v == normal`, `u` is the direction
+  `x` measures along and `v` the direction `y` measures along. The canonical
+  `{0, 0, 1}` normal reduces to the XY plane with `u == x̂` and `v == ŷ`.
+
+  Exposed because a planar joint's Jacobian columns must be expressed in the same
+  basis `to_transform/2` lifts its configuration through, and the two disagreeing
+  would be a silently wrong derivative.
+
+  ## Examples
+
+      iex> {u, v} = BB.Math.Transform2D.plane_basis(BB.Math.Vec3.unit_z())
+      iex> {BB.Math.Vec3.to_list(u), BB.Math.Vec3.to_list(v)}
+      {[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]}
+  """
+  @spec plane_basis(Vec3.t()) :: {Vec3.t(), Vec3.t()}
+  def plane_basis(%Vec3{} = normal) do
+    basis(Vec3.normalise(normal))
+  end
+
+  # The seed is whichever cardinal axis is least aligned with the normal, which
+  # keeps the cross product well-conditioned.
+  defp basis(%Vec3{} = n) do
     seed =
       if abs(Vec3.z(n)) < 0.9 do
         Vec3.unit_z()

--- a/lib/bb/math/transform2d.ex
+++ b/lib/bb/math/transform2d.ex
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Math.Transform2D do
+  @moduledoc """
+  A rigid transform within a plane: translation and rotation about the plane's normal.
+
+  This is the configuration of a `:planar` joint — two translations in the plane
+  and one rotation about its normal, which is the joint's `axis`.
+
+  ## Not tensor-backed
+
+  Unlike `BB.Math.Transform`, this holds three plain floats rather than an Nx
+  tensor. `BB.Math.Transform` needs a matrix because it composes through
+  kinematic chains by matrix multiply; a planar configuration does not, because
+  it is lifted into a `BB.Math.Transform` by `to_transform/2` before it reaches
+  forward kinematics.
+
+  Storing `theta` as an angle rather than as the `sin`/`cos` entries of a
+  rotation matrix means there is no orthonormality to lose and no
+  renormalisation on read.
+
+  ## Conventions
+
+  - `x` and `y` are in metres, within the plane
+  - `theta` is in radians, right-handed about the plane's normal
+
+  ## Examples
+
+      iex> t = BB.Math.Transform2D.new(1.0, 2.0, :math.pi() / 2)
+      iex> {t.x, t.y}
+      {1.0, 2.0}
+  """
+
+  alias BB.Math.Transform
+  alias BB.Math.Vec3
+
+  defstruct [:x, :y, :theta]
+
+  @type t :: %__MODULE__{x: float(), y: float(), theta: float()}
+
+  @doc """
+  Create a planar transform from in-plane translation and rotation.
+
+  ## Examples
+
+      iex> BB.Math.Transform2D.new(1, 2, 0)
+      %BB.Math.Transform2D{x: 1.0, y: 2.0, theta: 0.0}
+  """
+  @spec new(number(), number(), number()) :: t()
+  def new(x, y, theta) when is_number(x) and is_number(y) and is_number(theta) do
+    %__MODULE__{x: x / 1, y: y / 1, theta: theta / 1}
+  end
+
+  @doc """
+  The identity planar transform.
+
+  ## Examples
+
+      iex> BB.Math.Transform2D.identity()
+      %BB.Math.Transform2D{x: 0.0, y: 0.0, theta: 0.0}
+  """
+  @spec identity() :: t()
+  def identity, do: %__MODULE__{x: 0.0, y: 0.0, theta: 0.0}
+
+  @doc """
+  Compose two planar transforms.
+
+  `compose(a, b)` returns the transform that applies `a` first, then `b`,
+  matching `BB.Math.Transform.compose/2`.
+
+  ## Examples
+
+      iex> a = BB.Math.Transform2D.new(1.0, 0.0, :math.pi() / 2)
+      iex> b = BB.Math.Transform2D.new(1.0, 0.0, 0.0)
+      iex> c = BB.Math.Transform2D.compose(a, b)
+      iex> {Float.round(c.x, 6), Float.round(c.y, 6)}
+      {1.0, 1.0}
+  """
+  @spec compose(t(), t()) :: t()
+  def compose(%__MODULE__{} = a, %__MODULE__{} = b) do
+    c = :math.cos(a.theta)
+    s = :math.sin(a.theta)
+
+    %__MODULE__{
+      x: a.x + c * b.x - s * b.y,
+      y: a.y + s * b.x + c * b.y,
+      theta: a.theta + b.theta
+    }
+  end
+
+  @doc """
+  Invert a planar transform.
+
+  ## Examples
+
+      iex> t = BB.Math.Transform2D.new(1.0, 2.0, 0.5)
+      iex> c = BB.Math.Transform2D.compose(t, BB.Math.Transform2D.inverse(t))
+      iex> {abs(c.x) < 1.0e-12, abs(c.y) < 1.0e-12, abs(c.theta) < 1.0e-12}
+      {true, true, true}
+  """
+  @spec inverse(t()) :: t()
+  def inverse(%__MODULE__{} = t) do
+    c = :math.cos(t.theta)
+    s = :math.sin(t.theta)
+
+    %__MODULE__{
+      x: -(c * t.x) - s * t.y,
+      y: s * t.x - c * t.y,
+      theta: -t.theta
+    }
+  end
+
+  @doc """
+  Lift into 3D, given the normal of the plane the transform is in.
+
+  The normal is the `:planar` joint's `axis`. It is taken as a parameter rather
+  than carried on the struct so that the joint remains the single source of
+  truth for its own plane — a configuration carrying a copy could disagree with
+  the joint that owns it.
+
+  The plane is spanned by two axes perpendicular to `normal`, with `x` along the
+  first and `y` along the second, and `theta` is a right-handed rotation about
+  `normal`. For the canonical `{0, 0, 1}` normal this reduces to the XY plane
+  with `theta` as yaw.
+
+  ## Examples
+
+      iex> t2d = BB.Math.Transform2D.new(1.0, 2.0, 0.0)
+      iex> t = BB.Math.Transform2D.to_transform(t2d, BB.Math.Vec3.unit_z())
+      iex> BB.Math.Transform.get_translation(t) |> BB.Math.Vec3.to_list()
+      [1.0, 2.0, 0.0]
+  """
+  @spec to_transform(t(), Vec3.t()) :: Transform.t()
+  def to_transform(%__MODULE__{} = t, %Vec3{} = normal) do
+    n = Vec3.normalise(normal)
+    {u, v} = plane_basis(n)
+
+    offset = Vec3.add(Vec3.scale(u, t.x), Vec3.scale(v, t.y))
+
+    offset
+    |> Transform.translation()
+    |> Transform.compose(Transform.from_axis_angle(n, t.theta))
+  end
+
+  # `{u, v, n}` is right-handed with `u × v == n`. The seed is whichever cardinal
+  # axis is least aligned with the normal, which keeps the cross product
+  # well-conditioned and makes the canonical `{0, 0, 1}` normal reduce to the XY
+  # plane with `u == x̂` and `v == ŷ`.
+  defp plane_basis(%Vec3{} = n) do
+    seed =
+      if abs(Vec3.z(n)) < 0.9 do
+        Vec3.unit_z()
+      else
+        Vec3.unit_y()
+      end
+
+    u = seed |> Vec3.cross(n) |> Vec3.normalise()
+    v = n |> Vec3.cross(u) |> Vec3.normalise()
+
+    {u, v}
+  end
+end

--- a/lib/bb/message/geometry/twist2d.ex
+++ b/lib/bb/message/geometry/twist2d.ex
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Geometry.Twist2D do
+  @moduledoc """
+  Linear and angular velocity within a plane.
+
+  The planar counterpart of `BB.Message.Geometry.Twist`, and the velocity of a
+  `:planar` joint. `vx`/`vy` are in the plane spanned by the joint's `axis`
+  normal, and `omega` is about that normal — the same basis
+  `BB.Math.Transform2D.to_transform/2` uses.
+
+  Using the 3D `Twist` with the out-of-plane components zeroed would let a
+  producer emit a physically impossible out-of-plane velocity that nothing would
+  reject.
+
+  ## Fields
+
+  - `vx` - In-plane linear velocity along the plane's first axis, in m/s
+  - `vy` - In-plane linear velocity along the plane's second axis, in m/s
+  - `omega` - Angular velocity about the plane's normal, in rad/s
+
+  ## Examples
+
+      alias BB.Message.Geometry.Twist2D
+
+      {:ok, msg} = Twist2D.new(:chassis, 0.5, 0.0, 0.1)
+  """
+
+  defstruct [:vx, :vy, :omega]
+
+  use BB.Message,
+    schema: [
+      vx: [type: :float, required: true, doc: "In-plane linear velocity in m/s"],
+      vy: [type: :float, required: true, doc: "In-plane linear velocity in m/s"],
+      omega: [type: :float, required: true, doc: "Angular velocity about the normal in rad/s"]
+    ]
+
+  @type t :: %__MODULE__{vx: float(), vy: float(), omega: float()}
+
+  @doc """
+  Create a new Twist2D message.
+
+  Returns `{:ok, %BB.Message{}}` with the twist as payload.
+
+  ## Examples
+
+      {:ok, msg} = Twist2D.new(:chassis, 0.5, 0.0, 0.1)
+  """
+  @spec new(atom(), number(), number(), number()) :: {:ok, BB.Message.t()} | {:error, term()}
+  def new(frame_id, vx, vy, omega) when is_number(vx) and is_number(vy) and is_number(omega) do
+    new(frame_id, vx: vx / 1, vy: vy / 1, omega: omega / 1)
+  end
+end

--- a/lib/bb/message/geometry/wrench2d.ex
+++ b/lib/bb/message/geometry/wrench2d.ex
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Geometry.Wrench2D do
+  @moduledoc """
+  Force and torque within a plane.
+
+  The planar counterpart of `BB.Message.Geometry.Wrench`, and the effort of a
+  `:planar` joint. `fx`/`fy` are in the plane spanned by the joint's `axis`
+  normal, and `tau` is about that normal — the same basis
+  `BB.Math.Transform2D.to_transform/2` uses.
+
+  Using the 3D `Wrench` with the out-of-plane components zeroed would let a
+  producer emit a physically impossible out-of-plane force that nothing would
+  reject.
+
+  ## Fields
+
+  - `fx` - In-plane force along the plane's first axis, in Newtons
+  - `fy` - In-plane force along the plane's second axis, in Newtons
+  - `tau` - Torque about the plane's normal, in Newton-metres
+
+  ## Examples
+
+      alias BB.Message.Geometry.Wrench2D
+
+      {:ok, msg} = Wrench2D.new(:chassis, 12.0, 0.0, 0.4)
+  """
+
+  defstruct [:fx, :fy, :tau]
+
+  use BB.Message,
+    schema: [
+      fx: [type: :float, required: true, doc: "In-plane force in Newtons"],
+      fy: [type: :float, required: true, doc: "In-plane force in Newtons"],
+      tau: [type: :float, required: true, doc: "Torque about the normal in Newton-metres"]
+    ]
+
+  @type t :: %__MODULE__{fx: float(), fy: float(), tau: float()}
+
+  @doc """
+  Create a new Wrench2D message.
+
+  Returns `{:ok, %BB.Message{}}` with the wrench as payload.
+
+  ## Examples
+
+      {:ok, msg} = Wrench2D.new(:chassis, 12.0, 0.0, 0.4)
+  """
+  @spec new(atom(), number(), number(), number()) :: {:ok, BB.Message.t()} | {:error, term()}
+  def new(frame_id, fx, fy, tau) when is_number(fx) and is_number(fy) and is_number(tau) do
+    new(frame_id, fx: fx / 1, fy: fy / 1, tau: tau / 1)
+  end
+end

--- a/lib/bb/message/option.ex
+++ b/lib/bb/message/option.ex
@@ -24,7 +24,12 @@ defmodule BB.Message.Option do
   alias BB.Math.Covariance6
   alias BB.Math.Quaternion
   alias BB.Math.Transform
+  alias BB.Math.Transform2D
   alias BB.Math.Vec3
+  alias BB.Message.Geometry.Twist
+  alias BB.Message.Geometry.Twist2D
+  alias BB.Message.Geometry.Wrench
+  alias BB.Message.Geometry.Wrench2D
 
   @doc """
   Returns a Spark.Options type for validating `BB.Vec3.t()`.
@@ -156,4 +161,126 @@ defmodule BB.Message.Option do
   def validate_covariance6(value, _opts) do
     {:error, "expected BB.Math.Covariance6.t(), got: #{inspect(value)}"}
   end
+
+  @doc """
+  Returns a Spark.Options type for a list of joint configurations.
+
+  A joint's configuration is shaped to its type, so the list is heterogeneous: a
+  float for single-DoF joints, a `BB.Math.Transform2D` for `:planar` and a
+  `BB.Math.Transform` for `:floating`.
+
+  This checks each element is one of those three, which is as much as a message
+  can check — matching a *particular* joint's type needs the robot, which the
+  message does not carry. `BB.Robot.State.set_configuration/3` is what rejects a
+  shape that doesn't match its joint.
+
+  ## Examples
+
+      iex> BB.Message.Option.configurations_type()
+      {:custom, BB.Message.Option, :validate_configurations, [[]]}
+  """
+  @spec configurations_type() :: {:custom, module(), atom(), list()}
+  def configurations_type, do: {:custom, __MODULE__, :validate_configurations, [[]]}
+
+  @doc """
+  Returns a Spark.Options type for a list of joint velocities.
+
+  As `configurations_type/0`, but the multi-DoF shapes are
+  `BB.Message.Geometry.Twist2D` and `BB.Message.Geometry.Twist`.
+
+  ## Examples
+
+      iex> BB.Message.Option.velocities_type()
+      {:custom, BB.Message.Option, :validate_velocities, [[]]}
+  """
+  @spec velocities_type() :: {:custom, module(), atom(), list()}
+  def velocities_type, do: {:custom, __MODULE__, :validate_velocities, [[]]}
+
+  @doc """
+  Returns a Spark.Options type for a list of joint efforts.
+
+  As `configurations_type/0`, but the multi-DoF shapes are
+  `BB.Message.Geometry.Wrench2D` and `BB.Message.Geometry.Wrench`.
+
+  ## Examples
+
+      iex> BB.Message.Option.efforts_type()
+      {:custom, BB.Message.Option, :validate_efforts, [[]]}
+  """
+  @spec efforts_type() :: {:custom, module(), atom(), list()}
+  def efforts_type, do: {:custom, __MODULE__, :validate_efforts, [[]]}
+
+  @doc """
+  Validates a list of joint configurations.
+
+  ## Examples
+
+      iex> BB.Message.Option.validate_configurations([0.5, BB.Math.Transform.identity()], [])
+      {:ok, [0.5, BB.Math.Transform.identity()]}
+
+      iex> BB.Message.Option.validate_configurations([:nope], [])
+      {:error,
+       "expected element 0 to be a float, BB.Math.Transform2D.t() or BB.Math.Transform.t(), got: :nope"}
+  """
+  @spec validate_configurations(term(), keyword()) :: {:ok, list()} | {:error, String.t()}
+  def validate_configurations(values, _opts) do
+    validate_joint_values(
+      values,
+      &configuration?/1,
+      "a float, BB.Math.Transform2D.t() or BB.Math.Transform.t()"
+    )
+  end
+
+  @doc "Validates a list of joint velocities."
+  @spec validate_velocities(term(), keyword()) :: {:ok, list()} | {:error, String.t()}
+  def validate_velocities(values, _opts) do
+    validate_joint_values(
+      values,
+      &velocity?/1,
+      "a float, BB.Message.Geometry.Twist2D.t() or BB.Message.Geometry.Twist.t()"
+    )
+  end
+
+  @doc "Validates a list of joint efforts."
+  @spec validate_efforts(term(), keyword()) :: {:ok, list()} | {:error, String.t()}
+  def validate_efforts(values, _opts) do
+    validate_joint_values(
+      values,
+      &effort?/1,
+      "a float, BB.Message.Geometry.Wrench2D.t() or BB.Message.Geometry.Wrench.t()"
+    )
+  end
+
+  # Naming the offending index matters: these lists run parallel to `names`, and
+  # "element 4 is wrong" is the difference between finding the bad joint and
+  # eyeballing a list of transforms.
+  defp validate_joint_values(values, acceptable?, expected) when is_list(values) do
+    case Enum.find_index(values, &(not acceptable?.(&1))) do
+      nil ->
+        {:ok, values}
+
+      index ->
+        {:error,
+         "expected element #{index} to be #{expected}, got: #{inspect(Enum.at(values, index))}"}
+    end
+  end
+
+  defp validate_joint_values(values, _acceptable?, _expected) do
+    {:error, "expected a list, got: #{inspect(values)}"}
+  end
+
+  defp configuration?(value) when is_float(value), do: true
+  defp configuration?(%Transform2D{}), do: true
+  defp configuration?(%Transform{}), do: true
+  defp configuration?(_), do: false
+
+  defp velocity?(value) when is_float(value), do: true
+  defp velocity?(%Twist2D{}), do: true
+  defp velocity?(%Twist{}), do: true
+  defp velocity?(_), do: false
+
+  defp effort?(value) when is_float(value), do: true
+  defp effort?(%Wrench2D{}), do: true
+  defp effort?(%Wrench{}), do: true
+  defp effort?(_), do: false
 end

--- a/lib/bb/message/sensor/joint_state.ex
+++ b/lib/bb/message/sensor/joint_state.ex
@@ -9,12 +9,37 @@ defmodule BB.Message.Sensor.JointState do
   ## Fields
 
   - `names` - List of joint names as atoms
-  - `positions` - Joint positions in radians (revolute) or metres (prismatic)
-  - `velocities` - Joint velocities in rad/s or m/s
-  - `efforts` - Joint efforts in Nm or N
+  - `positions` - Joint configurations
+  - `velocities` - Joint velocities
+  - `efforts` - Joint efforts
 
   All lists must have the same length. Missing values can be represented
   as empty lists.
+
+  ## Values are shaped to the joint's type
+
+  A joint with more than one degree of freedom has no single number to report, so
+  each list is heterogeneous and its elements line up with `names`:
+
+  | Joint type | `positions` | `velocities` | `efforts` |
+  |---|---|---|---|
+  | single-DoF | `float` | `float` | `float` |
+  | `:planar` | `BB.Math.Transform2D` | `BB.Message.Geometry.Twist2D` | `BB.Message.Geometry.Wrench2D` |
+  | `:floating` | `BB.Math.Transform` | `BB.Message.Geometry.Twist` | `BB.Message.Geometry.Wrench` |
+
+  Most consumers only ever see single-DoF joints, so in practice their handling is
+  unchanged — but a consumer that pattern matches on a float, or does arithmetic
+  on an element, should say which joint types it supports.
+
+  Splitting multi-DoF state into a separate message type was considered and
+  rejected: a robot's joint state would then arrive on two topics, and every
+  consumer wanting the whole configuration would have to subscribe to both and
+  correlate them by timestamp to reconstruct one instant. That is a permanent tax
+  on every consumer, levied to avoid changing one message.
+
+  All three lists changed together for the same reason. `velocities` and `efforts`
+  have precisely the same problem as `positions`, and breaking a widely-consumed
+  message twice is worse than breaking it once.
 
   ## Examples
 
@@ -26,22 +51,58 @@ defmodule BB.Message.Sensor.JointState do
         velocities: [0.1, 0.0],
         efforts: [0.5, 0.2]
       )
+
+      # A mobile base reports its whole pose in the same message as its mast
+      {:ok, msg} = JointState.new(:rover,
+        names: [:base, :mast],
+        positions: [BB.Math.Transform2D.new(12.4, -3.1, 1.57), 0.5]
+      )
   """
+
+  import BB.Message.Option
+
+  alias BB.Math.Transform
+  alias BB.Math.Transform2D
+  alias BB.Message.Geometry.Twist
+  alias BB.Message.Geometry.Twist2D
+  alias BB.Message.Geometry.Wrench
+  alias BB.Message.Geometry.Wrench2D
 
   defstruct [:names, :positions, :velocities, :efforts]
 
   use BB.Message,
     schema: [
       names: [type: {:list, :atom}, required: true, doc: "Joint names"],
-      positions: [type: {:list, :float}, default: [], doc: "Joint positions in radians or metres"],
-      velocities: [type: {:list, :float}, default: [], doc: "Joint velocities in rad/s or m/s"],
-      efforts: [type: {:list, :float}, default: [], doc: "Joint efforts in Nm or N"]
+      positions: [
+        type: configurations_type(),
+        default: [],
+        doc: "Joint configurations, shaped to each joint's type"
+      ],
+      velocities: [
+        type: velocities_type(),
+        default: [],
+        doc: "Joint velocities, shaped to each joint's type"
+      ],
+      efforts: [
+        type: efforts_type(),
+        default: [],
+        doc: "Joint efforts, shaped to each joint's type"
+      ]
     ]
+
+  @typedoc "A joint's configuration, shaped to its type."
+  @type configuration :: float() | Transform2D.t() | Transform.t()
+
+  @typedoc "A joint's velocity, shaped to its type."
+  @type velocity :: float() | Twist2D.t() | Twist.t()
+
+  @typedoc "A joint's effort, shaped to its type."
+  @type effort :: float() | Wrench2D.t() | Wrench.t()
 
   @type t :: %__MODULE__{
           names: [atom()],
-          positions: [float()],
-          velocities: [float()],
-          efforts: [float()]
+          positions: [configuration()],
+          velocities: [velocity()],
+          efforts: [effort()]
         }
 end

--- a/lib/bb/motion.ex
+++ b/lib/bb/motion.ex
@@ -412,7 +412,8 @@ defmodule BB.Motion do
   end
 
   defp send_position_to_actuator(robot_module, robot, actuator_name, position, :pubsub, opts) do
-    path = BB.Robot.actuator_path(robot, actuator_name)
+    # The name came from the joint's own actuator list, so the lookup cannot miss.
+    {:ok, path} = BB.Robot.actuator_path(robot, actuator_name)
     Actuator.set_position(robot_module, path, position, opts)
   end
 

--- a/lib/bb/motion.ex
+++ b/lib/bb/motion.ex
@@ -135,7 +135,7 @@ defmodule BB.Motion do
       fn ->
         case solver.solve(robot, robot_state, target_link, target, solver_opts) do
           {:ok, positions, meta} ->
-            RobotState.set_positions(robot_state, positions)
+            RobotState.set_configurations(robot_state, positions)
             send_positions_to_actuators(robot_module, robot, positions, delivery)
 
             result = {:ok, meta}
@@ -261,7 +261,7 @@ defmodule BB.Motion do
         {robot_module, robot, robot_state} = extract_context(robot_or_context)
 
         all_positions = merge_all_positions(results)
-        RobotState.set_positions(robot_state, all_positions)
+        RobotState.set_configurations(robot_state, all_positions)
         send_positions_to_actuators(robot_module, robot, all_positions, delivery)
 
         {:ok, results}
@@ -360,7 +360,7 @@ defmodule BB.Motion do
       [:bb, :motion, :send_positions],
       %{robot: robot.name, joint_count: map_size(positions), delivery: delivery},
       fn ->
-        RobotState.set_positions(robot_state, positions)
+        RobotState.set_configurations(robot_state, positions)
         send_positions_to_actuators(robot_module, robot, positions, delivery, actuator_opts)
         {:ok, %{}}
       end

--- a/lib/bb/motion.ex
+++ b/lib/bb/motion.ex
@@ -35,28 +35,32 @@ defmodule BB.Motion do
   ## Examples
 
       # Single target
-      case BB.Motion.move_to(MyRobot, :gripper, {0.3, 0.2, 0.1}, solver: BB.IK.FABRIK) do
+      case BB.Motion.move_to(MyRobot, :gripper, {0.3, 0.2, 0.1},
+             source_link: :base_link, solver: BB.IK.FABRIK) do
         {:ok, meta} -> IO.puts("Reached target in \#{meta.iterations} iterations")
         {:error, %{class: :kinematics} = error} -> IO.puts("Failed: \#{BB.Error.message(error)}")
       end
 
       # Multiple targets (for gait, coordinated motion)
       targets = %{left_foot: {0.1, 0.0, 0.0}, right_foot: {-0.1, 0.0, 0.0}}
-      case BB.Motion.move_to_multi(MyRobot, targets, solver: BB.IK.FABRIK) do
+      case BB.Motion.move_to_multi(MyRobot, targets,
+             source_link: :body, solver: BB.IK.FABRIK) do
         {:ok, results} -> IO.puts("All targets reached")
         {:error, failed_link, error, _results} -> IO.puts("Failed: \#{failed_link}")
       end
 
       # In a custom command handler
       def handle_command(%{target: target}, context) do
-        case BB.Motion.move_to(context, :gripper, target, solver: BB.IK.FABRIK) do
+        case BB.Motion.move_to(context, :gripper, target,
+               source_link: :base_link, solver: BB.IK.FABRIK) do
           {:ok, meta} -> {:ok, %{residual: meta.residual}}
           {:error, error} -> {:error, error}
         end
       end
 
       # Just solve without moving (for validation)
-      case BB.Motion.solve_only(MyRobot, :gripper, {0.3, 0.2, 0.1}, solver: BB.IK.FABRIK) do
+      case BB.Motion.solve_only(MyRobot, :gripper, {0.3, 0.2, 0.1},
+             source_link: :base_link, solver: BB.IK.FABRIK) do
         {:ok, positions, meta} -> IO.inspect(positions, label: "Would set")
         {:error, %BB.Error.Kinematics.Unreachable{}} -> IO.puts("Cannot reach target")
       end
@@ -99,6 +103,9 @@ defmodule BB.Motion do
 
   Required:
   - `:solver` - Module implementing `BB.IK.Solver` behaviour
+  - `:source_link` - The link the chain starts at. No default: the root is right
+    for a fixed-base arm and silently wrong for a robot whose base floats, so
+    pass `BB.Robot.root_link(robot)` when you do mean the whole tree
 
   Optional:
   - `:delivery` - How to send actuator commands: `:pubsub` (default), `:direct`, or `:sync`
@@ -113,9 +120,13 @@ defmodule BB.Motion do
 
   ## Examples
 
-      BB.Motion.move_to(MyRobot, :gripper, {0.3, 0.2, 0.1}, solver: BB.IK.FABRIK)
+      BB.Motion.move_to(MyRobot, :gripper, {0.3, 0.2, 0.1},
+        source_link: :base_link,
+        solver: BB.IK.FABRIK
+      )
 
       BB.Motion.move_to(context, :gripper, target,
+        source_link: :base_link,
         solver: BB.IK.FABRIK,
         delivery: :direct,
         max_iterations: 100
@@ -124,6 +135,7 @@ defmodule BB.Motion do
   @spec move_to(robot_or_context(), atom(), target(), keyword()) :: motion_result()
   def move_to(robot_or_context, target_link, target, opts) do
     solver = Keyword.fetch!(opts, :solver)
+    source_link = Keyword.fetch!(opts, :source_link)
     delivery = Keyword.get(opts, :delivery, :pubsub)
     solver_opts = extract_solver_opts(opts)
 
@@ -133,7 +145,7 @@ defmodule BB.Motion do
       [:bb, :motion, :move_to],
       %{robot: robot.name, target_link: target_link, solver: solver},
       fn ->
-        case solver.solve(robot, robot_state, target_link, target, solver_opts) do
+        case solver.solve(robot, robot_state, source_link, target_link, target, solver_opts) do
           {:ok, positions, meta} ->
             RobotState.set_configurations(robot_state, positions)
             send_positions_to_actuators(robot_module, robot, positions, delivery)
@@ -177,7 +189,8 @@ defmodule BB.Motion do
   ## Examples
 
       # Check if target is reachable
-      case BB.Motion.solve_only(MyRobot, :gripper, target, solver: BB.IK.FABRIK) do
+      case BB.Motion.solve_only(MyRobot, :gripper, target,
+             source_link: :base_link, solver: BB.IK.FABRIK) do
         {:ok, _positions, %{reached: true}} -> :reachable
         {:error, _} -> :unreachable
       end
@@ -185,6 +198,7 @@ defmodule BB.Motion do
   @spec solve_only(robot_or_context(), atom(), target(), keyword()) :: solve_result()
   def solve_only(robot_or_context, target_link, target, opts) do
     solver = Keyword.fetch!(opts, :solver)
+    source_link = Keyword.fetch!(opts, :source_link)
     solver_opts = extract_solver_opts(opts)
 
     {_robot_module, robot, robot_state} = extract_context(robot_or_context)
@@ -193,7 +207,7 @@ defmodule BB.Motion do
       [:bb, :motion, :solve],
       %{robot: robot.name, target_link: target_link, solver: solver},
       fn ->
-        case solver.solve(robot, robot_state, target_link, target, solver_opts) do
+        case solver.solve(robot, robot_state, source_link, target_link, target, solver_opts) do
           {:ok, _positions, meta} = result ->
             extra_meta = %{
               iterations: meta.iterations,
@@ -226,6 +240,9 @@ defmodule BB.Motion do
 
   Required:
   - `:solver` - Module implementing `BB.IK.Solver` behaviour
+  - `:source_link` - The link the chain starts at. No default: the root is right
+    for a fixed-base arm and silently wrong for a robot whose base floats, so
+    pass `BB.Robot.root_link(robot)` when you do mean the whole tree
 
   Optional:
   - `:delivery` - How to send actuator commands: `:pubsub` (default), `:direct`, or `:sync`
@@ -245,7 +262,8 @@ defmodule BB.Motion do
         right_foot: {-0.1, 0.0, 0.0}
       }
 
-      case BB.Motion.move_to_multi(MyRobot, targets, solver: BB.IK.FABRIK) do
+      case BB.Motion.move_to_multi(MyRobot, targets,
+             source_link: :body, solver: BB.IK.FABRIK) do
         {:ok, results} ->
           IO.puts("All targets reached")
 
@@ -290,7 +308,8 @@ defmodule BB.Motion do
 
       targets = %{left_foot: {0.1, 0.0, 0.0}, right_foot: {-0.1, 0.0, 0.0}}
 
-      case BB.Motion.solve_only_multi(MyRobot, targets, solver: BB.IK.FABRIK) do
+      case BB.Motion.solve_only_multi(MyRobot, targets,
+             source_link: :body, solver: BB.IK.FABRIK) do
         {:ok, results} ->
           Enum.each(results, fn {link, {:ok, _positions, meta}} ->
             IO.puts("\#{link}: residual=\#{meta.residual}")
@@ -303,13 +322,15 @@ defmodule BB.Motion do
   @spec solve_only_multi(robot_or_context(), targets(), keyword()) :: multi_solve_result()
   def solve_only_multi(robot_or_context, targets, opts) do
     solver = Keyword.fetch!(opts, :solver)
+    source_link = Keyword.fetch!(opts, :source_link)
     solver_opts = extract_solver_opts(opts)
 
     {_robot_module, robot, robot_state} = extract_context(robot_or_context)
 
     targets
     |> Task.async_stream(fn {target_link, target} ->
-      {target_link, solver.solve(robot, robot_state, target_link, target, solver_opts)}
+      {target_link,
+       solver.solve(robot, robot_state, source_link, target_link, target, solver_opts)}
     end)
     |> Enum.reduce_while({:ok, %{}}, fn
       {:ok, {link, {:ok, _, _} = result}}, {:ok, results} ->
@@ -381,7 +402,7 @@ defmodule BB.Motion do
 
   defp extract_solver_opts(opts) do
     opts
-    |> Keyword.drop([:solver, :delivery, :velocity, :duration, :command_id])
+    |> Keyword.drop([:solver, :source_link, :delivery, :velocity, :duration, :command_id])
     |> Keyword.reject(fn {_k, v} -> is_nil(v) end)
   end
 

--- a/lib/bb/robot.ex
+++ b/lib/bb/robot.ex
@@ -35,6 +35,11 @@ defmodule BB.Robot do
   - Angular velocity: rad/s
   """
 
+  alias BB.Error.Kinematics.NoParentJoint
+  alias BB.Error.Kinematics.NotAnAncestor
+  alias BB.Error.Kinematics.UnknownActuator
+  alias BB.Error.Kinematics.UnknownJoint
+  alias BB.Error.Kinematics.UnknownLink
   alias BB.Robot.{Joint, Link, Topology}
 
   defstruct [
@@ -83,53 +88,111 @@ defmodule BB.Robot do
         }
 
   @doc """
+  Get the link at the root of the kinematic tree.
+
+  Returns a bare atom rather than a result tuple: unlike every other lookup here
+  it cannot fail, because `BB.Dsl.TopologyTransformer` guarantees exactly one
+  root link exists.
+
+  Useful when a caller genuinely wants a whole-tree chain and has to say so —
+  `BB.Motion` requires `:source_link` with no default, precisely so that
+  root-to-target is recorded as a decision rather than assumed.
+
+      BB.Motion.move_to(robot, :gripper, target,
+        source_link: BB.Robot.root_link(robot),
+        solver: BB.IK.DLS
+      )
+  """
+  @spec root_link(t()) :: atom()
+  def root_link(%__MODULE__{root_link: root_link}), do: root_link
+
+  @doc """
   Get a link by name.
   """
-  @spec get_link(t(), atom()) :: Link.t() | nil
-  def get_link(%__MODULE__{links: links}, name) do
-    Map.get(links, name)
+  @spec get_link(t(), atom()) :: {:ok, Link.t()} | {:error, UnknownLink.t()}
+  def get_link(%__MODULE__{links: links, name: robot_name}, name) do
+    case Map.fetch(links, name) do
+      {:ok, link} -> {:ok, link}
+      :error -> {:error, UnknownLink.exception(link: name, robot: robot_name)}
+    end
   end
 
   @doc """
   Get a joint by name.
   """
-  @spec get_joint(t(), atom()) :: Joint.t() | nil
-  def get_joint(%__MODULE__{joints: joints}, name) do
-    Map.get(joints, name)
+  @spec get_joint(t(), atom()) :: {:ok, Joint.t()} | {:error, UnknownJoint.t()}
+  def get_joint(%__MODULE__{joints: joints, name: robot_name}, name) do
+    case Map.fetch(joints, name) do
+      {:ok, joint} -> {:ok, joint}
+      :error -> {:error, UnknownJoint.exception(joint: name, robot: robot_name)}
+    end
   end
 
   @doc """
-  Get the parent joint of a link (nil for root link).
+  Get the parent joint of a link.
+
+  The root link has no parent joint, which is reported as
+  `{:error, %BB.Error.Kinematics.NoParentJoint{}}` — a distinct type from
+  `UnknownLink` so a caller walking up the tree can match on it as a termination
+  signal rather than being told a valid root link doesn't exist.
   """
-  @spec parent_joint(t(), atom()) :: Joint.t() | nil
+  @spec parent_joint(t(), atom()) ::
+          {:ok, Joint.t()} | {:error, UnknownLink.t() | UnknownJoint.t() | NoParentJoint.t()}
   def parent_joint(%__MODULE__{} = robot, link_name) do
     case get_link(robot, link_name) do
-      %Link{parent_joint: nil} -> nil
-      %Link{parent_joint: joint_name} -> get_joint(robot, joint_name)
-      nil -> nil
+      {:ok, %Link{parent_joint: nil}} -> {:error, NoParentJoint.exception(link: link_name)}
+      {:ok, %Link{parent_joint: joint_name}} -> get_joint(robot, joint_name)
+      {:error, reason} -> {:error, reason}
     end
   end
 
   @doc """
   Get the child joints of a link.
-  """
-  @spec child_joints(t(), atom()) :: [Joint.t()]
-  def child_joints(%__MODULE__{} = robot, link_name) do
-    case get_link(robot, link_name) do
-      %Link{child_joints: joint_names} ->
-        Enum.map(joint_names, &get_joint(robot, &1))
 
-      nil ->
-        []
+  A link with no children returns `{:ok, []}`, which is distinct from naming a
+  link that doesn't exist.
+  """
+  @spec child_joints(t(), atom()) :: {:ok, [Joint.t()]} | {:error, UnknownLink.t()}
+  def child_joints(%__MODULE__{joints: joints} = robot, link_name) do
+    case get_link(robot, link_name) do
+      {:ok, %Link{child_joints: joint_names}} ->
+        {:ok, Enum.map(joint_names, &Map.fetch!(joints, &1))}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
   @doc """
   Get the path from root to a given link or joint.
+
+  Equivalent to `path_between/3` from the root link, and delegates to
+  `BB.Robot.Topology.path_to/2`.
   """
-  @spec path_to(t(), atom()) :: [atom()] | nil
-  def path_to(%__MODULE__{topology: topology}, name) do
-    Map.get(topology.paths, name)
+  @spec path_to(t(), atom()) :: {:ok, [atom()]} | {:error, UnknownLink.t()}
+  def path_to(%__MODULE__{topology: topology} = robot, name) do
+    topology |> Topology.path_to(name) |> attribute_to(robot)
+  end
+
+  @doc """
+  Get the path from a source link down to a target link.
+
+  Restricted to the case where `source_link` is an ancestor of `target_link`,
+  which is a prefix drop on the precomputed root-relative paths. The result
+  starts at `source_link` and ends at `target_link`, interleaving the joints and
+  links between them, so `path_to/2` is the special case of a source at the root.
+
+  A source that isn't above the target reports
+  `BB.Error.Kinematics.NotAnAncestor`, carrying the nearest common ancestor so
+  the message names the link the caller should have passed.
+
+      BB.Robot.path_between(robot, :chassis, :sensor_head)
+      #=> {:ok, [:chassis, :mast, :sensor_head]}
+  """
+  @spec path_between(t(), atom(), atom()) ::
+          {:ok, [atom()]} | {:error, UnknownLink.t() | NotAnAncestor.t()}
+  def path_between(%__MODULE__{topology: topology} = robot, source_link, target_link) do
+    topology |> Topology.path_between(source_link, target_link) |> attribute_to(robot)
   end
 
   @doc """
@@ -141,18 +204,16 @@ defmodule BB.Robot do
   actuator's `:bb` option, and therefore the topic its commands are published
   to — `[:actuator | actuator_path(robot, name)]`.
 
-  Returns `nil` if no actuator by that name exists.
-
       BB.Robot.actuator_path(robot, :pan_servo)
-      #=> [:base, :pan, :pan_servo]
+      #=> {:ok, [:base, :pan, :pan_servo]}
   """
-  @spec actuator_path(t(), atom()) :: [atom()] | nil
-  def actuator_path(%__MODULE__{actuators: actuators} = robot, name) do
-    with %{joint: joint_name} <- Map.get(actuators, name),
-         joint_path when is_list(joint_path) <- path_to(robot, joint_name) do
-      joint_path ++ [name]
+  @spec actuator_path(t(), atom()) :: {:ok, [atom()]} | {:error, UnknownActuator.t()}
+  def actuator_path(%__MODULE__{actuators: actuators, name: robot_name} = robot, name) do
+    with {:ok, %{joint: joint_name}} <- Map.fetch(actuators, name),
+         {:ok, joint_path} <- path_to(robot, joint_name) do
+      {:ok, joint_path ++ [name]}
     else
-      _ -> nil
+      _ -> {:error, UnknownActuator.exception(actuator: name, robot: robot_name)}
     end
   end
 
@@ -171,4 +232,12 @@ defmodule BB.Robot do
   def joints_in_order(%__MODULE__{topology: topology, joints: joints}) do
     Enum.map(topology.joint_order, &Map.fetch!(joints, &1))
   end
+
+  # `BB.Robot.Topology` has no robot name to put in its errors, so name them here
+  # rather than leaving the diagnostic weaker than the error type allows.
+  defp attribute_to({:error, %UnknownLink{} = error}, %__MODULE__{name: name}) do
+    {:error, %{error | robot: name}}
+  end
+
+  defp attribute_to(result, %__MODULE__{}), do: result
 end

--- a/lib/bb/robot/joint.ex
+++ b/lib/bb/robot/joint.ex
@@ -112,4 +112,24 @@ defmodule BB.Robot.Joint do
   @spec movable?(t()) :: boolean()
   def movable?(%__MODULE__{type: :fixed}), do: false
   def movable?(%__MODULE__{}), do: true
+
+  @doc """
+  How many degrees of freedom this joint has.
+
+  This is the number of Jacobian columns the joint contributes, and the size of
+  its configuration — see `BB.Robot.State` for the shape each type carries.
+
+  ## Examples
+
+      iex> BB.Robot.Joint.dof(%BB.Robot.Joint{type: :revolute})
+      1
+
+      iex> BB.Robot.Joint.dof(%BB.Robot.Joint{type: :floating})
+      6
+  """
+  @spec dof(t()) :: 0 | 1 | 3 | 6
+  def dof(%__MODULE__{type: :fixed}), do: 0
+  def dof(%__MODULE__{type: :planar}), do: 3
+  def dof(%__MODULE__{type: :floating}), do: 6
+  def dof(%__MODULE__{}), do: 1
 end

--- a/lib/bb/robot/kinematics.ex
+++ b/lib/bb/robot/kinematics.ex
@@ -67,13 +67,7 @@ defmodule BB.Robot.Kinematics do
   end
 
   def forward_kinematics(%Robot{} = robot, positions, target_link) when is_map(positions) do
-    path = Robot.path_to(robot, target_link)
-
-    if is_nil(path) do
-      raise ArgumentError, "Unknown link: #{inspect(target_link)}"
-    end
-
-    compute_chain_transform(robot, positions, path)
+    compute_chain_transform(robot, positions, path_to!(robot, target_link))
   end
 
   @doc """
@@ -99,7 +93,7 @@ defmodule BB.Robot.Kinematics do
 
     specs =
       Enum.map(link_order, fn link_name ->
-        link = Robot.get_link(robot, link_name)
+        {:ok, link} = Robot.get_link(robot, link_name)
         link_joint_spec(robot, positions, index_of, link_name, link.parent_joint)
       end)
 
@@ -161,13 +155,7 @@ defmodule BB.Robot.Kinematics do
 
   def position_jacobian(%Robot{} = robot, positions, target_link, joint_names)
       when is_map(positions) do
-    path = Robot.path_to(robot, target_link)
-
-    if is_nil(path) do
-      raise ArgumentError, "Unknown link: #{inspect(target_link)}"
-    end
-
-    chain_joints = Enum.filter(path, &Map.has_key?(robot.joints, &1))
+    chain_joints = chain_joints(robot, path_to!(robot, target_link))
     chain_jacobian(robot, positions, chain_joints, joint_names)
   end
 
@@ -191,13 +179,7 @@ defmodule BB.Robot.Kinematics do
   end
 
   def jacobian(%Robot{} = robot, positions, target_link, joint_names) when is_map(positions) do
-    path = Robot.path_to(robot, target_link)
-
-    if is_nil(path) do
-      raise ArgumentError, "Unknown link: #{inspect(target_link)}"
-    end
-
-    chain_joints = Enum.filter(path, &Map.has_key?(robot.joints, &1))
+    chain_joints = chain_joints(robot, path_to!(robot, target_link))
 
     position = chain_jacobian(robot, positions, chain_joints, joint_names)
     orientation = chain_orientation_jacobian(robot, positions, chain_joints, joint_names)
@@ -213,7 +195,7 @@ defmodule BB.Robot.Kinematics do
   """
   @spec compute_joint_transform(Robot.t(), %{atom() => float()}, atom()) :: Transform.t()
   def compute_joint_transform(%Robot{} = robot, positions, joint_name) do
-    joint = Robot.get_joint(robot, joint_name)
+    {:ok, joint} = Robot.get_joint(robot, joint_name)
     position = Map.get(positions, joint_name, 0.0)
 
     origin_transform = Transform.from_origin(joint.origin)
@@ -243,8 +225,22 @@ defmodule BB.Robot.Kinematics do
 
   defp tuple_to_vec3({x, y, z}), do: Vec3.new(x, y, z)
 
+  # These entry points raise rather than return a result tuple, which is the
+  # contract they have always had. Raising the structured error keeps the
+  # diagnosis in one place.
+  defp path_to!(robot, target_link) do
+    case Robot.path_to(robot, target_link) do
+      {:ok, path} -> path
+      {:error, error} -> raise error
+    end
+  end
+
+  defp chain_joints(%Robot{joints: joints}, path) do
+    Enum.filter(path, &Map.has_key?(joints, &1))
+  end
+
   defp compute_chain_transform(%Robot{} = robot, positions, path) do
-    case Enum.filter(path, &Map.has_key?(robot.joints, &1)) do
+    case chain_joints(robot, path) do
       [] ->
         Transform.identity()
 

--- a/lib/bb/robot/kinematics.ex
+++ b/lib/bb/robot/kinematics.ex
@@ -55,14 +55,14 @@ defmodule BB.Robot.Kinematics do
 
       robot = MyRobot.robot()
       {:ok, state} = BB.Robot.State.new(robot)
-      BB.Robot.State.set_joint_position(state, :shoulder, :math.pi() / 4)
+      BB.Robot.State.set_configuration(state, :shoulder, :math.pi() / 4)
 
       transform = BB.Robot.Kinematics.forward_kinematics(robot, state, :forearm)
       pos = BB.Math.Transform.get_translation(transform)
   """
   @spec forward_kinematics(Robot.t(), State.t() | %{atom() => float()}, atom()) :: Transform.t()
   def forward_kinematics(%Robot{} = robot, %State{} = state, target_link) do
-    positions = State.get_all_positions(state)
+    positions = State.get_all_configurations(state)
     forward_kinematics(robot, positions, target_link)
   end
 
@@ -83,7 +83,7 @@ defmodule BB.Robot.Kinematics do
   @spec all_link_transforms(Robot.t(), State.t() | %{atom() => float()}) ::
           %{atom() => Transform.t()}
   def all_link_transforms(%Robot{} = robot, %State{} = state) do
-    positions = State.get_all_positions(state)
+    positions = State.get_all_configurations(state)
     all_link_transforms(robot, positions)
   end
 
@@ -149,7 +149,7 @@ defmodule BB.Robot.Kinematics do
   @spec position_jacobian(Robot.t(), State.t() | %{atom() => float()}, atom(), [atom()]) ::
           Nx.Tensor.t()
   def position_jacobian(%Robot{} = robot, %State{} = state, target_link, joint_names) do
-    positions = State.get_all_positions(state)
+    positions = State.get_all_configurations(state)
     position_jacobian(robot, positions, target_link, joint_names)
   end
 
@@ -174,7 +174,7 @@ defmodule BB.Robot.Kinematics do
   """
   @spec jacobian(Robot.t(), State.t() | %{atom() => float()}, atom(), [atom()]) :: Nx.Tensor.t()
   def jacobian(%Robot{} = robot, %State{} = state, target_link, joint_names) do
-    positions = State.get_all_positions(state)
+    positions = State.get_all_configurations(state)
     jacobian(robot, positions, target_link, joint_names)
   end
 

--- a/lib/bb/robot/kinematics.ex
+++ b/lib/bb/robot/kinematics.ex
@@ -12,7 +12,7 @@ defmodule BB.Robot.Kinematics do
   ## Forward Kinematics
 
   Forward kinematics computes the position and orientation of any link
-  given the current joint positions:
+  given the current joint configurations:
 
       # Get the transform from base to end-effector
       transform = BB.Robot.Kinematics.forward_kinematics(
@@ -25,6 +25,19 @@ defmodule BB.Robot.Kinematics do
       pos = BB.Math.Transform.get_translation(transform)
       {BB.Math.Vec3.x(pos), BB.Math.Vec3.y(pos), BB.Math.Vec3.z(pos)}
 
+  ## Multi-DoF joints
+
+  A joint's configuration is shaped to its type: a bare float for single-DoF
+  joints, a `BB.Math.Transform2D` for `:planar`, a `BB.Math.Transform` for
+  `:floating`. See `BB.Robot.State` for the full table. A multi-DoF joint's
+  transform is used verbatim, so forward kinematics through a floating base is
+  bit-exact.
+
+  This makes **Jacobian width the sum of degrees of freedom along the chain**
+  rather than the number of joints in it — a floating joint contributes six
+  columns and a planar one three. `jacobian_columns/2` reports which joint and
+  degree of freedom each column belongs to.
+
   ## Conventions
 
   - All positions are in meters
@@ -34,10 +47,22 @@ defmodule BB.Robot.Kinematics do
   """
 
   alias BB.Math.Transform
+  alias BB.Math.Transform2D
   alias BB.Math.Vec3
   alias BB.Robot
+  alias BB.Robot.Joint
   alias BB.Robot.Kinematics.Defn
   alias BB.Robot.State
+
+  @typedoc """
+  A joint's configuration, shaped to its type.
+
+  See `BB.Robot.State` for the table of which shape belongs to which joint type.
+  """
+  @type configuration :: State.configuration()
+
+  @typedoc "A map of joint configurations, as `BB.Robot.State` returns."
+  @type configurations :: %{atom() => configuration()}
 
   @doc """
   Compute the forward kinematics transform from base to a target link.
@@ -60,7 +85,7 @@ defmodule BB.Robot.Kinematics do
       transform = BB.Robot.Kinematics.forward_kinematics(robot, state, :forearm)
       pos = BB.Math.Transform.get_translation(transform)
   """
-  @spec forward_kinematics(Robot.t(), State.t() | %{atom() => float()}, atom()) :: Transform.t()
+  @spec forward_kinematics(Robot.t(), State.t() | configurations(), atom()) :: Transform.t()
   def forward_kinematics(%Robot{} = robot, %State{} = state, target_link) do
     positions = State.get_all_configurations(state)
     forward_kinematics(robot, positions, target_link)
@@ -80,7 +105,7 @@ defmodule BB.Robot.Kinematics do
       transforms = BB.Robot.Kinematics.all_link_transforms(robot, state)
       end_effector_transform = transforms[:end_effector]
   """
-  @spec all_link_transforms(Robot.t(), State.t() | %{atom() => float()}) ::
+  @spec all_link_transforms(Robot.t(), State.t() | configurations()) ::
           %{atom() => Transform.t()}
   def all_link_transforms(%Robot{} = robot, %State{} = state) do
     positions = State.get_all_configurations(state)
@@ -105,6 +130,8 @@ defmodule BB.Robot.Kinematics do
         col(specs, :axis, :f64),
         col(specs, :revolute, :f64),
         col(specs, :prismatic, :f64),
+        specs |> Enum.map(& &1.stored) |> Nx.stack(),
+        Nx.broadcast(Nx.tensor(0.0, type: :f64), {length(specs), 6}),
         col(specs, :parent_index, :s64)
       )
 
@@ -123,7 +150,7 @@ defmodule BB.Robot.Kinematics do
 
       {x, y, z} = BB.Robot.Kinematics.link_position(robot, state, :end_effector)
   """
-  @spec link_position(Robot.t(), State.t() | %{atom() => float()}, atom()) ::
+  @spec link_position(Robot.t(), State.t() | configurations(), atom()) ::
           {float(), float(), float()}
   def link_position(%Robot{} = robot, state_or_positions, target_link) do
     transform = forward_kinematics(robot, state_or_positions, target_link)
@@ -134,57 +161,71 @@ defmodule BB.Robot.Kinematics do
   @doc """
   Compute the position Jacobian of a link with respect to the given joints.
 
-  Returns a `{3, length(joint_names)}` tensor where each column is the partial
-  derivative of the link's base-frame position with respect to that joint's
-  position. Joints that do not lie on the chain to `target_link` (and so do not
-  move it) get a zero column. Columns follow `joint_names` order.
+  Returns a `{3, columns}` tensor where each column is the partial derivative of
+  the link's base-frame position with respect to one degree of freedom. Joints
+  that do not lie on the chain to `target_link` (and so do not move it) get zero
+  columns.
+
+  **Width is the sum of degrees of freedom over `joint_names`, not their count** —
+  a `:floating` joint contributes six columns and a `:planar` one three, while a
+  `:fixed` joint contributes none. Use `jacobian_columns/2` to find out which
+  joint and degree of freedom each column belongs to.
 
   Computed analytically by differentiating the forward-kinematics `defn`, rather
   than by finite differences.
 
   ## Examples
 
-      jacobian = BB.Robot.Kinematics.position_jacobian(robot, positions, :tool0, joint_names)
+      jacobian = BB.Robot.Kinematics.position_jacobian(robot, configurations, :tool0, joint_names)
   """
-  @spec position_jacobian(Robot.t(), State.t() | %{atom() => float()}, atom(), [atom()]) ::
+  @spec position_jacobian(Robot.t(), State.t() | configurations(), atom(), [atom()]) ::
           Nx.Tensor.t()
   def position_jacobian(%Robot{} = robot, %State{} = state, target_link, joint_names) do
-    positions = State.get_all_configurations(state)
-    position_jacobian(robot, positions, target_link, joint_names)
+    configurations = State.get_all_configurations(state)
+    position_jacobian(robot, configurations, target_link, joint_names)
   end
 
-  def position_jacobian(%Robot{} = robot, positions, target_link, joint_names)
-      when is_map(positions) do
+  def position_jacobian(%Robot{} = robot, configurations, target_link, joint_names)
+      when is_map(configurations) do
     chain_joints = chain_joints(robot, path_to!(robot, target_link))
-    chain_jacobian(robot, positions, chain_joints, joint_names)
+    chain_jacobian(robot, configurations, chain_joints, joint_names, :position)
   end
 
   @doc """
   Compute the spatial (position and orientation) Jacobian of a link.
 
-  Returns a `{6, length(joint_names)}` tensor: the top three rows are the
-  position Jacobian (see `position_jacobian/4`) and the bottom three are the
-  orientation Jacobian — each column the joint's rotation axis in the base
-  frame for revolute joints, zero otherwise. This pairs with an orientation
-  error expressed as a base-frame rotation vector.
+  Returns a `{6, columns}` tensor: the top three rows are the position Jacobian
+  (see `position_jacobian/4`) and the bottom three are the orientation Jacobian.
+  For a revolute joint the orientation column is its rotation axis in the base
+  frame; for a multi-DoF joint's rotational degrees of freedom it is the
+  corresponding axis of the frame the joint's motion leaves behind; for prismatic
+  and purely translational degrees of freedom it is zero. This pairs with an
+  orientation error expressed as a base-frame rotation vector.
+
+  As with `position_jacobian/4`, width is the sum of degrees of freedom over
+  `joint_names` — see `jacobian_columns/2`.
 
   ## Examples
 
-      jacobian = BB.Robot.Kinematics.jacobian(robot, positions, :tool0, joint_names)
+      jacobian = BB.Robot.Kinematics.jacobian(robot, configurations, :tool0, joint_names)
   """
-  @spec jacobian(Robot.t(), State.t() | %{atom() => float()}, atom(), [atom()]) :: Nx.Tensor.t()
+  @spec jacobian(Robot.t(), State.t() | configurations(), atom(), [atom()]) :: Nx.Tensor.t()
   def jacobian(%Robot{} = robot, %State{} = state, target_link, joint_names) do
-    positions = State.get_all_configurations(state)
-    jacobian(robot, positions, target_link, joint_names)
+    configurations = State.get_all_configurations(state)
+    jacobian(robot, configurations, target_link, joint_names)
   end
 
-  def jacobian(%Robot{} = robot, positions, target_link, joint_names) when is_map(positions) do
+  def jacobian(%Robot{} = robot, configurations, target_link, joint_names)
+      when is_map(configurations) do
     chain_joints = chain_joints(robot, path_to!(robot, target_link))
 
-    position = chain_jacobian(robot, positions, chain_joints, joint_names)
-    orientation = chain_orientation_jacobian(robot, positions, chain_joints, joint_names)
-
-    Nx.concatenate([position, orientation], axis: 0)
+    Nx.concatenate(
+      [
+        chain_jacobian(robot, configurations, chain_joints, joint_names, :position),
+        chain_jacobian(robot, configurations, chain_joints, joint_names, :orientation)
+      ],
+      axis: 0
+    )
   end
 
   @doc """
@@ -193,35 +234,70 @@ defmodule BB.Robot.Kinematics do
   This combines the joint's fixed origin transform with the variable
   transform due to joint motion.
   """
-  @spec compute_joint_transform(Robot.t(), %{atom() => float()}, atom()) :: Transform.t()
-  def compute_joint_transform(%Robot{} = robot, positions, joint_name) do
+  @spec compute_joint_transform(Robot.t(), %{atom() => configuration()}, atom()) :: Transform.t()
+  def compute_joint_transform(%Robot{} = robot, configurations, joint_name) do
     {:ok, joint} = Robot.get_joint(robot, joint_name)
-    position = Map.get(positions, joint_name, 0.0)
+    configuration = Map.get(configurations, joint_name)
 
-    origin_transform = Transform.from_origin(joint.origin)
-
-    motion_transform =
-      case joint.type do
-        type when type in [:revolute, :continuous] ->
-          axis = tuple_to_vec3(joint.axis || {0.0, 0.0, 1.0})
-          Transform.from_axis_angle(axis, position)
-
-        :prismatic ->
-          axis = tuple_to_vec3(joint.axis || {0.0, 0.0, 1.0})
-          Transform.translation_along(axis, position)
-
-        :fixed ->
-          Transform.identity()
-
-        :floating ->
-          Transform.identity()
-
-        :planar ->
-          Transform.identity()
-      end
-
-    Transform.compose(origin_transform, motion_transform)
+    Transform.compose(
+      Transform.from_origin(joint.origin),
+      motion_transform(joint, configuration)
+    )
   end
+
+  @doc """
+  Describe the columns a Jacobian over `joint_names` will have.
+
+  Jacobian width is the sum of degrees of freedom along the chain rather than the
+  number of joints, so a caller applying a solver's delta needs to know which
+  joint and which degree of freedom each column belongs to. Returns one
+  `{joint_name, dof_index}` per column, in column order. Fixed joints contribute
+  nothing.
+
+  A `:planar` joint's three degrees of freedom are, in order, its two in-plane
+  translations and its rotation about the plane normal — the same order as its
+  `BB.Math.Transform2D` configuration. A `:floating` joint's six are three
+  translations then three rotations, in the frame its motion leaves behind.
+
+  ## Examples
+
+      BB.Robot.Kinematics.jacobian_columns(robot, [:base, :mast])
+      #=> [{:base, 0}, {:base, 1}, {:base, 2}, {:mast, 0}]
+  """
+  @spec jacobian_columns(Robot.t(), [atom()]) :: [{atom(), non_neg_integer()}]
+  def jacobian_columns(%Robot{} = robot, joint_names) do
+    Enum.flat_map(joint_names, fn joint_name ->
+      case Joint.dof(get_joint!(robot, joint_name)) do
+        0 -> []
+        dof -> Enum.map(0..(dof - 1), &{joint_name, &1})
+      end
+    end)
+  end
+
+  defp motion_transform(%{type: type} = joint, configuration)
+       when type in [:revolute, :continuous] do
+    Transform.from_axis_angle(joint_axis(joint), scalar(configuration))
+  end
+
+  defp motion_transform(%{type: :prismatic} = joint, configuration) do
+    Transform.translation_along(joint_axis(joint), scalar(configuration))
+  end
+
+  defp motion_transform(%{type: :planar} = joint, %Transform2D{} = configuration) do
+    Transform2D.to_transform(configuration, joint_axis(joint))
+  end
+
+  defp motion_transform(%{type: :floating}, %Transform{} = configuration), do: configuration
+
+  # An absent or wrongly-shaped configuration means "at rest", which is the
+  # identity. `BB.Robot.State.set_configuration/3` is what rejects a bad shape;
+  # forward kinematics is also called with bare maps a caller assembled by hand.
+  defp motion_transform(_joint, _configuration), do: Transform.identity()
+
+  defp joint_axis(%{axis: axis}), do: tuple_to_vec3(axis || {0.0, 0.0, 1.0})
+
+  defp scalar(value) when is_number(value), do: value * 1.0
+  defp scalar(_), do: 0.0
 
   defp tuple_to_vec3({x, y, z}), do: Vec3.new(x, y, z)
 
@@ -235,93 +311,174 @@ defmodule BB.Robot.Kinematics do
     end
   end
 
+  # Naming a joint the robot does not have used to yield one zero column, which
+  # silently swallowed a typo. It cannot survive per-DoF columns anyway: there is
+  # no way to know how many columns a joint that doesn't exist should contribute.
+  defp get_joint!(robot, joint_name) do
+    case Robot.get_joint(robot, joint_name) do
+      {:ok, joint} -> joint
+      {:error, error} -> raise error
+    end
+  end
+
   defp chain_joints(%Robot{joints: joints}, path) do
     Enum.filter(path, &Map.has_key?(joints, &1))
   end
 
-  defp compute_chain_transform(%Robot{} = robot, positions, path) do
+  defp compute_chain_transform(%Robot{} = robot, configurations, path) do
     case chain_joints(robot, path) do
       [] ->
         Transform.identity()
 
       joint_names ->
-        joints = Enum.map(joint_names, &Map.fetch!(robot.joints, &1))
-
-        Defn.fk_chain(
-          chain_positions(positions, joint_names),
-          rows(joints, &origin_rpy(&1.origin)),
-          rows(joints, &origin_xyz(&1.origin)),
-          rows(joints, &axis_row(&1.axis)),
-          column(joints, &revolute_mask/1),
-          column(joints, &prismatic_mask/1)
-        )
+        robot
+        |> chain_tensors(configurations, joint_names)
+        |> then(&apply(Defn, :fk_chain, &1))
         |> Transform.from_tensor()
     end
   end
 
-  defp chain_jacobian(_robot, _positions, [], joint_names) do
-    Nx.broadcast(Nx.tensor(0.0, type: :f64), {3, length(joint_names)})
+  defp chain_jacobian(robot, configurations, chain_joints, joint_names, kind) do
+    case chain_joints do
+      [] ->
+        Nx.broadcast(Nx.tensor(0.0, type: :f64), {3, column_count(robot, joint_names)})
+
+      _ ->
+        tensors = chain_tensors(robot, configurations, chain_joints)
+
+        assemble_columns(
+          robot,
+          apply(Defn, scalar_fun(kind), tensors),
+          apply(Defn, delta_fun(kind), tensors),
+          chain_joints,
+          joint_names
+        )
+    end
   end
 
-  defp chain_jacobian(robot, positions, chain_joints, joint_names) do
-    {positions_t, rpy, xyz, axes, revolute, prismatic} =
-      chain_tensors(robot, positions, chain_joints)
-
-    Defn.position_jacobian(positions_t, rpy, xyz, axes, revolute, prismatic)
-    |> select_columns(chain_joints, joint_names)
+  defp column_count(robot, joint_names) do
+    Enum.sum_by(joint_names, &Joint.dof(get_joint!(robot, &1)))
   end
 
-  defp chain_orientation_jacobian(_robot, _positions, [], joint_names) do
-    Nx.broadcast(Nx.tensor(0.0, type: :f64), {3, length(joint_names)})
-  end
+  defp scalar_fun(:position), do: :position_jacobian
+  defp scalar_fun(:orientation), do: :orientation_jacobian
+  defp delta_fun(:position), do: :position_jacobian_deltas
+  defp delta_fun(:orientation), do: :orientation_jacobian_deltas
 
-  defp chain_orientation_jacobian(robot, positions, chain_joints, joint_names) do
-    {positions_t, rpy, xyz, axes, revolute, prismatic} =
-      chain_tensors(robot, positions, chain_joints)
-
-    Defn.orientation_jacobian(positions_t, rpy, xyz, axes, revolute, prismatic)
-    |> select_columns(chain_joints, joint_names)
-  end
-
-  defp chain_tensors(robot, positions, chain_joints) do
+  defp chain_tensors(robot, configurations, chain_joints) do
     joints = Enum.map(chain_joints, &Map.fetch!(robot.joints, &1))
 
-    {
-      chain_positions(positions, chain_joints),
+    [
+      rows(joints, &scalar_position(configurations, &1)),
       rows(joints, &origin_rpy(&1.origin)),
       rows(joints, &origin_xyz(&1.origin)),
       rows(joints, &axis_row(&1.axis)),
-      column(joints, &revolute_mask/1),
-      column(joints, &prismatic_mask/1)
-    }
+      rows(joints, &revolute_mask/1),
+      rows(joints, &prismatic_mask/1),
+      stored_motions(configurations, joints),
+      Nx.broadcast(Nx.tensor(0.0, type: :f64), {length(joints), 6})
+    ]
   end
 
-  defp select_columns(chain_jac, chain_joints, joint_names) do
+  # A multi-DoF joint's motion cannot be expressed as a scalar, so it travels in
+  # `stored` as a matrix instead and its scalar slot is zeroed — which, with both
+  # motion masks also zero, leaves its scalar motion as the identity.
+  defp scalar_position(configurations, joint) do
+    case Map.get(configurations, joint.name, 0.0) do
+      value when is_number(value) -> value * 1.0
+      _ -> 0.0
+    end
+  end
+
+  defp stored_motions(configurations, joints) do
+    joints
+    |> Enum.map(&stored_motion(Map.get(configurations, &1.name), &1))
+    |> Nx.stack()
+  end
+
+  defp stored_motion(%Transform2D{} = configuration, %{type: :planar} = joint) do
+    configuration
+    |> Transform2D.to_transform(plane_normal(joint))
+    |> Transform.tensor()
+  end
+
+  defp stored_motion(%Transform{} = configuration, %{type: :floating}),
+    do: Transform.tensor(configuration)
+
+  defp stored_motion(_configuration, _joint), do: Nx.eye(4, type: :f64)
+
+  defp plane_normal(%{axis: axis}), do: tuple_to_vec3(axis || {0.0, 0.0, 1.0})
+
+  # Columns are per degree of freedom, not per joint, so a floating joint
+  # contributes six and a planar one three. Single-DoF joints take their column
+  # from the scalar gradient; multi-DoF joints project their {3, 6} perturbation
+  # block onto the degrees of freedom they actually have.
+  defp assemble_columns(robot, scalar_jacobian, delta_jacobian, chain_joints, joint_names) do
     index_of = chain_joints |> Enum.with_index() |> Map.new()
-    zero = Nx.broadcast(Nx.tensor(0.0, type: :f64), {3})
 
     joint_names
-    |> Enum.map(fn joint_name ->
-      case Map.fetch(index_of, joint_name) do
-        {:ok, index} -> chain_jac[[.., index]]
-        :error -> zero
-      end
+    |> Enum.flat_map(fn joint_name ->
+      joint = get_joint!(robot, joint_name)
+
+      joint_columns(
+        joint,
+        Map.fetch(index_of, joint_name),
+        scalar_jacobian,
+        delta_jacobian
+      )
     end)
     |> Nx.stack(axis: 1)
   end
 
-  defp chain_positions(positions, joint_names) do
-    joint_names
-    |> Enum.map(&(Map.get(positions, &1, 0.0) * 1.0))
-    |> Nx.tensor(type: :f64)
+  defp joint_columns(%{type: :fixed}, _index, _scalar_jacobian, _delta_jacobian), do: []
+
+  # A joint that isn't on the chain doesn't move the target, so it gets a zero
+  # column per degree of freedom rather than being dropped — the caller asked for
+  # it, and the column count must match what `jacobian_columns/2` reports.
+  defp joint_columns(joint, :error, _scalar_jacobian, _delta_jacobian) do
+    List.duplicate(Nx.broadcast(Nx.tensor(0.0, type: :f64), {3}), Joint.dof(joint))
+  end
+
+  defp joint_columns(%{type: type}, {:ok, index}, scalar_jacobian, _delta_jacobian)
+       when type in [:revolute, :continuous, :prismatic] do
+    [scalar_jacobian[[.., index]]]
+  end
+
+  defp joint_columns(joint, {:ok, index}, _scalar_jacobian, delta_jacobian) do
+    delta_jacobian[[.., index, ..]]
+    |> Nx.dot(dof_basis(joint))
+    |> split_columns()
+  end
+
+  defp split_columns(tensor) do
+    Enum.map(0..(Nx.axis_size(tensor, 1) - 1), &tensor[[.., &1]])
+  end
+
+  # Maps a joint's own degrees of freedom onto the six components of a local
+  # perturbation. A floating joint uses all of them; a planar joint uses the two
+  # in-plane translations and the rotation about its normal, in the same basis
+  # `BB.Math.Transform2D.to_transform/2` lifts its configuration through.
+  defp dof_basis(%{type: :floating}), do: Nx.eye(6, type: :f64)
+
+  defp dof_basis(%{type: :planar} = joint) do
+    normal = Vec3.normalise(plane_normal(joint))
+    {u, v} = Transform2D.plane_basis(normal)
+
+    Nx.stack(
+      [
+        Nx.concatenate([Vec3.tensor(u), Nx.broadcast(Nx.tensor(0.0, type: :f64), {3})]),
+        Nx.concatenate([Vec3.tensor(v), Nx.broadcast(Nx.tensor(0.0, type: :f64), {3})]),
+        Nx.concatenate([Nx.broadcast(Nx.tensor(0.0, type: :f64), {3}), Vec3.tensor(normal)])
+      ],
+      axis: 1
+    )
   end
 
   defp rows(joints, fun), do: joints |> Enum.map(fun) |> Nx.tensor(type: :f64)
-  defp column(joints, fun), do: joints |> Enum.map(fun) |> Nx.tensor(type: :f64)
 
   defp col(specs, key, type), do: specs |> Enum.map(&Map.fetch!(&1, key)) |> Nx.tensor(type: type)
 
-  defp link_joint_spec(_robot, _positions, index_of, link_name, nil) do
+  defp link_joint_spec(_robot, _configurations, index_of, link_name, nil) do
     %{
       rpy: origin_rpy(nil),
       xyz: origin_xyz(nil),
@@ -329,11 +486,12 @@ defmodule BB.Robot.Kinematics do
       revolute: revolute_mask(nil),
       prismatic: prismatic_mask(nil),
       position: 0.0,
+      stored: Nx.eye(4, type: :f64),
       parent_index: Map.fetch!(index_of, link_name)
     }
   end
 
-  defp link_joint_spec(robot, positions, index_of, _link_name, joint_name) do
+  defp link_joint_spec(robot, configurations, index_of, _link_name, joint_name) do
     joint = Map.fetch!(robot.joints, joint_name)
 
     %{
@@ -342,7 +500,8 @@ defmodule BB.Robot.Kinematics do
       axis: axis_row(joint.axis),
       revolute: revolute_mask(joint),
       prismatic: prismatic_mask(joint),
-      position: Map.get(positions, joint_name, 0.0) * 1.0,
+      position: scalar_position(configurations, joint),
+      stored: stored_motion(Map.get(configurations, joint_name), joint),
       parent_index: Map.fetch!(index_of, joint.parent_link)
     }
   end

--- a/lib/bb/robot/kinematics/defn.ex
+++ b/lib/bb/robot/kinematics/defn.ex
@@ -24,13 +24,43 @@ defmodule BB.Robot.Kinematics.Defn do
   - `axes` — `{n, 3}` per-joint motion axis (unit vector)
   - `is_revolute` — `{n}` `1.0` for revolute/continuous joints, else `0.0`
   - `is_prismatic` — `{n}` `1.0` for prismatic joints, else `0.0`
+  - `stored` — `{n, 4, 4}` per-joint multi-DoF motion, identity for single-DoF joints
+  - `deltas` — `{n, 6}` per-joint local perturbation, always passed as zeros
 
-  The result is the `{4, 4}` base-to-tip homogeneous transform. The per-joint
-  transform reproduces `BB.Math.Transform.from_origin/1` composed with the
-  motion transform: `origin = Rx · Ry · Rz · T(xyz)` and the motion is a
-  Rodrigues rotation about `axis` (revolute) or a translation along `axis`
-  (prismatic). Fixed/floating/planar joints carry both masks at `0.0`, leaving
-  an identity motion.
+  The result is the `{4, 4}` base-to-tip homogeneous transform. Each joint
+  contributes
+
+      origin · scalar_motion(q) · stored · (I + hat(delta))
+
+  where `origin = Rx · Ry · Rz · T(xyz)` reproduces
+  `BB.Math.Transform.from_origin/1`, and `scalar_motion` is a Rodrigues rotation
+  about `axis` (revolute) or a translation along `axis` (prismatic).
+
+  ## Why multi-DoF joints arrive as a matrix and a zero perturbation
+
+  A `:floating` joint's configuration is a `BB.Math.Transform` and a `:planar`
+  joint's is a `BB.Math.Transform2D` lifted into one. Neither can be handed to
+  this kernel as scalars without decomposing the rotation into three angles about
+  three axes — an Euler decomposition, which is lossy, non-unique and
+  gimbal-locked. So the matrix arrives verbatim in `stored`, and forward
+  kinematics is bit-exact.
+
+  The Jacobian still needs a differentiable parameter, which is what `deltas` is.
+  It is **only ever evaluated at zero**, and that makes the first-order factor
+  `I + hat(delta)` exactly right for both jobs:
+
+  - at zero it *is* the identity, so it contributes nothing to forward kinematics;
+  - `exp(delta) = I + hat(delta) + O(delta²)`, so its derivative at zero matches
+    the true exponential's. The dropped terms are never evaluated.
+
+  Differentiating at the identity also means an Euler chart's singularities are
+  never visited, so there is no gimbal lock to regularise — and unlike a genuine
+  `se(3)` exponential there is no `(1 - cos θ)/θ²` to blow up at `theta = 0`.
+
+  A single-DoF joint carries `stored = I` and `delta = 0`, so its motion reduces
+  to the scalar form. A multi-DoF joint carries both masks at `0.0`, so its
+  `scalar_motion` is the identity and its motion reduces to `stored`. One code
+  path serves both.
   """
 
   import Nx.Defn
@@ -40,10 +70,28 @@ defmodule BB.Robot.Kinematics.Defn do
 
   See the module documentation for the tensor layout.
   """
-  defn fk_chain(positions, origin_rpy, origin_xyz, axes, is_revolute, is_prismatic) do
-    origins = build_origins(origin_rpy, origin_xyz)
-    motions = build_motions(positions, axes, is_revolute, is_prismatic)
-    chain_product(batched_matmul(origins, motions))
+  defn fk_chain(
+         positions,
+         origin_rpy,
+         origin_xyz,
+         axes,
+         is_revolute,
+         is_prismatic,
+         stored,
+         deltas
+       ) do
+    chain_product(
+      joint_matrices(
+        positions,
+        origin_rpy,
+        origin_xyz,
+        axes,
+        is_revolute,
+        is_prismatic,
+        stored,
+        deltas
+      )
+    )
   end
 
   @doc """
@@ -63,11 +111,21 @@ defmodule BB.Robot.Kinematics.Defn do
          axes,
          is_revolute,
          is_prismatic,
+         stored,
+         deltas,
          parent_idx
        ) do
-    origins = build_origins(origin_rpy, origin_xyz)
-    motions = build_motions(positions, axes, is_revolute, is_prismatic)
-    joint_mats = batched_matmul(origins, motions)
+    joint_mats =
+      joint_matrices(
+        positions,
+        origin_rpy,
+        origin_xyz,
+        axes,
+        is_revolute,
+        is_prismatic,
+        stored,
+        deltas
+      )
 
     n = Nx.axis_size(joint_mats, 0)
     init = Nx.broadcast(Nx.eye(4, type: :f64), {n, 4, 4})
@@ -82,37 +140,64 @@ defmodule BB.Robot.Kinematics.Defn do
   end
 
   @doc """
-  Position Jacobian of the chain tip with respect to the chain joint positions.
+  Position Jacobian of the chain tip with respect to each single-DoF joint position.
 
-  Computed by differentiating `fk_chain/6`'s tip translation via `grad` — the
+  Computed by differentiating `fk_chain/8`'s tip translation via `grad` — the
   composable-`defn` payoff #147 is after: no finite differences, no extra
-  forward-kinematics evaluations. Inputs follow the `fk_chain/6` layout. Returns
+  forward-kinematics evaluations. Inputs follow the `fk_chain/8` layout. Returns
   `{3, n}`: row = spatial axis (x, y, z), column = chain joint in input order.
+
+  Multi-DoF joints get a zero column here, since their motion does not depend on
+  `positions`. Their columns come from `position_jacobian_deltas/8`.
   """
-  defn position_jacobian(positions, origin_rpy, origin_xyz, axes, is_revolute, is_prismatic) do
-    select_x = Nx.tensor([1.0, 0.0, 0.0, 0.0], type: :f64)
-    select_y = Nx.tensor([0.0, 1.0, 0.0, 0.0], type: :f64)
-    select_z = Nx.tensor([0.0, 0.0, 1.0, 0.0], type: :f64)
+  defn position_jacobian(
+         positions,
+         origin_rpy,
+         origin_xyz,
+         axes,
+         is_revolute,
+         is_prismatic,
+         stored,
+         deltas
+       ) do
+    args = {origin_rpy, origin_xyz, axes, is_revolute, is_prismatic, stored, deltas}
 
-    jx =
-      grad(
-        positions,
-        &tip_coordinate(&1, origin_rpy, origin_xyz, axes, is_revolute, is_prismatic, select_x)
-      )
+    Nx.stack([
+      position_gradient(positions, args, select_x()),
+      position_gradient(positions, args, select_y()),
+      position_gradient(positions, args, select_z())
+    ])
+  end
 
-    jy =
-      grad(
-        positions,
-        &tip_coordinate(&1, origin_rpy, origin_xyz, axes, is_revolute, is_prismatic, select_y)
-      )
+  @doc """
+  Position Jacobian of the chain tip with respect to each joint's local perturbation.
 
-    jz =
-      grad(
-        positions,
-        &tip_coordinate(&1, origin_rpy, origin_xyz, axes, is_revolute, is_prismatic, select_z)
-      )
+  Returns `{3, n, 6}`: row = spatial axis, then chain joint in input order, then
+  the six components of that joint's local perturbation — three translations
+  followed by three rotations, in the frame the joint's motion leaves behind.
 
-    Nx.stack([jx, jy, jz])
+  A single-DoF joint's block is meaningless and is discarded by the caller; only
+  `:planar` and `:floating` joints draw their columns from here, projected onto
+  the degrees of freedom they actually have. See the module documentation for why
+  differentiating at `deltas = 0` is exact.
+  """
+  defn position_jacobian_deltas(
+         positions,
+         origin_rpy,
+         origin_xyz,
+         axes,
+         is_revolute,
+         is_prismatic,
+         stored,
+         deltas
+       ) do
+    args = {origin_rpy, origin_xyz, axes, is_revolute, is_prismatic, stored, positions}
+
+    Nx.stack([
+      delta_gradient(deltas, args, select_x()),
+      delta_gradient(deltas, args, select_y()),
+      delta_gradient(deltas, args, select_z())
+    ])
   end
 
   @doc """
@@ -128,24 +213,119 @@ defmodule BB.Robot.Kinematics.Defn do
   accumulating the transform up to each joint's axis frame; `grad` is not
   involved, so the data-dependent `while` is fine here.
   """
-  defn orientation_jacobian(positions, origin_rpy, origin_xyz, axes, is_revolute, is_prismatic) do
+  defn orientation_jacobian(
+         positions,
+         origin_rpy,
+         origin_xyz,
+         axes,
+         is_revolute,
+         is_prismatic,
+         stored,
+         deltas
+       ) do
+    {axes_in_base, _rotations} =
+      orientation_frames(
+        positions,
+        origin_rpy,
+        origin_xyz,
+        axes,
+        is_revolute,
+        is_prismatic,
+        stored,
+        deltas
+      )
+
+    Nx.transpose(axes_in_base * Nx.new_axis(is_revolute, 1))
+  end
+
+  @doc """
+  Orientation Jacobian of the chain tip with respect to each joint's local perturbation.
+
+  Returns `{3, n, 6}`, matching `position_jacobian_deltas/8`'s layout. A
+  perturbation's three translation components produce no angular velocity, so
+  those blocks are zero; its three rotation components produce the columns of the
+  rotation taking the joint's post-motion frame into the base frame.
+
+  That frame is the right one because the perturbation is applied *after* the
+  joint's origin and stored motion — see the module documentation.
+  """
+  defn orientation_jacobian_deltas(
+         positions,
+         origin_rpy,
+         origin_xyz,
+         axes,
+         is_revolute,
+         is_prismatic,
+         stored,
+         deltas
+       ) do
+    {_axes_in_base, rotations} =
+      orientation_frames(
+        positions,
+        origin_rpy,
+        origin_xyz,
+        axes,
+        is_revolute,
+        is_prismatic,
+        stored,
+        deltas
+      )
+
+    n = Nx.axis_size(rotations, 0)
+    zeros = Nx.broadcast(Nx.tensor(0.0, type: :f64), {n, 3, 3})
+
+    # `rotations` is {n, 3, 3} with the frame's basis vectors as columns, which is
+    # already {spatial, dof} per joint. Concatenating zeros for the translation
+    # half gives {n, 3, 6}, then transposing lifts the spatial axis to the front.
+    Nx.transpose(Nx.concatenate([zeros, rotations], axis: 2), axes: [1, 0, 2])
+  end
+
+  # Walks the chain once, returning both the per-joint rotation axis in the base
+  # frame (for the revolute angular Jacobian) and the rotation of each joint's
+  # post-motion frame (which is the frame a local perturbation acts in). `grad` is
+  # not involved, so the data-dependent `while` is fine here.
+  defnp orientation_frames(
+          positions,
+          origin_rpy,
+          origin_xyz,
+          axes,
+          is_revolute,
+          is_prismatic,
+          stored,
+          deltas
+        ) do
     origins = build_origins(origin_rpy, origin_xyz)
-    motions = build_motions(positions, axes, is_revolute, is_prismatic)
-    joint_mats = batched_matmul(origins, motions)
+
+    joint_mats =
+      joint_matrices(
+        positions,
+        origin_rpy,
+        origin_xyz,
+        axes,
+        is_revolute,
+        is_prismatic,
+        stored,
+        deltas
+      )
 
     n = Nx.axis_size(origins, 0)
 
-    {axes_in_base, _origins, _joint_mats, _axes, _prefix, _i} =
-      while {acc = Nx.broadcast(Nx.tensor(0.0, type: :f64), {n, 3}), og = origins,
+    {axes_in_base, rotations, _og, _jm, _ax, _prefix, _i} =
+      while {acc = Nx.broadcast(Nx.tensor(0.0, type: :f64), {n, 3}),
+             rots = Nx.broadcast(Nx.tensor(0.0, type: :f64), {n, 3, 3}), og = origins,
              jm = joint_mats, ax = axes, prefix = Nx.eye(4, type: :f64), i = 0},
             i < n do
         axis_frame = Nx.dot(prefix, og[i])
         z = Nx.dot(Nx.slice(axis_frame, [0, 0], [3, 3]), ax[i])
 
-        {Nx.put_slice(acc, [i, 0], Nx.new_axis(z, 0)), og, jm, ax, Nx.dot(prefix, jm[i]), i + 1}
+        post = Nx.dot(prefix, jm[i])
+        rotation = Nx.slice(post, [0, 0], [3, 3])
+
+        {Nx.put_slice(acc, [i, 0], Nx.new_axis(z, 0)),
+         Nx.put_slice(rots, [i, 0, 0], Nx.new_axis(rotation, 0)), og, jm, ax, post, i + 1}
       end
 
-    Nx.transpose(axes_in_base * Nx.new_axis(is_revolute, 1))
+    {axes_in_base, rotations}
   end
 
   # The tip translation is `fk · [0, 0, 0, 1]ᵀ` (the homogeneous last column);
@@ -158,12 +338,114 @@ defmodule BB.Robot.Kinematics.Defn do
           axes,
           is_revolute,
           is_prismatic,
+          stored,
+          deltas,
           selector
         ) do
-    fk = fk_chain(positions, origin_rpy, origin_xyz, axes, is_revolute, is_prismatic)
+    fk =
+      fk_chain(
+        positions,
+        origin_rpy,
+        origin_xyz,
+        axes,
+        is_revolute,
+        is_prismatic,
+        stored,
+        deltas
+      )
+
     translation = Nx.dot(fk, Nx.tensor([0.0, 0.0, 0.0, 1.0], type: :f64))
     Nx.dot(translation, selector)
   end
+
+  # `origin · scalar_motion(q) · stored · (I + hat(delta))` per joint.
+  defnp joint_matrices(
+          positions,
+          origin_rpy,
+          origin_xyz,
+          axes,
+          is_revolute,
+          is_prismatic,
+          stored,
+          deltas
+        ) do
+    origins = build_origins(origin_rpy, origin_xyz)
+    motions = build_motions(positions, axes, is_revolute, is_prismatic)
+
+    origins
+    |> batched_matmul(motions)
+    |> batched_matmul(stored)
+    |> batched_matmul(augment(deltas))
+  end
+
+  # `I + hat(delta)`, the first-order rigid motion. Exactly the identity at
+  # `delta = 0`, and its derivative there matches `exp(delta)`'s — which is all
+  # that is asked of it, since `delta` is never evaluated anywhere else.
+  defnp augment(deltas) do
+    vx = deltas[[.., 0]]
+    vy = deltas[[.., 1]]
+    vz = deltas[[.., 2]]
+    wx = deltas[[.., 3]]
+    wy = deltas[[.., 4]]
+    wz = deltas[[.., 5]]
+
+    z = vx * 0.0
+    o = z + 1.0
+
+    Nx.stack(
+      [
+        Nx.stack([o, -wz, wy, vx], axis: 1),
+        Nx.stack([wz, o, -wx, vy], axis: 1),
+        Nx.stack([-wy, wx, o, vz], axis: 1),
+        Nx.stack([z, z, z, o], axis: 1)
+      ],
+      axis: 1
+    )
+  end
+
+  # The three grads are written out rather than mapped: `Enum.map/2` cannot be
+  # called inside `defn`, and the chain length is static at trace time anyway.
+  defnp position_gradient(positions, args, selector) do
+    {origin_rpy, origin_xyz, axes, is_revolute, is_prismatic, stored, deltas} = args
+
+    grad(
+      positions,
+      &tip_coordinate(
+        &1,
+        origin_rpy,
+        origin_xyz,
+        axes,
+        is_revolute,
+        is_prismatic,
+        stored,
+        deltas,
+        selector
+      )
+    )
+  end
+
+  defnp delta_gradient(deltas, args, selector) do
+    {origin_rpy, origin_xyz, axes, is_revolute, is_prismatic, stored, positions} = args
+
+    grad(
+      deltas,
+      &tip_coordinate(
+        positions,
+        origin_rpy,
+        origin_xyz,
+        axes,
+        is_revolute,
+        is_prismatic,
+        stored,
+        &1,
+        selector
+      )
+    )
+  end
+
+  defnp(select_x, do: Nx.tensor([1.0, 0.0, 0.0, 0.0], type: :f64))
+  defnp(select_y, do: Nx.tensor([0.0, 1.0, 0.0, 0.0], type: :f64))
+  defnp(select_z, do: Nx.tensor([0.0, 0.0, 1.0, 0.0], type: :f64))
 
   defnp build_origins(rpy, xyz) do
     roll = rpy[[.., 0]]

--- a/lib/bb/robot/runtime.ex
+++ b/lib/bb/robot/runtime.ex
@@ -268,33 +268,36 @@ defmodule BB.Robot.Runtime do
   end
 
   @doc """
-  Get all joint positions as a map.
+  Get all joint configurations as a map.
 
-  Reads directly from ETS for fast concurrent access. Returns a map of
-  joint names to their current positions (in radians for revolute joints,
-  metres for prismatic joints).
+  Reads directly from ETS for fast concurrent access. Returns a map of joint
+  names to their current configurations, each shaped to its joint's type — a
+  float for single-DoF joints, a `BB.Math.Transform2D` for planar and a
+  `BB.Math.Transform` for floating. See `BB.Robot.State` for the full table.
 
-  Positions are updated automatically by the Runtime when sensors publish
+  Configurations are updated automatically by the Runtime when sensors publish
   `JointState` messages.
 
   ## Examples
 
-      iex> BB.Robot.Runtime.positions(MyRobot)
+      iex> BB.Robot.Runtime.configurations(MyRobot)
       %{pan_joint: 0.0, tilt_joint: 0.0}
 
   """
-  @spec positions(module()) :: %{atom() => float()}
-  def positions(robot_module) do
+  @spec configurations(module()) :: %{atom() => RobotState.configuration()}
+  def configurations(robot_module) do
     robot_state = get_robot_state(robot_module)
-    RobotState.get_all_positions(robot_state)
+    RobotState.get_all_configurations(robot_state)
   end
 
   @doc """
   Get all joint velocities as a map.
 
-  Reads directly from ETS for fast concurrent access. Returns a map of
-  joint names to their current velocities (in rad/s for revolute joints,
-  m/s for prismatic joints).
+  Reads directly from ETS for fast concurrent access. Returns a map of joint
+  names to their current velocities, each shaped to its joint's type — a float
+  for single-DoF joints, a `BB.Message.Geometry.Twist2D` for planar and a
+  `BB.Message.Geometry.Twist` for floating. See `BB.Robot.State` for the full
+  table.
 
   Velocities are updated automatically by the Runtime when sensors publish
   `JointState` messages.
@@ -305,7 +308,7 @@ defmodule BB.Robot.Runtime do
       %{pan_joint: 0.0, tilt_joint: 0.0}
 
   """
-  @spec velocities(module()) :: %{atom() => float()}
+  @spec velocities(module()) :: %{atom() => RobotState.velocity()}
   def velocities(robot_module) do
     robot_state = get_robot_state(robot_module)
     RobotState.get_all_velocities(robot_state)
@@ -996,23 +999,18 @@ defmodule BB.Robot.Runtime do
     %{state | operational_state: new_robot_state}
   end
 
+  # A publisher can name a joint this robot doesn't have, or report a value whose
+  # shape doesn't match the joint's type. Neither is grounds for taking the
+  # runtime down, so a rejected entry is dropped and the rest are applied.
   defp update_joint_state(robot_state, %JointState{} = joint_state) do
     names = joint_state.names || []
-    positions = joint_state.positions || []
-    velocities = joint_state.velocities || []
 
-    # Update positions
-    names
-    |> Enum.zip(positions)
-    |> Enum.each(fn {name, position} ->
-      RobotState.set_joint_position(robot_state, name, position)
+    Enum.each(names |> Enum.zip(joint_state.positions || []), fn {name, configuration} ->
+      RobotState.set_configuration(robot_state, name, configuration)
     end)
 
-    # Update velocities
-    names
-    |> Enum.zip(velocities)
-    |> Enum.each(fn {name, velocity} ->
-      RobotState.set_joint_velocity(robot_state, name, velocity)
+    Enum.each(names |> Enum.zip(joint_state.velocities || []), fn {name, velocity} ->
+      RobotState.set_velocity(robot_state, name, velocity)
     end)
   end
 

--- a/lib/bb/robot/state.ex
+++ b/lib/bb/robot/state.ex
@@ -206,10 +206,10 @@ defmodule BB.Robot.State do
   @spec get_chain_positions(t(), atom()) :: [{atom(), float()}]
   def get_chain_positions(%__MODULE__{robot: robot} = state, target_link) do
     case Robot.path_to(robot, target_link) do
-      nil ->
+      {:error, _} ->
         []
 
-      path ->
+      {:ok, path} ->
         path
         |> Enum.filter(&Map.has_key?(robot.joints, &1))
         |> Enum.map(fn joint_name ->

--- a/lib/bb/robot/state.ex
+++ b/lib/bb/robot/state.ex
@@ -6,32 +6,60 @@ defmodule BB.Robot.State do
   @moduledoc """
   ETS-backed mutable state for robot instances.
 
-  This module manages joint positions, velocities, and computed transforms
+  This module manages joint configurations, velocities, and computed transforms
   for robot instances. Each robot instance has its own ETS table for
   concurrent read access.
 
-  ## State Structure
+  ## Configurations, not positions
 
-  For each joint, the following state is stored:
-  - `position`: current joint position (radians for revolute, meters for prismatic)
-  - `velocity`: current joint velocity (rad/s or m/s)
+  A joint's configuration is a point in its own configuration space, and its
+  shape depends on the joint's type:
+
+  | Joint type | DoF | Configuration | Velocity |
+  |---|---|---|---|
+  | `:fixed` | 0 | `0.0`, the only one it has | `0.0` |
+  | `:revolute`, `:continuous` | 1 | `float` angle in radians | `float` rad/s |
+  | `:prismatic` | 1 | `float` displacement in metres | `float` m/s |
+  | `:planar` | 3 | `BB.Math.Transform2D` | `BB.Message.Geometry.Twist2D` |
+  | `:floating` | 6 | `BB.Math.Transform` | `BB.Message.Geometry.Twist` |
+
+  "Position" is the wrong word for a 4x4 homogeneous transform, which is why
+  these functions say "configuration" — the standard term for a point in a
+  robot's configuration space, and correct for every joint type.
+
+  Writes are whole-configuration and atomic. There is no API for setting part of
+  a floating joint, because a partial update invites inconsistent intermediate
+  states and the natural producer of such a configuration is an estimator
+  emitting a complete pose.
+
+  A fixed joint has zero degrees of freedom, so its configuration space is a
+  single point and `0.0` is the only value it accepts. It is still present in
+  `get_all_configurations/1` so that map can be handed straight back to
+  `set_configurations/2`.
 
   ## Usage
 
       # Create state for a robot instance
       {:ok, state} = BB.Robot.State.new(robot)
 
-      # Set/get joint positions
-      :ok = BB.Robot.State.set_joint_position(state, :shoulder, 0.5)
-      pos = BB.Robot.State.get_joint_position(state, :shoulder)
+      # Set/get a joint configuration
+      :ok = BB.Robot.State.set_configuration(state, :shoulder, 0.5)
+      {:ok, angle} = BB.Robot.State.get_configuration(state, :shoulder)
 
-      # Get all joint positions as a map
-      positions = BB.Robot.State.get_all_positions(state)
+      # Get every joint's configuration as a map
+      configurations = BB.Robot.State.get_all_configurations(state)
 
       # Clean up when done
       :ok = BB.Robot.State.delete(state)
   """
 
+  alias BB.Error.Invalid.JointConfig
+  alias BB.Error.Kinematics.UnknownJoint
+  alias BB.Math.Transform
+  alias BB.Math.Transform2D
+  alias BB.Math.Vec3
+  alias BB.Message.Geometry.Twist
+  alias BB.Message.Geometry.Twist2D
   alias BB.Robot
 
   defstruct [:table, :robot]
@@ -40,6 +68,16 @@ defmodule BB.Robot.State do
           table: :ets.table(),
           robot: Robot.t()
         }
+
+  @typedoc """
+  A joint's configuration, shaped to its type.
+
+  See the module documentation for which shape belongs to which joint type.
+  """
+  @type configuration :: float() | Transform2D.t() | Transform.t()
+
+  @typedoc "A joint's velocity, shaped to its type."
+  @type velocity :: float() | Twist2D.t() | Twist.t()
 
   @doc """
   Create a new state table for a robot.
@@ -73,124 +111,114 @@ defmodule BB.Robot.State do
   end
 
   @doc """
-  Get the current position of a joint.
+  Get the current configuration of a joint.
 
-  Returns `nil` if the joint doesn't exist.
+  ## Examples
+
+      {:ok, 0.5} = BB.Robot.State.get_configuration(state, :shoulder)
+      {:ok, %BB.Math.Transform{}} = BB.Robot.State.get_configuration(state, :base)
   """
-  @spec get_joint_position(t(), atom()) :: float() | nil
-  def get_joint_position(%__MODULE__{table: table}, joint_name) do
-    case :ets.lookup(table, {:position, joint_name}) do
-      [{{:position, ^joint_name}, value}] -> value
-      [] -> nil
+  @spec get_configuration(t(), atom()) :: {:ok, configuration()} | {:error, UnknownJoint.t()}
+  def get_configuration(%__MODULE__{table: table} = state, joint_name) do
+    with {:ok, joint} <- fetch_joint(state, joint_name) do
+      {:ok, read(table, :configuration, joint_name, joint.type)}
     end
   end
 
   @doc """
-  Set the position of a joint.
+  Set the configuration of a joint.
+
+  The value's shape must match the joint's type, so a `BB.Math.Transform2D`
+  aimed at a revolute joint is an error rather than a wrong pose.
+
+  ## Examples
+
+      :ok = BB.Robot.State.set_configuration(state, :shoulder, 0.5)
+      :ok = BB.Robot.State.set_configuration(state, :base, transform)
   """
-  @spec set_joint_position(t(), atom(), float()) :: :ok
-  def set_joint_position(%__MODULE__{table: table}, joint_name, position)
-      when is_float(position) or is_integer(position) do
-    :ets.insert(table, {{:position, joint_name}, position / 1})
-    :ok
+  @spec set_configuration(t(), atom(), configuration()) ::
+          :ok | {:error, UnknownJoint.t() | JointConfig.t()}
+  def set_configuration(%__MODULE__{table: table} = state, joint_name, value) do
+    with {:ok, joint} <- fetch_joint(state, joint_name),
+         {:ok, encoded} <- encode(joint, :configuration, value) do
+      :ets.insert(table, {{:configuration, joint_name}, encoded})
+      :ok
+    end
   end
 
   @doc """
   Get the current velocity of a joint.
-
-  Returns `nil` if the joint doesn't exist.
   """
-  @spec get_joint_velocity(t(), atom()) :: float() | nil
-  def get_joint_velocity(%__MODULE__{table: table}, joint_name) do
-    case :ets.lookup(table, {:velocity, joint_name}) do
-      [{{:velocity, ^joint_name}, value}] -> value
-      [] -> nil
+  @spec get_velocity(t(), atom()) :: {:ok, velocity()} | {:error, UnknownJoint.t()}
+  def get_velocity(%__MODULE__{table: table} = state, joint_name) do
+    with {:ok, joint} <- fetch_joint(state, joint_name) do
+      {:ok, read(table, :velocity, joint_name, joint.type)}
     end
   end
 
   @doc """
   Set the velocity of a joint.
   """
-  @spec set_joint_velocity(t(), atom(), float()) :: :ok
-  def set_joint_velocity(%__MODULE__{table: table}, joint_name, velocity)
-      when is_float(velocity) or is_integer(velocity) do
-    :ets.insert(table, {{:velocity, joint_name}, velocity / 1})
-    :ok
+  @spec set_velocity(t(), atom(), velocity()) ::
+          :ok | {:error, UnknownJoint.t() | JointConfig.t()}
+  def set_velocity(%__MODULE__{table: table} = state, joint_name, value) do
+    with {:ok, joint} <- fetch_joint(state, joint_name),
+         {:ok, encoded} <- encode(joint, :velocity, value) do
+      :ets.insert(table, {{:velocity, joint_name}, encoded})
+      :ok
+    end
   end
 
   @doc """
-  Get all joint positions as a map.
+  Get every joint's configuration as a map.
+
+  Every joint in the robot is present, shaped to its own type.
 
   ## Examples
 
-      iex> positions = BB.Robot.State.get_all_positions(state)
-      %{shoulder: 0.0, elbow: 0.5, wrist: -0.3}
+      iex> BB.Robot.State.get_all_configurations(state)
+      %{shoulder: 0.5, elbow: -0.2, base: %BB.Math.Transform{}}
   """
-  @spec get_all_positions(t()) :: %{atom() => float()}
-  def get_all_positions(%__MODULE__{table: table, robot: robot}) do
-    robot.joints
-    |> Map.keys()
-    |> Map.new(fn joint_name ->
-      case :ets.lookup(table, {:position, joint_name}) do
-        [{{:position, ^joint_name}, value}] -> {joint_name, value}
-        [] -> {joint_name, 0.0}
-      end
-    end)
-  end
+  @spec get_all_configurations(t()) :: %{atom() => configuration()}
+  def get_all_configurations(%__MODULE__{} = state), do: read_all(state, :configuration)
 
   @doc """
-  Get all joint velocities as a map.
+  Get every joint's velocity as a map.
   """
-  @spec get_all_velocities(t()) :: %{atom() => float()}
-  def get_all_velocities(%__MODULE__{table: table, robot: robot}) do
-    robot.joints
-    |> Map.keys()
-    |> Map.new(fn joint_name ->
-      case :ets.lookup(table, {:velocity, joint_name}) do
-        [{{:velocity, ^joint_name}, value}] -> {joint_name, value}
-        [] -> {joint_name, 0.0}
-      end
-    end)
-  end
+  @spec get_all_velocities(t()) :: %{atom() => velocity()}
+  def get_all_velocities(%__MODULE__{} = state), do: read_all(state, :velocity)
 
   @doc """
-  Set multiple joint positions at once.
+  Set multiple joint configurations at once.
+
+  Every value is validated before anything is written, so a rejected map leaves
+  the table untouched rather than applying part of itself.
 
   ## Examples
 
-      :ok = BB.Robot.State.set_positions(state, %{
+      :ok = BB.Robot.State.set_configurations(state, %{
         shoulder: 0.5,
         elbow: -0.3,
-        wrist: 0.0
+        base: transform
       })
   """
-  @spec set_positions(t(), %{atom() => float()}) :: :ok
-  def set_positions(%__MODULE__{table: table}, positions) when is_map(positions) do
-    entries =
-      Enum.map(positions, fn {joint_name, position} ->
-        {{:position, joint_name}, position / 1}
-      end)
-
-    :ets.insert(table, entries)
-    :ok
+  @spec set_configurations(t(), %{atom() => configuration()}) ::
+          :ok | {:error, UnknownJoint.t() | JointConfig.t()}
+  def set_configurations(%__MODULE__{} = state, configurations) when is_map(configurations) do
+    write_all(state, :configuration, configurations)
   end
 
   @doc """
   Set multiple joint velocities at once.
   """
-  @spec set_velocities(t(), %{atom() => float()}) :: :ok
-  def set_velocities(%__MODULE__{table: table}, velocities) when is_map(velocities) do
-    entries =
-      Enum.map(velocities, fn {joint_name, velocity} ->
-        {{:velocity, joint_name}, velocity / 1}
-      end)
-
-    :ets.insert(table, entries)
-    :ok
+  @spec set_velocities(t(), %{atom() => velocity()}) ::
+          :ok | {:error, UnknownJoint.t() | JointConfig.t()}
+  def set_velocities(%__MODULE__{} = state, velocities) when is_map(velocities) do
+    write_all(state, :velocity, velocities)
   end
 
   @doc """
-  Reset all joints to their default positions (0.0).
+  Reset all joints to their identity configurations and zero velocities.
   """
   @spec reset(t()) :: :ok
   def reset(%__MODULE__{} = state) do
@@ -199,12 +227,12 @@ defmodule BB.Robot.State do
   end
 
   @doc """
-  Get the positions of joints along a path from root to a target link.
+  Get the configurations of joints along a path from root to a target link.
 
-  Returns a list of {joint_name, position} tuples in traversal order.
+  Returns a list of `{joint_name, configuration}` tuples in traversal order.
   """
-  @spec get_chain_positions(t(), atom()) :: [{atom(), float()}]
-  def get_chain_positions(%__MODULE__{robot: robot} = state, target_link) do
+  @spec get_chain_configurations(t(), atom()) :: [{atom(), configuration()}]
+  def get_chain_configurations(%__MODULE__{robot: robot} = state, target_link) do
     case Robot.path_to(robot, target_link) do
       {:error, _} ->
         []
@@ -213,7 +241,8 @@ defmodule BB.Robot.State do
         path
         |> Enum.filter(&Map.has_key?(robot.joints, &1))
         |> Enum.map(fn joint_name ->
-          {joint_name, get_joint_position(state, joint_name) || 0.0}
+          {:ok, configuration} = get_configuration(state, joint_name)
+          {joint_name, configuration}
         end)
     end
   end
@@ -384,12 +413,10 @@ defmodule BB.Robot.State do
 
   defp initialise_joints(%__MODULE__{table: table, robot: robot}) do
     joint_entries =
-      robot.joints
-      |> Map.keys()
-      |> Enum.flat_map(fn joint_name ->
+      Enum.flat_map(robot.joints, fn {joint_name, joint} ->
         [
-          {{:position, joint_name}, 0.0},
-          {{:velocity, joint_name}, 0.0}
+          {{:configuration, joint_name}, encoded_default(joint.type, :configuration)},
+          {{:velocity, joint_name}, encoded_default(joint.type, :velocity)}
         ]
       end)
 
@@ -397,4 +424,134 @@ defmodule BB.Robot.State do
     entries = [{:robot_state, :idle} | joint_entries]
     :ets.insert(table, entries)
   end
+
+  defp fetch_joint(%__MODULE__{robot: robot}, joint_name), do: Robot.get_joint(robot, joint_name)
+
+  defp read(table, kind, joint_name, joint_type) do
+    case :ets.lookup(table, {kind, joint_name}) do
+      [{{^kind, ^joint_name}, stored}] -> decode(joint_type, kind, stored)
+      [] -> decode(joint_type, kind, encoded_default(joint_type, kind))
+    end
+  end
+
+  defp read_all(%__MODULE__{table: table, robot: robot}, kind) do
+    Map.new(robot.joints, fn {joint_name, joint} ->
+      {joint_name, read(table, kind, joint_name, joint.type)}
+    end)
+  end
+
+  # Every value is encoded before anything is inserted, so a map containing one
+  # bad entry leaves the table untouched rather than applying its valid half.
+  defp write_all(%__MODULE__{table: table} = state, kind, values) do
+    with {:ok, entries} <- encode_all(state, kind, values) do
+      :ets.insert(table, entries)
+      :ok
+    end
+  end
+
+  defp encode_all(state, kind, values) do
+    Enum.reduce_while(values, {:ok, []}, fn {joint_name, value}, {:ok, encoded} ->
+      with {:ok, joint} <- fetch_joint(state, joint_name),
+           {:ok, value} <- encode(joint, kind, value) do
+        {:cont, {:ok, [{{kind, joint_name}, value} | encoded]}}
+      else
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  # ----------------------------------------------------------------------------
+  # Storage encoding
+  #
+  # Nothing backend-specific may reach ETS. A `%Nx.Tensor{}` struct carries
+  # backend state: fine under `Nx.BinaryBackend`, but under EXLA it is a
+  # reference to accelerator memory, which is not meaningfully shareable through
+  # a table and may be invalidated out from under a reader. So tensor-backed
+  # values are stored as their raw bytes.
+  #
+  # Those bytes are also the only lossless option. Decomposing a 4x4 to a
+  # quaternion and translation is a `sqrt` with a branch on the trace, 16 numbers
+  # to 7 is not a bijection, and the round-trip would run on *every read* — so
+  # error would accumulate rather than being a one-off. `Nx.to_binary/1` and
+  # `Nx.from_binary/2` are bit-exact and involve no arithmetic at all.
+  # ----------------------------------------------------------------------------
+
+  # A fixed joint's configuration space is a single point, so the one thing you
+  # may assign is that point. Accepting it keeps read-modify-write working — the
+  # value comes straight back out of `get_all_configurations/1` — while a nonzero
+  # angle or a `Transform` aimed at a welded joint is still caught. Forward
+  # kinematics ignores the value either way, since both motion masks are zero.
+  defp encode(%{type: :fixed}, _kind, value) when is_number(value) and value == 0, do: {:ok, 0.0}
+
+  defp encode(%{type: type}, _kind, value)
+       when type in [:revolute, :continuous, :prismatic] and is_number(value) do
+    {:ok, value / 1}
+  end
+
+  defp encode(%{type: :planar}, :configuration, %Transform2D{} = value) do
+    {:ok, {value.x, value.y, value.theta}}
+  end
+
+  defp encode(%{type: :planar}, :velocity, %Twist2D{} = value) do
+    {:ok, {value.vx, value.vy, value.omega}}
+  end
+
+  defp encode(%{type: :floating}, :configuration, %Transform{} = value) do
+    {:ok, value |> Transform.tensor() |> Nx.to_binary()}
+  end
+
+  defp encode(%{type: :floating}, :velocity, %Twist{linear: linear, angular: angular}) do
+    {:ok, Nx.to_binary(Nx.concatenate([Vec3.tensor(linear), Vec3.tensor(angular)]))}
+  end
+
+  defp encode(joint, kind, value), do: {:error, invalid(joint, kind, value)}
+
+  defp decode(type, _kind, stored) when type in [:fixed, :revolute, :continuous, :prismatic] do
+    stored
+  end
+
+  defp decode(:planar, :configuration, {x, y, theta}), do: Transform2D.new(x, y, theta)
+  defp decode(:planar, :velocity, {vx, vy, omega}), do: %Twist2D{vx: vx, vy: vy, omega: omega}
+
+  defp decode(:floating, :configuration, bytes) do
+    bytes |> Nx.from_binary(:f64) |> Nx.reshape({4, 4}) |> Transform.from_tensor()
+  end
+
+  defp decode(:floating, :velocity, bytes) do
+    components = Nx.from_binary(bytes, :f64)
+
+    %Twist{
+      linear: components |> Nx.slice([0], [3]) |> Vec3.from_tensor(),
+      angular: components |> Nx.slice([3], [3]) |> Vec3.from_tensor()
+    }
+  end
+
+  defp encoded_default(:planar, :configuration), do: {0.0, 0.0, 0.0}
+  defp encoded_default(:planar, :velocity), do: {0.0, 0.0, 0.0}
+
+  defp encoded_default(:floating, :configuration) do
+    Transform.identity() |> Transform.tensor() |> Nx.to_binary()
+  end
+
+  defp encoded_default(:floating, :velocity) do
+    Nx.to_binary(Nx.broadcast(Nx.tensor(0.0, type: :f64), {6}))
+  end
+
+  defp encoded_default(_type, _kind), do: 0.0
+
+  defp invalid(%{name: name, type: type}, kind, value) do
+    JointConfig.exception(
+      joint: name,
+      field: kind,
+      value: value,
+      expected: expected(type, kind)
+    )
+  end
+
+  defp expected(:fixed, _kind), do: 0.0
+  defp expected(:planar, :configuration), do: Transform2D
+  defp expected(:planar, :velocity), do: Twist2D
+  defp expected(:floating, :configuration), do: Transform
+  defp expected(:floating, :velocity), do: Twist
+  defp expected(_type, _kind), do: :float
 end

--- a/lib/bb/robot/topology.ex
+++ b/lib/bb/robot/topology.ex
@@ -8,9 +8,18 @@ defmodule BB.Robot.Topology do
 
   This struct contains ordering information that allows:
   - Forward kinematics to process joints in the correct order
-  - Path lookup from root to any node
+  - Path lookup between any two nodes
   - Depth information for tree operations
+
+  Paths are root-relative and interleave links and joints, starting and ending
+  with the node they name — `[:base, :shoulder, :upper_arm, :elbow, :forearm]`.
+
+  Lookups here have no robot name to attribute their errors to. `BB.Robot`
+  delegates to them and fills the name in.
   """
+
+  alias BB.Error.Kinematics.NotAnAncestor
+  alias BB.Error.Kinematics.UnknownLink
 
   defstruct [
     :link_order,
@@ -31,9 +40,12 @@ defmodule BB.Robot.Topology do
 
   The root link has depth 0. Each joint/link pair adds 1 to the depth.
   """
-  @spec depth_of(t(), atom()) :: non_neg_integer() | nil
+  @spec depth_of(t(), atom()) :: {:ok, non_neg_integer()} | {:error, UnknownLink.t()}
   def depth_of(%__MODULE__{depth: depth}, name) do
-    Map.get(depth, name)
+    case Map.fetch(depth, name) do
+      {:ok, value} -> {:ok, value}
+      :error -> {:error, UnknownLink.exception(link: name)}
+    end
   end
 
   @doc """
@@ -41,9 +53,35 @@ defmodule BB.Robot.Topology do
 
   Returns a list of link/joint names from the root to the given node.
   """
-  @spec path_to(t(), atom()) :: [atom()] | nil
+  @spec path_to(t(), atom()) :: {:ok, [atom()]} | {:error, UnknownLink.t()}
   def path_to(%__MODULE__{paths: paths}, name) do
-    Map.get(paths, name)
+    case Map.fetch(paths, name) do
+      {:ok, path} -> {:ok, path}
+      :error -> {:error, UnknownLink.exception(link: name)}
+    end
+  end
+
+  @doc """
+  Get the path from a source node down to a target node.
+
+  Restricted to the case where `source` is an ancestor of `target`, which makes
+  this a prefix drop on the precomputed paths. The result starts at `source` and
+  ends at `target`; a source equal to the target gives `{:ok, [source]}`.
+
+  Fails with `BB.Error.Kinematics.NotAnAncestor` when the source sits somewhere
+  other than above the target, carrying their nearest common ancestor. That
+  ancestor always exists: `BB.Dsl.TopologyTransformer` rejects any topology
+  without exactly one root link and the DSL's nesting makes cycles impossible,
+  so the topology is a single tree in which any two nodes share at least the
+  root.
+  """
+  @spec path_between(t(), atom(), atom()) ::
+          {:ok, [atom()]} | {:error, UnknownLink.t() | NotAnAncestor.t()}
+  def path_between(%__MODULE__{paths: paths}, source, target) do
+    with {:ok, source_path} <- fetch_path(paths, source, :source),
+         {:ok, target_path} <- fetch_path(paths, target, :target) do
+      descend(source_path, target_path, source, target)
+    end
   end
 
   @doc """
@@ -52,10 +90,7 @@ defmodule BB.Robot.Topology do
   @spec leaf_links(t(), BB.Robot.t()) :: [atom()]
   def leaf_links(%__MODULE__{link_order: link_order}, robot) do
     Enum.filter(link_order, fn link_name ->
-      case BB.Robot.get_link(robot, link_name) do
-        %BB.Robot.Link{child_joints: []} -> true
-        _ -> false
-      end
+      match?({:ok, %BB.Robot.Link{child_joints: []}}, BB.Robot.get_link(robot, link_name))
     end)
   end
 
@@ -67,5 +102,37 @@ defmodule BB.Robot.Topology do
     depth
     |> Map.values()
     |> Enum.max(fn -> 0 end)
+  end
+
+  defp fetch_path(paths, name, role) do
+    case Map.fetch(paths, name) do
+      {:ok, path} -> {:ok, path}
+      :error -> {:error, UnknownLink.exception(link: name, role: role)}
+    end
+  end
+
+  defp descend(source_path, target_path, source, target) do
+    if List.starts_with?(target_path, source_path) do
+      {:ok, Enum.drop(target_path, length(source_path) - 1)}
+    else
+      {:error,
+       NotAnAncestor.exception(
+         source_link: source,
+         target_link: target,
+         common_ancestor: nearest_common_ancestor(source_path, target_path)
+       )}
+    end
+  end
+
+  # Paths alternate link, joint, link, …, so every even index is a link and the
+  # deepest common link is the last of them. Both paths start at the same root,
+  # so there is always at least one.
+  defp nearest_common_ancestor(source_path, target_path) do
+    source_path
+    |> Enum.zip(target_path)
+    |> Enum.take_while(fn {source, target} -> source == target end)
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.take_every(2)
+    |> List.last()
   end
 end

--- a/lib/bb/transmission/resolver.ex
+++ b/lib/bb/transmission/resolver.ex
@@ -130,27 +130,22 @@ defmodule BB.Transmission.Resolver do
 
   defp joint_type_for_attachment(robot, :actuator, name) do
     case robot.actuators[name] do
-      %{joint: joint_name} ->
-        case Robot.get_joint(robot, joint_name) do
-          %{type: type} -> type
-          _ -> nil
-        end
-
-      _ ->
-        nil
+      %{joint: joint_name} -> joint_type(robot, joint_name)
+      _ -> nil
     end
   end
 
   defp joint_type_for_attachment(robot, :sensor, name) do
     case robot.sensors[name] do
-      %{attached_to: {:joint, joint_name}} ->
-        case Robot.get_joint(robot, joint_name) do
-          %{type: type} -> type
-          _ -> nil
-        end
+      %{attached_to: {:joint, joint_name}} -> joint_type(robot, joint_name)
+      _ -> nil
+    end
+  end
 
-      _ ->
-        nil
+  defp joint_type(robot, joint_name) do
+    case Robot.get_joint(robot, joint_name) do
+      {:ok, %{type: type}} -> type
+      {:error, _} -> nil
     end
   end
 

--- a/test/bb/actuator/addressing_test.exs
+++ b/test/bb/actuator/addressing_test.exs
@@ -52,16 +52,17 @@ defmodule BB.Actuator.AddressingTest do
 
   describe "BB.Robot.actuator_path/2" do
     test "resolves an actuator directly under the root link's joint" do
-      assert BB.Robot.actuator_path(Robot.robot(), :motor) == [:base, :shoulder, :motor]
+      assert BB.Robot.actuator_path(Robot.robot(), :motor) == {:ok, [:base, :shoulder, :motor]}
     end
 
     test "resolves an actuator nested deeper in the topology" do
       assert BB.Robot.actuator_path(Robot.robot(), :forearm_motor) ==
-               [:base, :shoulder, :arm, :elbow, :forearm_motor]
+               {:ok, [:base, :shoulder, :arm, :elbow, :forearm_motor]}
     end
 
-    test "returns nil for an unknown actuator" do
-      assert BB.Robot.actuator_path(Robot.robot(), :nonexistent) == nil
+    test "reports an unknown actuator as an actuator, not a link" do
+      assert {:error, %BB.Error.Kinematics.UnknownActuator{actuator: :nonexistent}} =
+               BB.Robot.actuator_path(Robot.robot(), :nonexistent)
     end
 
     test "agrees with the path the framework injects into the driver" do

--- a/test/bb/command/move_to_test.exs
+++ b/test/bb/command/move_to_test.exs
@@ -92,6 +92,42 @@ defmodule BB.Command.MoveToTest do
                call_command(goal, context)
     end
 
+    # A command reports a missing `:source_link` as an invalid argument rather
+    # than letting a `KeyError` escape from inside BB.Motion.
+    test "returns error when source_link is missing in single-target mode" do
+      robot = MoveToTestRobot.robot()
+      {:ok, robot_state} = RobotState.new(robot)
+
+      context = %Context{
+        robot_module: MoveToTestRobot,
+        robot: robot,
+        robot_state: robot_state,
+        execution_id: make_ref()
+      }
+
+      goal = %{target: Vec3.new(0.3, 0.0, 0.0), target_link: :tip, solver: MockSolver}
+
+      assert {:error, %InvalidCommand{argument: :source_link, reason: "required"}} =
+               call_command(goal, context)
+    end
+
+    test "returns error when source_link is missing in multi-target mode" do
+      robot = MoveToTestRobot.robot()
+      {:ok, robot_state} = RobotState.new(robot)
+
+      context = %Context{
+        robot_module: MoveToTestRobot,
+        robot: robot,
+        robot_state: robot_state,
+        execution_id: make_ref()
+      }
+
+      goal = %{targets: %{tip: Vec3.new(0.3, 0.0, 0.0)}, solver: MockSolver}
+
+      assert {:error, %InvalidCommand{argument: :source_link, reason: "required"}} =
+               call_command(goal, context)
+    end
+
     test "returns ok with metadata on success" do
       start_supervised!(MoveToTestRobot)
 
@@ -117,6 +153,7 @@ defmodule BB.Command.MoveToTest do
       goal = %{
         target: Vec3.new(0.3, 0.0, 0.0),
         target_link: :tip,
+        source_link: :base_link,
         solver: MockSolver
       }
 
@@ -146,6 +183,7 @@ defmodule BB.Command.MoveToTest do
       goal = %{
         target: Vec3.new(10.0, 0.0, 0.0),
         target_link: :tip,
+        source_link: :base_link,
         solver: MockSolver
       }
 
@@ -173,6 +211,7 @@ defmodule BB.Command.MoveToTest do
       goal = %{
         target: Vec3.new(0.3, 0.0, 0.0),
         target_link: :tip,
+        source_link: :base_link,
         solver: MockSolver,
         max_iterations: 100,
         tolerance: 0.01,
@@ -181,7 +220,7 @@ defmodule BB.Command.MoveToTest do
 
       {:ok, _meta} = call_command(goal, context)
 
-      {_robot, _state, _link, _target, opts} = MockSolver.last_call()
+      {_robot, _state, _source, _link, _target, opts} = MockSolver.last_call()
       assert opts[:max_iterations] == 100
       assert opts[:tolerance] == 0.01
       assert opts[:respect_limits] == false
@@ -206,6 +245,7 @@ defmodule BB.Command.MoveToTest do
 
       goal = %{
         targets: %{tip: {0.3, 0.0, 0.0}},
+        source_link: :base_link,
         solver: MockSolver
       }
 

--- a/test/bb/dsl/joint_axis_validation_test.exs
+++ b/test/bb/dsl/joint_axis_validation_test.exs
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Dsl.JointAxisValidationTest do
+  @moduledoc """
+  A joint's `axis` means something different for each type, and for two of them it
+  means nothing at all. `BB.Dsl.TopologyTransformer` owns the checks, alongside
+  the existing "limits are required for revolute and prismatic joints" rule.
+  """
+  use ExUnit.Case, async: true
+
+  alias BB.Math.Transform
+  alias BB.Math.Vec3
+  alias BB.Robot.Kinematics
+
+  describe "planar joints" do
+    test "accept an axis, which is the plane's surface normal" do
+      defmodule PlanarWithAxis do
+        use BB
+
+        topology do
+          link :odom do
+            joint :base do
+              type(:planar)
+
+              axis do
+              end
+
+              link(:chassis)
+            end
+          end
+        end
+      end
+
+      {:ok, joint} = BB.Robot.get_joint(PlanarWithAxis.robot(), :base)
+      assert joint.axis == {0.0, 0.0, 1.0}
+    end
+
+    # Without a normal there is no plane, so defaulting one would silently pick a
+    # plane that has nothing to do with the robot.
+    test "are rejected without an axis" do
+      error =
+        assert_raise Spark.Error.DslError, fn ->
+          defmodule PlanarWithoutAxis do
+            use BB
+
+            topology do
+              link :odom do
+                joint :base do
+                  type(:planar)
+
+                  link(:chassis)
+                end
+              end
+            end
+          end
+        end
+
+      message = Exception.message(error)
+
+      assert message =~ "An axis must be present for planar joints"
+      assert message =~ "surface normal"
+    end
+  end
+
+  describe "floating joints" do
+    test "are accepted without an axis" do
+      defmodule FloatingWithoutAxis do
+        use BB
+
+        topology do
+          link :world do
+            joint :base do
+              type(:floating)
+
+              link(:airframe)
+            end
+          end
+        end
+      end
+
+      assert FloatingWithoutAxis.robot()
+    end
+
+    # Six degrees of freedom leave no distinguished direction, so accepting an
+    # axis would let a user believe they had constrained something.
+    test "are rejected with an axis" do
+      error =
+        assert_raise Spark.Error.DslError, fn ->
+          defmodule FloatingWithAxis do
+            use BB
+
+            topology do
+              link :world do
+                joint :base do
+                  type(:floating)
+
+                  axis do
+                  end
+
+                  link(:airframe)
+                end
+              end
+            end
+          end
+        end
+
+      message = Exception.message(error)
+
+      assert message =~ "Cannot set an axis when parent joint is floating"
+      # The message should point at the type the user probably wanted.
+      assert message =~ ":planar"
+    end
+  end
+
+  describe "fixed joints" do
+    test "are rejected with an axis, and say why" do
+      error =
+        assert_raise Spark.Error.DslError, fn ->
+          defmodule FixedWithAxis do
+            use BB
+
+            topology do
+              link :base do
+                joint :j do
+                  type(:fixed)
+
+                  axis do
+                  end
+
+                  link(:child)
+                end
+              end
+            end
+          end
+        end
+
+      # This rule already existed but built its error with `module:` where
+      # `message:` was meant, so the diagnostic read `nil`.
+      assert Exception.message(error) =~ "Cannot set an axis when parent joint is fixed"
+    end
+  end
+
+  describe "single-DoF joints" do
+    test "may still omit their axis entirely" do
+      defmodule RevoluteWithoutAxis do
+        use BB
+        import BB.Unit
+
+        topology do
+          link :base do
+            joint :j do
+              type(:revolute)
+
+              limit do
+                effort(~u(10 newton_meter))
+                velocity(~u(90 degree_per_second))
+              end
+
+              link(:child)
+            end
+          end
+        end
+      end
+
+      robot = RevoluteWithoutAxis.robot()
+      {:ok, joint} = BB.Robot.get_joint(robot, :j)
+
+      # An omitted axis stays `nil` on the built joint; the Z default is applied
+      # by `BB.Robot.Kinematics` at use time, not baked in by the builder. So a
+      # rotation about it must still behave as a rotation about Z.
+      assert joint.axis == nil
+
+      rotated =
+        robot
+        |> Kinematics.forward_kinematics(%{j: :math.pi() / 2}, :child)
+        |> Transform.apply_to_point(Vec3.unit_x())
+
+      assert Enum.map(Vec3.to_list(rotated), &Float.round(&1, 9)) == [0.0, 1.0, 0.0]
+    end
+  end
+
+  describe "nested joints" do
+    test "are checked below the root, not just at it" do
+      assert_raise Spark.Error.DslError, ~r/floating/, fn ->
+        defmodule NestedFloatingWithAxis do
+          use BB
+          import BB.Unit
+
+          topology do
+            link :base do
+              joint :shallow do
+                type(:revolute)
+
+                limit do
+                  effort(~u(10 newton_meter))
+                  velocity(~u(90 degree_per_second))
+                end
+
+                link :middle do
+                  joint :deep do
+                    type(:floating)
+
+                    axis do
+                    end
+
+                    link(:tip)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/bb/error/kinematics_test.exs
+++ b/test/bb/error/kinematics_test.exs
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Error.KinematicsTest do
+  use ExUnit.Case, async: true
+
+  alias BB.Error.Kinematics.NoParentJoint
+  alias BB.Error.Kinematics.NotAnAncestor
+  alias BB.Error.Kinematics.UnknownActuator
+  alias BB.Error.Kinematics.UnknownJoint
+  alias BB.Error.Kinematics.UnknownLink
+
+  describe "UnknownLink" do
+    test "carries link, role and robot" do
+      err = UnknownLink.exception(link: :gripper, role: :target, robot: MyRobot)
+
+      assert err.link == :gripper
+      assert err.role == :target
+      assert err.robot == MyRobot
+    end
+
+    test "is an error" do
+      assert BB.Error.severity(UnknownLink.exception(link: :gripper)) == :error
+    end
+
+    test "names the role so an unknown source isn't reported as a target" do
+      source = UnknownLink.exception(link: :body, role: :source)
+      target = UnknownLink.exception(link: :body, role: :target)
+
+      assert UnknownLink.message(source) =~ "source link"
+      assert UnknownLink.message(target) =~ "target link"
+    end
+
+    test "omits the role when a lookup takes only one link" do
+      message = UnknownLink.message(UnknownLink.exception(link: :gripper))
+
+      assert message =~ "Unknown link: :gripper"
+      refute message =~ "source"
+      refute message =~ "target"
+    end
+
+    test "message includes the robot when known" do
+      err = UnknownLink.exception(link: :gripper, robot: MyRobot)
+      assert UnknownLink.message(err) =~ "MyRobot"
+    end
+  end
+
+  describe "UnknownJoint" do
+    test "carries joint and robot" do
+      err = UnknownJoint.exception(joint: :elbow, robot: MyRobot)
+
+      assert err.joint == :elbow
+      assert err.robot == MyRobot
+    end
+
+    test "is an error" do
+      assert BB.Error.severity(UnknownJoint.exception(joint: :elbow)) == :error
+    end
+
+    test "message names the joint" do
+      assert UnknownJoint.message(UnknownJoint.exception(joint: :elbow)) =~
+               "Unknown joint: :elbow"
+    end
+  end
+
+  describe "UnknownActuator" do
+    test "carries actuator and robot" do
+      err = UnknownActuator.exception(actuator: :pan_servo, robot: MyRobot)
+
+      assert err.actuator == :pan_servo
+      assert err.robot == MyRobot
+    end
+
+    test "is an error" do
+      assert BB.Error.severity(UnknownActuator.exception(actuator: :pan_servo)) == :error
+    end
+
+    test "message names the actuator" do
+      err = UnknownActuator.exception(actuator: :pan_servo)
+      assert UnknownActuator.message(err) =~ "Unknown actuator: :pan_servo"
+    end
+  end
+
+  describe "NoParentJoint" do
+    test "carries the link" do
+      assert NoParentJoint.exception(link: :world).link == :world
+    end
+
+    test "is an error" do
+      assert BB.Error.severity(NoParentJoint.exception(link: :world)) == :error
+    end
+
+    test "message says the link is the root rather than that it doesn't exist" do
+      message = NoParentJoint.message(NoParentJoint.exception(link: :world))
+
+      assert message =~ ":world"
+      assert message =~ "root"
+      refute message =~ "not found"
+    end
+  end
+
+  describe "NotAnAncestor" do
+    test "carries both links and the common ancestor" do
+      err =
+        NotAnAncestor.exception(
+          source_link: :left_gripper,
+          target_link: :right_gripper,
+          common_ancestor: :torso
+        )
+
+      assert err.source_link == :left_gripper
+      assert err.target_link == :right_gripper
+      assert err.common_ancestor == :torso
+    end
+
+    test "is an error" do
+      err =
+        NotAnAncestor.exception(
+          source_link: :a,
+          target_link: :b,
+          common_ancestor: :root
+        )
+
+      assert BB.Error.severity(err) == :error
+    end
+
+    # The point of carrying the ancestor is that the message names the link the
+    # caller should have passed, rather than just reporting a failure.
+    test "message names the link the caller should have passed" do
+      err =
+        NotAnAncestor.exception(
+          source_link: :left_gripper,
+          target_link: :right_gripper,
+          common_ancestor: :torso
+        )
+
+      message = NotAnAncestor.message(err)
+
+      assert message =~ ":left_gripper is not an ancestor of :right_gripper"
+      assert message =~ "nearest common ancestor is :torso"
+    end
+  end
+end

--- a/test/bb/joint_test.exs
+++ b/test/bb/joint_test.exs
@@ -368,7 +368,10 @@ defmodule BB.JointTest do
       assert joint.name == :planar_joint
     end
 
-    test "planar joint with optional axis compiles" do
+    # A planar joint's axis is the surface normal of the plane it moves in, so it
+    # is required rather than optional — an empty block gives the horizontal
+    # plane, which is what a ground vehicle wants.
+    test "planar joint axis defaults to the horizontal plane's normal" do
       [link] = Info.topology(PlanarRobot)
       [joint] = link.joints
       assert is_struct(joint.axis, Axis)
@@ -383,6 +386,9 @@ defmodule BB.JointTest do
         link :base_link do
           joint :planar_joint do
             type :planar
+
+            axis do
+            end
 
             dynamics do
               damping ~u(0.5 newton_second_per_meter)

--- a/test/bb/math/transform2d_test.exs
+++ b/test/bb/math/transform2d_test.exs
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Math.Transform2DTest do
+  use ExUnit.Case, async: true
+  doctest BB.Math.Transform2D
+
+  alias BB.Math.Transform
+  alias BB.Math.Transform2D
+  alias BB.Math.Vec3
+
+  @normals [
+    Vec3.unit_x(),
+    Vec3.unit_y(),
+    Vec3.unit_z(),
+    Vec3.normalise(Vec3.new(1.0, 1.0, 1.0)),
+    Vec3.normalise(Vec3.new(1.0, 0.0, 2.0))
+  ]
+
+  defp matrix(%Transform{} = t), do: t |> Transform.tensor() |> Nx.to_flat_list()
+
+  defp assert_transforms_equal(a, b) do
+    Enum.zip(matrix(a), matrix(b))
+    |> Enum.each(fn {left, right} -> assert_in_delta left, right, 1.0e-12 end)
+  end
+
+  describe "new/3" do
+    test "coerces integers to floats" do
+      assert %Transform2D{x: 1.0, y: 2.0, theta: +0.0} = Transform2D.new(1, 2, 0)
+    end
+  end
+
+  describe "compose/2" do
+    test "identity is a left and right unit" do
+      t = Transform2D.new(1.0, 2.0, 0.5)
+
+      assert Transform2D.compose(Transform2D.identity(), t) == t
+      assert Transform2D.compose(t, Transform2D.identity()) == t
+    end
+
+    test "rotates the second transform's translation by the first's angle" do
+      a = Transform2D.new(1.0, 0.0, :math.pi() / 2)
+      b = Transform2D.new(1.0, 0.0, 0.0)
+
+      c = Transform2D.compose(a, b)
+
+      assert_in_delta c.x, 1.0, 1.0e-12
+      assert_in_delta c.y, 1.0, 1.0e-12
+    end
+  end
+
+  describe "inverse/1" do
+    test "composes to the identity" do
+      t = Transform2D.new(1.5, -2.5, 0.9)
+      c = Transform2D.compose(t, Transform2D.inverse(t))
+
+      assert_in_delta c.x, 0.0, 1.0e-12
+      assert_in_delta c.y, 0.0, 1.0e-12
+      assert_in_delta c.theta, 0.0, 1.0e-12
+    end
+  end
+
+  describe "to_transform/2" do
+    test "a Z normal reduces to the XY plane with theta as yaw" do
+      t = Transform2D.to_transform(Transform2D.new(1.0, 2.0, :math.pi() / 2), Vec3.unit_z())
+
+      translation = t |> Transform.get_translation() |> Vec3.to_list()
+      assert Enum.map(translation, &Float.round(&1, 9)) == [1.0, 2.0, 0.0]
+
+      rotated = Transform.apply_to_point(t, Vec3.unit_x())
+      assert Enum.map(Vec3.to_list(rotated), &Float.round(&1, 9)) == [1.0, 3.0, 0.0]
+    end
+
+    test "the plane basis is orthonormal and right-handed about the normal" do
+      for normal <- @normals do
+        u = in_plane_axis(Transform2D.new(1.0, 0.0, 0.0), normal)
+        v = in_plane_axis(Transform2D.new(0.0, 1.0, 0.0), normal)
+
+        assert_in_delta Vec3.magnitude(u), 1.0, 1.0e-12
+        assert_in_delta Vec3.magnitude(v), 1.0, 1.0e-12
+        assert_in_delta Vec3.dot(u, normal), 0.0, 1.0e-12
+        assert_in_delta Vec3.dot(v, normal), 0.0, 1.0e-12
+        assert_in_delta Vec3.dot(u, v), 0.0, 1.0e-12
+
+        Enum.zip(Vec3.to_list(Vec3.cross(u, v)), Vec3.to_list(normal))
+        |> Enum.each(fn {left, right} -> assert_in_delta left, right, 1.0e-12 end)
+      end
+    end
+
+    test "theta rotates about the normal, leaving it fixed" do
+      for normal <- @normals do
+        t = Transform2D.to_transform(Transform2D.new(0.0, 0.0, 0.7), normal)
+
+        Enum.zip(Vec3.to_list(Transform.apply_to_point(t, normal)), Vec3.to_list(normal))
+        |> Enum.each(fn {left, right} -> assert_in_delta left, right, 1.0e-12 end)
+      end
+    end
+
+    # Lifting the composition must equal composing the liftings, or a planar
+    # joint's kinematics would disagree with its own configuration algebra.
+    test "agrees with Transform.compose/2" do
+      a = Transform2D.new(1.0, 2.0, 0.7)
+      b = Transform2D.new(-0.5, 0.25, -0.3)
+
+      for normal <- @normals do
+        assert_transforms_equal(
+          Transform2D.to_transform(Transform2D.compose(a, b), normal),
+          Transform.compose(
+            Transform2D.to_transform(a, normal),
+            Transform2D.to_transform(b, normal)
+          )
+        )
+      end
+    end
+
+    test "agrees with Transform.inverse/1" do
+      t = Transform2D.new(1.5, -2.5, 0.9)
+
+      for normal <- @normals do
+        assert_transforms_equal(
+          Transform2D.to_transform(Transform2D.inverse(t), normal),
+          Transform.inverse(Transform2D.to_transform(t, normal))
+        )
+      end
+    end
+
+    test "the identity lifts to the identity" do
+      for normal <- @normals do
+        assert_transforms_equal(
+          Transform2D.to_transform(Transform2D.identity(), normal),
+          Transform.identity()
+        )
+      end
+    end
+
+    test "normalises the given normal" do
+      unit = Transform2D.to_transform(Transform2D.new(1.0, 2.0, 0.4), Vec3.unit_z())
+      scaled = Transform2D.to_transform(Transform2D.new(1.0, 2.0, 0.4), Vec3.new(0.0, 0.0, 5.0))
+
+      assert_transforms_equal(unit, scaled)
+    end
+  end
+
+  defp in_plane_axis(%Transform2D{} = t, normal) do
+    t |> Transform2D.to_transform(normal) |> Transform.get_translation()
+  end
+end

--- a/test/bb/message/geometry/twist2d_test.exs
+++ b/test/bb/message/geometry/twist2d_test.exs
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Geometry.Twist2DTest do
+  use ExUnit.Case, async: true
+  doctest BB.Message.Geometry.Twist2D
+
+  alias BB.Message
+  alias BB.Message.Geometry.Twist2D
+
+  test "creates a twist message" do
+    {:ok, msg} = Twist2D.new(:chassis, 0.5, 0.0, 0.1)
+
+    assert %Message{payload: %Twist2D{vx: 0.5, vy: +0.0, omega: 0.1}} = msg
+    assert msg.frame_id == :chassis
+  end
+
+  test "coerces integers to floats" do
+    {:ok, msg} = Twist2D.new(:chassis, 1, 2, 3)
+
+    assert %Message{payload: %Twist2D{vx: 1.0, vy: 2.0, omega: 3.0}} = msg
+  end
+
+  test "requires every component" do
+    assert {:error, _} = Twist2D.new(:chassis, vx: 0.5, vy: 0.0)
+  end
+end

--- a/test/bb/message/geometry/wrench2d_test.exs
+++ b/test/bb/message/geometry/wrench2d_test.exs
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Message.Geometry.Wrench2DTest do
+  use ExUnit.Case, async: true
+  doctest BB.Message.Geometry.Wrench2D
+
+  alias BB.Message
+  alias BB.Message.Geometry.Wrench2D
+
+  test "creates a wrench message" do
+    {:ok, msg} = Wrench2D.new(:chassis, 12.0, 0.0, 0.4)
+
+    assert %Message{payload: %Wrench2D{fx: 12.0, fy: +0.0, tau: 0.4}} = msg
+    assert msg.frame_id == :chassis
+  end
+
+  test "coerces integers to floats" do
+    {:ok, msg} = Wrench2D.new(:chassis, 1, 2, 3)
+
+    assert %Message{payload: %Wrench2D{fx: 1.0, fy: 2.0, tau: 3.0}} = msg
+  end
+
+  test "requires every component" do
+    assert {:error, _} = Wrench2D.new(:chassis, fx: 12.0, fy: 0.0)
+  end
+end

--- a/test/bb/message/sensor/joint_state_test.exs
+++ b/test/bb/message/sensor/joint_state_test.exs
@@ -5,7 +5,14 @@
 defmodule BB.Message.Sensor.JointStateTest do
   use ExUnit.Case, async: true
 
+  alias BB.Math.Transform
+  alias BB.Math.Transform2D
+  alias BB.Math.Vec3
   alias BB.Message
+  alias BB.Message.Geometry.Twist
+  alias BB.Message.Geometry.Twist2D
+  alias BB.Message.Geometry.Wrench
+  alias BB.Message.Geometry.Wrench2D
   alias BB.Message.Sensor.JointState
 
   test "creates a joint state message" do
@@ -27,5 +34,82 @@ defmodule BB.Message.Sensor.JointStateTest do
     assert msg.payload.positions == []
     assert msg.payload.velocities == []
     assert msg.payload.efforts == []
+  end
+
+  describe "multi-DoF joints" do
+    # The whole point of widening this message rather than adding a second one:
+    # a mobile base's pose and its mast's angle arrive together, in one instant,
+    # so no consumer has to correlate two topics by timestamp.
+    test "carry a planar joint alongside a single-DoF joint" do
+      configuration = Transform2D.new(12.4, -3.1, 1.57)
+
+      {:ok, msg} =
+        JointState.new(:rover,
+          names: [:base, :mast],
+          positions: [configuration, 0.5],
+          velocities: [%Twist2D{vx: 0.3, vy: 0.0, omega: 0.1}, 0.05],
+          efforts: [%Wrench2D{fx: 12.0, fy: 0.0, tau: 0.4}, 0.2]
+        )
+
+      assert msg.payload.positions == [configuration, 0.5]
+      assert [%Twist2D{vx: 0.3}, 0.05] = msg.payload.velocities
+      assert [%Wrench2D{fx: 12.0}, 0.2] = msg.payload.efforts
+    end
+
+    test "carry a floating joint" do
+      pose = Transform.translation(Vec3.new(1.0, 2.0, 3.0))
+
+      {:ok, msg} =
+        JointState.new(:drone,
+          names: [:base, :gimbal],
+          positions: [pose, 0.5],
+          velocities: [%Twist{linear: Vec3.zero(), angular: Vec3.zero()}, 0.0],
+          efforts: [%Wrench{force: Vec3.zero(), torque: Vec3.zero()}, 0.0]
+        )
+
+      assert [^pose, 0.5] = msg.payload.positions
+      assert [%Twist{}, +0.0] = msg.payload.velocities
+      assert [%Wrench{}, +0.0] = msg.payload.efforts
+    end
+  end
+
+  describe "validation" do
+    # Widening the lists must not mean accepting anything. The message cannot
+    # check a value against a *particular* joint's type — that needs the robot,
+    # which it does not carry — but it can reject something that is no joint value
+    # at all.
+    test "rejects a value that is no joint configuration at all" do
+      assert {:error, error} =
+               JointState.new(:arm, names: [:joint1], positions: ["not a configuration"])
+
+      assert Exception.message(error) =~ "element 0"
+    end
+
+    test "names the offending index, since the lists run parallel to names" do
+      assert {:error, error} =
+               JointState.new(:arm,
+                 names: [:a, :b, :c],
+                 positions: [0.1, 0.2, :nope]
+               )
+
+      assert Exception.message(error) =~ "element 2"
+    end
+
+    test "rejects a velocity in the positions list" do
+      twist = %Twist2D{vx: 0.0, vy: 0.0, omega: 0.0}
+
+      assert {:error, _} = JointState.new(:arm, names: [:joint1], positions: [twist])
+    end
+
+    test "rejects a configuration in the velocities list" do
+      assert {:error, _} =
+               JointState.new(:arm, names: [:joint1], velocities: [Transform2D.identity()])
+    end
+
+    test "rejects a velocity in the efforts list" do
+      twist = %Twist2D{vx: 0.0, vy: 0.0, omega: 0.0}
+
+      assert {:error, _} = JointState.new(:arm, names: [:joint1], efforts: [twist])
+    end
   end
 end

--- a/test/bb/motion_test.exs
+++ b/test/bb/motion_test.exs
@@ -93,17 +93,75 @@ defmodule BB.MotionTest do
         execution_id: make_ref()
       }
 
-      {:ok, positions, meta} = Motion.solve_only(context, :tip, target, solver: MockSolver)
+      {:ok, positions, meta} =
+        Motion.solve_only(context, :tip, target, source_link: :base_link, solver: MockSolver)
 
       assert positions == %{shoulder_joint: 0.5, elbow_joint: 0.3}
       assert meta.iterations == 10
       assert meta.residual == 0.001
       assert meta.reached == true
 
-      {called_robot, _called_state, called_link, called_target, _opts} = MockSolver.last_call()
+      {called_robot, _called_state, called_source, called_link, called_target, _opts} =
+        MockSolver.last_call()
+
       assert called_robot == robot
+      assert called_source == :base_link
       assert called_link == :tip
       assert called_target == target
+    end
+
+    # No default anywhere: the root is right for a fixed-base arm and silently
+    # wrong for a robot whose base floats, so a missing `:source_link` must be
+    # loud rather than quietly producing the contaminated chain.
+    test "requires :source_link with no default" do
+      robot = MotionTestRobot.robot()
+      {:ok, robot_state} = RobotState.new(robot)
+
+      context = %Context{
+        robot_module: MotionTestRobot,
+        robot: robot,
+        robot_state: robot_state,
+        execution_id: make_ref()
+      }
+
+      assert_raise KeyError, fn ->
+        Motion.solve_only(context, :tip, {0.3, 0.2, 0.1}, solver: MockSolver)
+      end
+
+      assert_raise KeyError, fn ->
+        Motion.move_to(context, :tip, {0.3, 0.2, 0.1}, solver: MockSolver)
+      end
+
+      assert_raise KeyError, fn ->
+        Motion.solve_only_multi(context, %{tip: {0.3, 0.2, 0.1}}, solver: MockSolver)
+      end
+
+      assert_raise KeyError, fn ->
+        Motion.move_to_multi(context, %{tip: {0.3, 0.2, 0.1}}, solver: MockSolver)
+      end
+    end
+
+    test "does not pass :source_link on to the solver as an option" do
+      robot = MotionTestRobot.robot()
+      {:ok, robot_state} = RobotState.new(robot)
+
+      context = %Context{
+        robot_module: MotionTestRobot,
+        robot: robot,
+        robot_state: robot_state,
+        execution_id: make_ref()
+      }
+
+      {:ok, _positions, _meta} =
+        Motion.solve_only(context, :tip, {0.3, 0.2, 0.1},
+          source_link: :base_link,
+          solver: MockSolver
+        )
+
+      {_robot, _state, _source, _link, _target, opts} = MockSolver.last_call()
+
+      refute Keyword.has_key?(opts, :source_link)
+      refute Keyword.has_key?(opts, :solver)
     end
 
     test "passes solver options through" do
@@ -120,13 +178,14 @@ defmodule BB.MotionTest do
       }
 
       Motion.solve_only(context, :tip, {0.3, 0.2, 0.1},
+        source_link: :base_link,
         solver: MockSolver,
         max_iterations: 100,
         tolerance: 0.01,
         respect_limits: false
       )
 
-      {_robot, _state, _link, _target, opts} = MockSolver.last_call()
+      {_robot, _state, _source, _link, _target, opts} = MockSolver.last_call()
       assert opts[:max_iterations] == 100
       assert opts[:tolerance] == 0.01
       assert opts[:respect_limits] == false
@@ -148,7 +207,10 @@ defmodule BB.MotionTest do
       }
 
       {:error, %Unreachable{} = error} =
-        Motion.solve_only(context, :tip, {10.0, 0.0, 0.0}, solver: MockSolver)
+        Motion.solve_only(context, :tip, {10.0, 0.0, 0.0},
+          source_link: :base_link,
+          solver: MockSolver
+        )
 
       assert error.iterations == 50
       assert error.residual == 0.5
@@ -178,7 +240,11 @@ defmodule BB.MotionTest do
         execution_id: make_ref()
       }
 
-      {:ok, meta} = Motion.move_to(context, :tip, {0.3, 0.2, 0.1}, solver: MockSolver)
+      {:ok, meta} =
+        Motion.move_to(context, :tip, {0.3, 0.2, 0.1},
+          source_link: :base_link,
+          solver: MockSolver
+        )
 
       assert meta.reached == true
 
@@ -205,7 +271,10 @@ defmodule BB.MotionTest do
       }
 
       {:error, %Unreachable{}} =
-        Motion.move_to(context, :tip, {10.0, 0.0, 0.0}, solver: MockSolver)
+        Motion.move_to(context, :tip, {10.0, 0.0, 0.0},
+          source_link: :base_link,
+          solver: MockSolver
+        )
 
       assert RobotState.get_configuration(robot_state, :shoulder_joint) == {:ok, 1.0}
       assert RobotState.get_configuration(robot_state, :elbow_joint) == {:ok, 1.0}
@@ -248,11 +317,14 @@ defmodule BB.MotionTest do
       )
 
       {:ok, _positions, meta} =
-        Motion.solve_only(MotionTestRobot, :tip, {0.3, 0.2, 0.1}, solver: MockSolver)
+        Motion.solve_only(MotionTestRobot, :tip, {0.3, 0.2, 0.1},
+          source_link: :base_link,
+          solver: MockSolver
+        )
 
       assert meta.reached == true
 
-      {called_robot, _state, _link, _target, _opts} = MockSolver.last_call()
+      {called_robot, _state, _source, _link, _target, _opts} = MockSolver.last_call()
       assert called_robot.name == MotionTestRobot
     end
   end
@@ -275,7 +347,8 @@ defmodule BB.MotionTest do
 
       targets = %{tip: {0.3, 0.2, 0.1}, upper_arm: {0.2, 0.1, 0.0}}
 
-      {:ok, results} = Motion.solve_only_multi(context, targets, solver: MockSolver)
+      {:ok, results} =
+        Motion.solve_only_multi(context, targets, source_link: :base_link, solver: MockSolver)
 
       assert Map.has_key?(results, :tip)
       assert Map.has_key?(results, :upper_arm)
@@ -300,7 +373,7 @@ defmodule BB.MotionTest do
 
         alias BB.Error.Kinematics.Unreachable
 
-        def solve(_robot, _state, target_link, _target, _opts) do
+        def solve(_robot, _state, _source_link, target_link, _target, _opts) do
           if target_link == :upper_arm do
             {:error,
              %Unreachable{
@@ -316,7 +389,10 @@ defmodule BB.MotionTest do
       end
 
       {:error, :upper_arm, %Unreachable{}, results} =
-        Motion.solve_only_multi(context, targets, solver: FailOnSecondSolver)
+        Motion.solve_only_multi(context, targets,
+          source_link: :base_link,
+          solver: FailOnSecondSolver
+        )
 
       assert {:error, %Unreachable{}} = results[:upper_arm]
     end
@@ -343,7 +419,8 @@ defmodule BB.MotionTest do
 
       targets = %{tip: {0.3, 0.2, 0.1}}
 
-      {:ok, results} = Motion.move_to_multi(context, targets, solver: MockSolver)
+      {:ok, results} =
+        Motion.move_to_multi(context, targets, source_link: :base_link, solver: MockSolver)
 
       assert {:ok, _positions, meta} = results[:tip]
       assert meta.reached == true

--- a/test/bb/motion_test.exs
+++ b/test/bb/motion_test.exs
@@ -182,16 +182,16 @@ defmodule BB.MotionTest do
 
       assert meta.reached == true
 
-      assert RobotState.get_joint_position(robot_state, :shoulder_joint) == 0.5
-      assert RobotState.get_joint_position(robot_state, :elbow_joint) == 0.3
+      assert RobotState.get_configuration(robot_state, :shoulder_joint) == {:ok, 0.5}
+      assert RobotState.get_configuration(robot_state, :elbow_joint) == {:ok, 0.3}
     end
 
     test "does not update state on error" do
       robot = MotionTestRobot.robot()
       {:ok, robot_state} = RobotState.new(robot)
 
-      RobotState.set_joint_position(robot_state, :shoulder_joint, 1.0)
-      RobotState.set_joint_position(robot_state, :elbow_joint, 1.0)
+      RobotState.set_configuration(robot_state, :shoulder_joint, 1.0)
+      RobotState.set_configuration(robot_state, :elbow_joint, 1.0)
 
       MockSolver.set_result(
         {:error, MockSolver.unreachable_error(:tip, iterations: 50, residual: 0.5)}
@@ -207,8 +207,8 @@ defmodule BB.MotionTest do
       {:error, %Unreachable{}} =
         Motion.move_to(context, :tip, {10.0, 0.0, 0.0}, solver: MockSolver)
 
-      assert RobotState.get_joint_position(robot_state, :shoulder_joint) == 1.0
-      assert RobotState.get_joint_position(robot_state, :elbow_joint) == 1.0
+      assert RobotState.get_configuration(robot_state, :shoulder_joint) == {:ok, 1.0}
+      assert RobotState.get_configuration(robot_state, :elbow_joint) == {:ok, 1.0}
     end
   end
 
@@ -229,8 +229,8 @@ defmodule BB.MotionTest do
       positions = %{shoulder_joint: 0.7, elbow_joint: 0.4}
       :ok = Motion.send_positions(context, positions)
 
-      assert RobotState.get_joint_position(robot_state, :shoulder_joint) == 0.7
-      assert RobotState.get_joint_position(robot_state, :elbow_joint) == 0.4
+      assert RobotState.get_configuration(robot_state, :shoulder_joint) == {:ok, 0.7}
+      assert RobotState.get_configuration(robot_state, :elbow_joint) == {:ok, 0.4}
     end
   end
 

--- a/test/bb/robot/kinematics_test.exs
+++ b/test/bb/robot/kinematics_test.exs
@@ -391,8 +391,8 @@ defmodule BB.Robot.KinematicsTest do
       robot = PlanarArm.robot()
       {:ok, state} = State.new(robot)
 
-      State.set_joint_position(state, :joint1, :math.pi() / 4)
-      State.set_joint_position(state, :joint2, :math.pi() / 6)
+      State.set_configuration(state, :joint1, :math.pi() / 4)
+      State.set_configuration(state, :joint2, :math.pi() / 6)
 
       all_transforms = Kinematics.all_link_transforms(robot, state)
 

--- a/test/bb/robot/kinematics_test.exs
+++ b/test/bb/robot/kinematics_test.exs
@@ -686,8 +686,9 @@ defmodule BB.Robot.KinematicsTest do
   end
 
   defp reference_chain(robot, positions, target_link) do
-    robot
-    |> BB.Robot.path_to(target_link)
+    {:ok, path} = BB.Robot.path_to(robot, target_link)
+
+    path
     |> Enum.filter(&Map.has_key?(robot.joints, &1))
     |> Enum.reduce(Transform.identity(), fn joint_name, acc ->
       Transform.compose(acc, Kinematics.compute_joint_transform(robot, positions, joint_name))
@@ -698,10 +699,10 @@ defmodule BB.Robot.KinematicsTest do
     Enum.reduce(robot.topology.link_order, %{}, fn link_name, transforms ->
       transform =
         case BB.Robot.get_link(robot, link_name) do
-          %{parent_joint: nil} ->
+          {:ok, %{parent_joint: nil}} ->
             Transform.identity()
 
-          %{parent_joint: parent_joint_name} ->
+          {:ok, %{parent_joint: parent_joint_name}} ->
             parent_link = robot.joints[parent_joint_name].parent_link
 
             Transform.compose(

--- a/test/bb/robot/kinematics_test.exs
+++ b/test/bb/robot/kinematics_test.exs
@@ -6,6 +6,8 @@ defmodule BB.Robot.KinematicsTest do
   use ExUnit.Case, async: true
   import BB.Unit
 
+  alias BB.Error.Kinematics.UnknownJoint
+  alias BB.ExampleRobots.DifferentialDriveRobot
   alias BB.ExampleRobots.LinearActuator
   alias BB.ExampleRobots.SixDofArm
   alias BB.Math.Quaternion
@@ -500,15 +502,34 @@ defmodule BB.Robot.KinematicsTest do
 
       assert Nx.to_flat_list(picked[[.., 0]]) == Nx.to_flat_list(base[[.., 2]])
       assert Nx.to_flat_list(picked[[.., 1]]) == Nx.to_flat_list(base[[.., 0]])
+    end
 
-      # A joint that does not lie on the chain to the target gets a zero column.
-      with_unrelated =
+    test "a real joint off the chain to the target gets a zero column" do
+      robot = DifferentialDriveRobot.robot()
+
+      configurations = %{left_wheel_joint: 0.3, right_wheel_joint: -0.4}
+
+      jacobian =
+        Kinematics.position_jacobian(robot, configurations, :right_wheel, [
+          :right_wheel_joint,
+          :left_wheel_joint
+        ])
+
+      assert Nx.to_flat_list(jacobian[[.., 1]]) == [0.0, 0.0, 0.0]
+    end
+
+    # Previously a name the robot didn't have quietly produced one zero column,
+    # which hid a typo. It cannot survive per-DoF columns either: there is no way
+    # to know how wide a joint that doesn't exist should be.
+    test "a joint the robot doesn't have is an error, not a zero column" do
+      robot = SixDofArm.robot()
+
+      assert_raise UnknownJoint, ~r/Unknown joint: :not_a_real_joint/, fn ->
         Kinematics.position_jacobian(robot, @sixdof_positions, :tool0, [
           :wrist_3_joint,
           :not_a_real_joint
         ])
-
-      assert Nx.to_flat_list(with_unrelated[[.., 1]]) == [0.0, 0.0, 0.0]
+      end
     end
   end
 

--- a/test/bb/robot/lifecycle_test.exs
+++ b/test/bb/robot/lifecycle_test.exs
@@ -23,9 +23,9 @@ defmodule BB.Robot.LifecycleTest do
         |> Enum.into(%{})
         |> Map.take([:shoulder, :elbow])
 
-      :ok = RobotState.set_positions(context.robot_state, positions)
+      :ok = RobotState.set_configurations(context.robot_state, positions)
 
-      new_positions = RobotState.get_all_positions(context.robot_state)
+      new_positions = RobotState.get_all_configurations(context.robot_state)
       {:stop, :normal, %{state | result: {:ok, new_positions}}}
     end
 

--- a/test/bb/robot/multi_dof_kinematics_test.exs
+++ b/test/bb/robot/multi_dof_kinematics_test.exs
@@ -1,0 +1,461 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Robot.MultiDofKinematicsTest do
+  @moduledoc """
+  Kinematics for `:planar` and `:floating` joints.
+
+  Correctness here is established two ways, both deliberately independent of the
+  code under test:
+
+  - **Forward kinematics against hand-computed poses.** A round-trip through our
+    own composition is self-consistent — a systematically wrong transform order
+    passes it perfectly — so expected poses are worked out by hand from the
+    fixture geometry.
+  - **The Jacobian against central finite differences of forward kinematics.**
+    Numerically differentiating FK is an independent derivation, so it catches
+    column ordering, sign, and per-DoF-width errors. Note this validates the
+    Jacobian *given* FK, which is why FK needs its own check above.
+  """
+  use ExUnit.Case, async: true
+
+  alias BB.ExampleRobots.DifferentialDriveRobot
+  alias BB.ExampleRobots.FloatingDrone
+  alias BB.ExampleRobots.PlanarRover
+  alias BB.Math.Quaternion
+  alias BB.Math.Transform
+  alias BB.Math.Transform2D
+  alias BB.Math.Vec3
+  alias BB.Robot.Kinematics
+
+  @half_pi :math.pi() / 2
+
+  defp rover, do: PlanarRover.robot()
+  defp drone, do: FloatingDrone.robot()
+
+  defp position(robot, configurations, link) do
+    Kinematics.link_position(robot, configurations, link)
+  end
+
+  defp assert_position({x, y, z}, {ex, ey, ez}) do
+    assert_in_delta x, ex, 1.0e-9
+    assert_in_delta y, ey, 1.0e-9
+    assert_in_delta z, ez, 1.0e-9
+  end
+
+  describe "planar joint forward kinematics" do
+    # The mast sits 0.2 m above the chassis, so with the base at the origin the
+    # sensor head is directly above it.
+    test "identity configuration leaves the chain at its origin offsets" do
+      configurations = %{base: Transform2D.identity(), mast: 0.0}
+
+      assert_position(position(rover(), configurations, :chassis), {0.0, 0.0, 0.0})
+      assert_position(position(rover(), configurations, :sensor_head), {0.0, 0.0, 0.2})
+    end
+
+    # Hand-computed: the base translates by (12.4, -3.1) in the XY plane, and the
+    # mast offset is along the plane normal so yaw cannot move it.
+    test "in-plane translation carries the whole chain" do
+      configurations = %{base: Transform2D.new(12.4, -3.1, 0.0), mast: 0.0}
+
+      assert_position(position(rover(), configurations, :chassis), {12.4, -3.1, 0.0})
+      assert_position(position(rover(), configurations, :sensor_head), {12.4, -3.1, 0.2})
+    end
+
+    test "yaw about the plane normal does not move a point on the axis" do
+      configurations = %{base: Transform2D.new(0.0, 0.0, 1.0), mast: 0.0}
+
+      assert_position(position(rover(), configurations, :sensor_head), {0.0, 0.0, 0.2})
+    end
+
+    # Rotating the base by +90 degrees about Z then translating (1, 0) in the
+    # *rotated* frame is a different pose from translating first — the base's own
+    # translation is applied in the parent frame, so this checks the convention.
+    test "translation is in the parent frame, not the rotated one" do
+      configurations = %{base: Transform2D.new(1.0, 0.0, @half_pi), mast: 0.0}
+
+      assert_position(position(rover(), configurations, :sensor_head), {1.0, 0.0, 0.2})
+    end
+
+    test "the mast composes on top of the base" do
+      configurations = %{base: Transform2D.new(2.0, 3.0, 0.0), mast: @half_pi}
+
+      # The mast rotates about Z and the sensor head is on that axis, so its
+      # position is unchanged while its orientation is not.
+      assert_position(position(rover(), configurations, :sensor_head), {2.0, 3.0, 0.2})
+
+      transform = Kinematics.forward_kinematics(rover(), configurations, :sensor_head)
+      rotated = Transform.apply_to_point(transform, Vec3.unit_x())
+
+      assert_position({Vec3.x(rotated), Vec3.y(rotated), Vec3.z(rotated)}, {2.0, 4.0, 0.2})
+    end
+
+    test "agrees with composing the joint transforms by hand" do
+      configurations = %{base: Transform2D.new(1.5, -2.5, 0.6), mast: 0.4}
+
+      expected =
+        Transform.compose(
+          Kinematics.compute_joint_transform(rover(), configurations, :base),
+          Kinematics.compute_joint_transform(rover(), configurations, :mast)
+        )
+
+      actual = Kinematics.forward_kinematics(rover(), configurations, :sensor_head)
+
+      assert_transforms_equal(actual, expected)
+    end
+
+    test "all_link_transforms/2 agrees with forward_kinematics/3" do
+      configurations = %{base: Transform2D.new(1.5, -2.5, 0.6), mast: 0.4}
+      transforms = Kinematics.all_link_transforms(rover(), configurations)
+
+      for link <- [:odom, :chassis, :sensor_head] do
+        assert_transforms_equal(
+          Map.fetch!(transforms, link),
+          Kinematics.forward_kinematics(rover(), configurations, link)
+        )
+      end
+    end
+  end
+
+  describe "planar joints with a non-Z surface normal" do
+    # `axis` is the plane's surface normal, so a rover declared with a Y normal
+    # moves in the XZ plane. Assuming XY would put the sensor head in the wrong
+    # place, and nothing else in this suite would notice.
+    test "the plane follows the joint's axis" do
+      robot = tilted_rover()
+      {u, v} = Transform2D.plane_basis(Vec3.unit_y())
+
+      # A unit of the base's x moves the chassis one metre along the plane's
+      # first axis, and a unit of its y along the second — whatever those are.
+      assert_position(
+        position(robot, %{base: Transform2D.new(1.0, 0.0, 0.0), mast: 0.0}, :chassis),
+        {Vec3.x(u), Vec3.y(u), Vec3.z(u)}
+      )
+
+      assert_position(
+        position(robot, %{base: Transform2D.new(0.0, 1.0, 0.0), mast: 0.0}, :chassis),
+        {Vec3.x(v), Vec3.y(v), Vec3.z(v)}
+      )
+    end
+
+    test "the plane is not the XY plane" do
+      robot = tilted_rover()
+
+      # A Y normal means motion in XZ, so the chassis must leave the XY plane.
+      {_x, y, z} = position(robot, %{base: Transform2D.new(0.0, 1.0, 0.0), mast: 0.0}, :chassis)
+
+      assert_in_delta y, 0.0, 1.0e-9
+      refute_in_delta z, 0.0, 1.0e-9
+    end
+
+    test "yaw is about the declared normal, leaving it fixed" do
+      robot = tilted_rover()
+      configurations = %{base: Transform2D.new(0.0, 0.0, 0.7), mast: 0.0}
+
+      transform = Kinematics.forward_kinematics(robot, configurations, :chassis)
+      fixed = Transform.apply_to_point(transform, Vec3.unit_y())
+
+      assert_position({Vec3.x(fixed), Vec3.y(fixed), Vec3.z(fixed)}, {0.0, 1.0, 0.0})
+    end
+  end
+
+  describe "floating joint forward kinematics" do
+    test "identity configuration leaves the chain at its origin offsets" do
+      configurations = %{base: Transform.identity(), gimbal: 0.0}
+
+      assert_position(position(drone(), configurations, :airframe), {0.0, 0.0, 0.0})
+      assert_position(position(drone(), configurations, :camera), {0.1, 0.0, -0.05})
+    end
+
+    test "the stored transform is used verbatim" do
+      pose = Transform.translation(Vec3.new(5.0, -2.0, 30.0))
+      configurations = %{base: pose, gimbal: 0.0}
+
+      assert_position(position(drone(), configurations, :airframe), {5.0, -2.0, 30.0})
+      assert_position(position(drone(), configurations, :camera), {5.1, -2.0, 29.95})
+    end
+
+    # Hand-computed: yaw of +90 degrees takes the gimbal's local +x offset to
+    # world +y, and leaves the -z offset alone.
+    test "a rotated base carries the child link's offset with it" do
+      configurations = %{base: Transform.rotation_z(@half_pi), gimbal: 0.0}
+
+      assert_position(position(drone(), configurations, :camera), {0.0, 0.1, -0.05})
+    end
+
+    test "a full pose composes rotation then translation in the parent frame" do
+      pose =
+        Transform.compose(
+          Transform.translation(Vec3.new(1.0, 2.0, 3.0)),
+          Transform.rotation_z(@half_pi)
+        )
+
+      configurations = %{base: pose, gimbal: 0.0}
+
+      assert_position(position(drone(), configurations, :camera), {1.0, 2.1, 2.95})
+    end
+
+    # A floating base and a revolute joint do not commute, so composing them the
+    # wrong way round must be detectable rather than coincidentally equal.
+    test "composition with the gimbal does not commute" do
+      pose =
+        Transform.compose(
+          Transform.translation(Vec3.new(1.0, 2.0, 3.0)),
+          Transform.rotation_z(0.9)
+        )
+
+      forwards = %{base: pose, gimbal: 0.7}
+
+      correct = Kinematics.forward_kinematics(drone(), forwards, :camera)
+
+      swapped =
+        Transform.compose(
+          Kinematics.compute_joint_transform(drone(), forwards, :gimbal),
+          Kinematics.compute_joint_transform(drone(), forwards, :base)
+        )
+
+      refute Nx.to_binary(Transform.tensor(correct)) == Nx.to_binary(Transform.tensor(swapped))
+    end
+
+    test "forward kinematics is bit-exact for the stored pose" do
+      pose =
+        Transform.compose(
+          Transform.translation(Vec3.new(12.400000000000001, -3.0999999999999996, 0.7)),
+          Transform.from_quaternion(
+            Quaternion.from_axis_angle(
+              Vec3.normalise(Vec3.new(0.3, -0.7, 0.64)),
+              1.2345678901234567
+            )
+          )
+        )
+
+      # The airframe's parent joint has no origin, so its base-frame transform
+      # must be the stored pose with no arithmetic applied at all.
+      actual = Kinematics.forward_kinematics(drone(), %{base: pose, gimbal: 0.0}, :airframe)
+
+      assert Nx.to_binary(Transform.tensor(actual)) == Nx.to_binary(Transform.tensor(pose))
+    end
+
+    test "all_link_transforms/2 agrees with forward_kinematics/3" do
+      pose =
+        Transform.compose(
+          Transform.translation(Vec3.new(1.0, 2.0, 3.0)),
+          Transform.rotation_z(0.9)
+        )
+
+      configurations = %{base: pose, gimbal: 0.7}
+      transforms = Kinematics.all_link_transforms(drone(), configurations)
+
+      for link <- [:world, :airframe, :camera] do
+        assert_transforms_equal(
+          Map.fetch!(transforms, link),
+          Kinematics.forward_kinematics(drone(), configurations, link)
+        )
+      end
+    end
+  end
+
+  describe "jacobian_columns/2" do
+    test "reports three columns for a planar joint and one for a revolute" do
+      assert Kinematics.jacobian_columns(rover(), [:base, :mast]) == [
+               {:base, 0},
+               {:base, 1},
+               {:base, 2},
+               {:mast, 0}
+             ]
+    end
+
+    test "reports six columns for a floating joint" do
+      assert Kinematics.jacobian_columns(drone(), [:base, :gimbal]) == [
+               {:base, 0},
+               {:base, 1},
+               {:base, 2},
+               {:base, 3},
+               {:base, 4},
+               {:base, 5},
+               {:gimbal, 0}
+             ]
+    end
+
+    test "a fixed joint contributes no columns" do
+      assert Kinematics.jacobian_columns(DifferentialDriveRobot.robot(), [:caster_joint]) == []
+    end
+  end
+
+  describe "jacobian width" do
+    test "is the sum of degrees of freedom, not the joint count" do
+      configurations = %{base: Transform2D.new(1.0, 2.0, 0.3), mast: 0.4}
+
+      jacobian =
+        Kinematics.position_jacobian(rover(), configurations, :sensor_head, [:base, :mast])
+
+      assert Nx.shape(jacobian) == {3, 4}
+    end
+
+    test "a floating base contributes three translation and three rotation columns" do
+      configurations = %{base: Transform.rotation_z(0.4), gimbal: 0.2}
+
+      jacobian = Kinematics.jacobian(drone(), configurations, :camera, [:base, :gimbal])
+
+      assert Nx.shape(jacobian) == {6, 7}
+    end
+  end
+
+  describe "jacobian against finite differences" do
+    test "planar base and revolute mast" do
+      configurations = %{base: Transform2D.new(1.5, -2.5, 0.6), mast: 0.4}
+
+      assert_jacobian_matches_finite_differences(
+        rover(),
+        configurations,
+        :sensor_head,
+        [:base, :mast]
+      )
+    end
+
+    test "planar base with a non-Z surface normal" do
+      configurations = %{base: Transform2D.new(1.5, -2.5, 0.6), mast: 0.4}
+
+      assert_jacobian_matches_finite_differences(
+        tilted_rover(),
+        configurations,
+        :sensor_head,
+        [:base, :mast]
+      )
+    end
+
+    test "floating base and revolute gimbal" do
+      pose =
+        Transform.compose(
+          Transform.translation(Vec3.new(1.0, 2.0, 3.0)),
+          Transform.from_quaternion(
+            Quaternion.from_axis_angle(Vec3.normalise(Vec3.new(0.3, -0.7, 0.64)), 0.85)
+          )
+        )
+
+      configurations = %{base: pose, gimbal: 0.4}
+
+      assert_jacobian_matches_finite_differences(
+        drone(),
+        configurations,
+        :camera,
+        [:base, :gimbal]
+      )
+    end
+  end
+
+  # Perturbs each degree of freedom by the *true* rigid motion it represents —
+  # a real translation or a real `from_axis_angle` rotation, composed into the
+  # joint's stored configuration — and differentiates forward kinematics. This is
+  # an independent derivation of the Jacobian, so agreement is meaningful.
+  defp assert_jacobian_matches_finite_differences(robot, configurations, target, joint_names) do
+    columns = Kinematics.jacobian_columns(robot, joint_names)
+    analytic = Kinematics.position_jacobian(robot, configurations, target, joint_names)
+    h = 1.0e-7
+
+    for {{joint_name, dof}, column} <- Enum.with_index(columns) do
+      plus = position(robot, perturb(robot, configurations, joint_name, dof, h), target)
+      minus = position(robot, perturb(robot, configurations, joint_name, dof, -h), target)
+
+      for {axis, row} <- Enum.with_index([:x, :y, :z]) do
+        assert_in_delta Nx.to_number(analytic[row][column]),
+                        (elem(plus, row) - elem(minus, row)) / (2 * h),
+                        1.0e-5,
+                        "#{inspect(joint_name)} dof #{dof}, #{axis} row"
+      end
+    end
+  end
+
+  defp perturb(robot, configurations, joint_name, dof, amount) do
+    {:ok, joint} = BB.Robot.get_joint(robot, joint_name)
+
+    Map.put(
+      configurations,
+      joint_name,
+      perturbed_configuration(joint, Map.fetch!(configurations, joint_name), dof, amount)
+    )
+  end
+
+  # The perturbation is local to the joint, so it composes on the right — the same
+  # side `I + hat(delta)` sits on in the kernel.
+  defp perturbed_configuration(%{type: :planar}, configuration, dof, amount) do
+    delta =
+      case dof do
+        0 -> Transform2D.new(amount, 0.0, 0.0)
+        1 -> Transform2D.new(0.0, amount, 0.0)
+        2 -> Transform2D.new(0.0, 0.0, amount)
+      end
+
+    Transform2D.compose(configuration, delta)
+  end
+
+  defp perturbed_configuration(%{type: :floating}, configuration, dof, amount) do
+    delta =
+      case dof do
+        0 -> Transform.translation(Vec3.new(amount, 0.0, 0.0))
+        1 -> Transform.translation(Vec3.new(0.0, amount, 0.0))
+        2 -> Transform.translation(Vec3.new(0.0, 0.0, amount))
+        3 -> Transform.from_axis_angle(Vec3.unit_x(), amount)
+        4 -> Transform.from_axis_angle(Vec3.unit_y(), amount)
+        5 -> Transform.from_axis_angle(Vec3.unit_z(), amount)
+      end
+
+    Transform.compose(configuration, delta)
+  end
+
+  defp perturbed_configuration(_joint, configuration, 0, amount), do: configuration + amount
+
+  defp assert_transforms_equal(actual, expected) do
+    Enum.zip(
+      Nx.to_flat_list(Transform.tensor(actual)),
+      Nx.to_flat_list(Transform.tensor(expected))
+    )
+    |> Enum.each(fn {left, right} -> assert_in_delta left, right, 1.0e-9 end)
+  end
+
+  defmodule TiltedRover do
+    @moduledoc """
+    A rover whose ground plane has a **Y** surface normal rather than Z.
+
+    Exists so the tests prove `axis` is actually respected, rather than the plane
+    being assumed to be XY.
+    """
+    use BB
+    import BB.Unit
+
+    topology do
+      link :odom do
+        joint :base do
+          type(:planar)
+
+          axis do
+            roll(~u(-90 degree))
+          end
+
+          link :chassis do
+            joint :mast do
+              type(:revolute)
+
+              origin do
+                x(~u(0.2 meter))
+              end
+
+              axis do
+              end
+
+              limit do
+                effort(~u(10 newton_meter))
+                velocity(~u(90 degree_per_second))
+              end
+
+              link(:sensor_head)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  defp tilted_rover, do: TiltedRover.robot()
+end

--- a/test/bb/robot/state_test.exs
+++ b/test/bb/robot/state_test.exs
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Robot.StateTest do
+  use ExUnit.Case, async: true
+
+  alias BB.Error.Invalid.JointConfig
+  alias BB.ExampleRobots.DifferentialDriveRobot
+  alias BB.ExampleRobots.FloatingDrone
+  alias BB.ExampleRobots.PlanarRover
+  alias BB.Math.Quaternion
+  alias BB.Math.Transform
+  alias BB.Math.Transform2D
+  alias BB.Math.Vec3
+  alias BB.Message.Geometry.Twist
+  alias BB.Message.Geometry.Twist2D
+  alias BB.Robot.State
+
+  # Deliberately not axis-aligned and not round, so a value that silently goes
+  # through a quaternion decomposition or a float32 hop shows up as a mismatch.
+  defp awkward_transform do
+    Transform.compose(
+      Transform.translation(Vec3.new(12.400000000000001, -3.0999999999999996, 0.7)),
+      Transform.from_quaternion(
+        Quaternion.from_axis_angle(
+          Vec3.normalise(Vec3.new(0.3, -0.7, 0.64)),
+          1.2345678901234567
+        )
+      )
+    )
+  end
+
+  defp planar_state do
+    {:ok, state} = State.new(PlanarRover.robot())
+    state
+  end
+
+  defp floating_state do
+    {:ok, state} = State.new(FloatingDrone.robot())
+    state
+  end
+
+  describe "planar joints" do
+    test "default to the identity" do
+      assert State.get_configuration(planar_state(), :base) ==
+               {:ok, Transform2D.identity()}
+    end
+
+    test "round-trip a Transform2D exactly" do
+      state = planar_state()
+      configuration = Transform2D.new(12.4, -3.1, 1.5707963267948966)
+
+      assert :ok = State.set_configuration(state, :base, configuration)
+      assert State.get_configuration(state, :base) == {:ok, configuration}
+    end
+
+    test "round-trip a Twist2D exactly" do
+      state = planar_state()
+      velocity = %Twist2D{vx: 0.35, vy: -0.125, omega: 0.98765}
+
+      assert :ok = State.set_velocity(state, :base, velocity)
+      assert State.get_velocity(state, :base) == {:ok, velocity}
+    end
+
+    test "reject a bare float, naming Transform2D as expected" do
+      assert {:error, %JointConfig{joint: :base, field: :configuration, expected: Transform2D}} =
+               State.set_configuration(planar_state(), :base, 0.5)
+    end
+
+    test "reject a Transform, since a planar joint is not free in 3D" do
+      assert {:error, %JointConfig{expected: Transform2D}} =
+               State.set_configuration(planar_state(), :base, Transform.identity())
+    end
+
+    test "reject a 3D Twist as a velocity" do
+      twist = %Twist{linear: Vec3.zero(), angular: Vec3.zero()}
+
+      assert {:error, %JointConfig{field: :velocity, expected: Twist2D}} =
+               State.set_velocity(planar_state(), :base, twist)
+    end
+
+    test "sit alongside single-DoF joints in get_all_configurations/1" do
+      state = planar_state()
+      configuration = Transform2D.new(1.0, 2.0, 0.5)
+
+      :ok = State.set_configuration(state, :base, configuration)
+      :ok = State.set_configuration(state, :mast, 0.75)
+
+      assert State.get_all_configurations(state) == %{base: configuration, mast: 0.75}
+    end
+
+    test "appear in a chain's configurations in traversal order" do
+      state = planar_state()
+      configuration = Transform2D.new(1.0, 2.0, 0.5)
+
+      :ok = State.set_configuration(state, :base, configuration)
+      :ok = State.set_configuration(state, :mast, 0.75)
+
+      assert State.get_chain_configurations(state, :sensor_head) == [
+               {:base, configuration},
+               {:mast, 0.75}
+             ]
+    end
+  end
+
+  describe "floating joints" do
+    test "default to the identity" do
+      {:ok, configuration} = State.get_configuration(floating_state(), :base)
+
+      assert Nx.to_flat_list(Transform.tensor(configuration)) ==
+               Nx.to_flat_list(Transform.tensor(Transform.identity()))
+    end
+
+    # The whole point of storing raw bytes rather than decomposing to a
+    # quaternion and translation: 16 numbers to 7 is not a bijection, and the
+    # round-trip would run on every read, so error would accumulate.
+    test "round-trip a Transform bit-exactly" do
+      state = floating_state()
+      configuration = awkward_transform()
+
+      assert :ok = State.set_configuration(state, :base, configuration)
+      {:ok, recovered} = State.get_configuration(state, :base)
+
+      assert Nx.to_binary(Transform.tensor(recovered)) ==
+               Nx.to_binary(Transform.tensor(configuration))
+    end
+
+    test "survive repeated reads without drifting" do
+      state = floating_state()
+      configuration = awkward_transform()
+      :ok = State.set_configuration(state, :base, configuration)
+
+      expected = Nx.to_binary(Transform.tensor(configuration))
+
+      for _ <- 1..25 do
+        {:ok, recovered} = State.get_configuration(state, :base)
+        assert Nx.to_binary(Transform.tensor(recovered)) == expected
+      end
+    end
+
+    test "round-trip a Twist bit-exactly" do
+      state = floating_state()
+
+      velocity = %Twist{
+        linear: Vec3.new(1.2345678901234567, -0.9876543210987654, 0.5),
+        angular: Vec3.new(-0.111111111111111, 0.222222222222222, -0.333333333333333)
+      }
+
+      assert :ok = State.set_velocity(state, :base, velocity)
+      {:ok, recovered} = State.get_velocity(state, :base)
+
+      assert Nx.to_binary(Vec3.tensor(recovered.linear)) ==
+               Nx.to_binary(Vec3.tensor(velocity.linear))
+
+      assert Nx.to_binary(Vec3.tensor(recovered.angular)) ==
+               Nx.to_binary(Vec3.tensor(velocity.angular))
+    end
+
+    test "keep no tensor struct in the table, so the backend can't leak in" do
+      state = floating_state()
+      :ok = State.set_configuration(state, :base, awkward_transform())
+
+      assert [{{:configuration, :base}, stored}] =
+               :ets.lookup(state.table, {:configuration, :base})
+
+      assert is_binary(stored)
+      assert byte_size(stored) == 128
+    end
+
+    test "reject a bare float, naming Transform as expected" do
+      assert {:error, %JointConfig{joint: :base, expected: Transform}} =
+               State.set_configuration(floating_state(), :base, 0.5)
+    end
+
+    test "reject a Transform2D, since a floating joint is not confined to a plane" do
+      assert {:error, %JointConfig{expected: Transform}} =
+               State.set_configuration(floating_state(), :base, Transform2D.identity())
+    end
+
+    test "reject a Twist2D as a velocity" do
+      velocity = %Twist2D{vx: 0.0, vy: 0.0, omega: 0.0}
+
+      assert {:error, %JointConfig{field: :velocity, expected: Twist}} =
+               State.set_velocity(floating_state(), :base, velocity)
+    end
+  end
+
+  describe "fixed joints" do
+    setup do
+      {:ok, state} = State.new(DifferentialDriveRobot.robot())
+
+      %{state: state}
+    end
+
+    test "read as zero, which is what forward kinematics expects", %{state: state} do
+      assert State.get_configuration(state, :caster_joint) == {:ok, 0.0}
+      assert Map.fetch!(State.get_all_configurations(state), :caster_joint) == 0.0
+    end
+
+    # Zero DoF means a configuration space with exactly one point, so that point
+    # is assignable. Rejecting it broke read-modify-write on any robot with a
+    # fixed joint, which is most of them.
+    test "accept the single configuration they have", %{state: state} do
+      assert :ok = State.set_configuration(state, :caster_joint, 0.0)
+      assert :ok = State.set_configuration(state, :caster_joint, 0)
+      assert State.get_configuration(state, :caster_joint) == {:ok, 0.0}
+    end
+
+    test "reject a value they could never take", %{state: state} do
+      assert {:error, %JointConfig{joint: :caster_joint, expected: +0.0}} =
+               State.set_configuration(state, :caster_joint, 0.5)
+
+      assert {:error, %JointConfig{joint: :caster_joint}} =
+               State.set_configuration(state, :caster_joint, Transform.identity())
+    end
+  end
+
+  describe "read-modify-write" do
+    # get_all_configurations/1 must hand back a map set_configurations/2 accepts,
+    # or the most obvious way to use this module is broken.
+    test "a whole configuration map round-trips unchanged" do
+      for robot <- [
+            DifferentialDriveRobot.robot(),
+            PlanarRover.robot(),
+            FloatingDrone.robot()
+          ] do
+        {:ok, state} = State.new(robot)
+
+        configurations = State.get_all_configurations(state)
+        assert :ok = State.set_configurations(state, configurations)
+      end
+    end
+
+    test "a whole velocity map round-trips unchanged" do
+      for robot <- [
+            DifferentialDriveRobot.robot(),
+            PlanarRover.robot(),
+            FloatingDrone.robot()
+          ] do
+        {:ok, state} = State.new(robot)
+
+        assert :ok = State.set_velocities(state, State.get_all_velocities(state))
+      end
+    end
+
+    test "round-trips a modified map, including the multi-DoF entries" do
+      {:ok, state} = State.new(PlanarRover.robot())
+      configuration = Transform2D.new(1.5, -2.5, 0.75)
+
+      modified =
+        state
+        |> State.get_all_configurations()
+        |> Map.put(:base, configuration)
+        |> Map.put(:mast, 0.25)
+
+      assert :ok = State.set_configurations(state, modified)
+      assert State.get_all_configurations(state) == modified
+    end
+  end
+
+  describe "bulk writes" do
+    test "accept a mixture of shapes" do
+      state = planar_state()
+      configuration = Transform2D.new(3.0, 4.0, -0.25)
+
+      assert :ok = State.set_configurations(state, %{base: configuration, mast: 0.5})
+
+      assert State.get_configuration(state, :base) == {:ok, configuration}
+      assert State.get_configuration(state, :mast) == {:ok, 0.5}
+    end
+
+    test "reject the whole map when one shape is wrong" do
+      state = planar_state()
+
+      assert {:error, %JointConfig{joint: :base}} =
+               State.set_configurations(state, %{base: 0.5, mast: 0.5})
+
+      assert State.get_configuration(state, :base) == {:ok, Transform2D.identity()}
+      assert State.get_configuration(state, :mast) == {:ok, 0.0}
+    end
+  end
+end

--- a/test/bb/robot_test.exs
+++ b/test/bb/robot_test.exs
@@ -6,6 +6,10 @@ defmodule BB.RobotTest do
   use ExUnit.Case, async: true
   import BB.Unit
 
+  alias BB.Error.Kinematics.NoParentJoint
+  alias BB.Error.Kinematics.NotAnAncestor
+  alias BB.Error.Kinematics.UnknownJoint
+  alias BB.Error.Kinematics.UnknownLink
   alias BB.Math.Transform
   alias BB.Math.Vec3
   alias BB.Robot
@@ -106,48 +110,142 @@ defmodule BB.RobotTest do
       assert map_size(robot.joints) == 3
     end
 
+    test "root_link/1 returns the root of the kinematic tree" do
+      assert Robot.root_link(SimpleArm.robot()) == :base
+    end
+
     test "get_link/2 returns correct link" do
       robot = SimpleArm.robot()
-      link = Robot.get_link(robot, :upper_arm)
-      assert %Link{name: :upper_arm} = link
+      assert {:ok, %Link{name: :upper_arm}} = Robot.get_link(robot, :upper_arm)
+    end
+
+    test "get_link/2 names the robot when the link doesn't exist" do
+      robot = SimpleArm.robot()
+
+      assert {:error, %UnknownLink{link: :nope, robot: robot_name}} =
+               Robot.get_link(robot, :nope)
+
+      assert robot_name == robot.name
     end
 
     test "get_joint/2 returns correct joint" do
       robot = SimpleArm.robot()
-      joint = Robot.get_joint(robot, :elbow)
-      assert %Joint{name: :elbow, type: :revolute} = joint
+      assert {:ok, %Joint{name: :elbow, type: :revolute}} = Robot.get_joint(robot, :elbow)
+    end
+
+    test "get_joint/2 reports an unknown joint as a joint, not a link" do
+      assert {:error, %UnknownJoint{joint: :nope}} = Robot.get_joint(SimpleArm.robot(), :nope)
     end
 
     test "parent_joint/2 returns parent joint of a link" do
       robot = SimpleArm.robot()
-      assert Robot.parent_joint(robot, :base) == nil
-      assert %Joint{name: :shoulder} = Robot.parent_joint(robot, :upper_arm)
-      assert %Joint{name: :elbow} = Robot.parent_joint(robot, :forearm)
+      assert {:ok, %Joint{name: :shoulder}} = Robot.parent_joint(robot, :upper_arm)
+      assert {:ok, %Joint{name: :elbow}} = Robot.parent_joint(robot, :forearm)
+    end
+
+    # The root having no parent is a structural fact, so a caller walking up the
+    # tree gets a termination signal rather than "that link doesn't exist".
+    test "parent_joint/2 distinguishes the root from an unknown link" do
+      robot = SimpleArm.robot()
+
+      assert {:error, %NoParentJoint{link: :base}} = Robot.parent_joint(robot, :base)
+      assert {:error, %UnknownLink{link: :nope}} = Robot.parent_joint(robot, :nope)
     end
 
     test "child_joints/2 returns child joints of a link" do
       robot = SimpleArm.robot()
-      [shoulder] = Robot.child_joints(robot, :base)
-      assert shoulder.name == :shoulder
+      assert {:ok, [%Joint{name: :shoulder}]} = Robot.child_joints(robot, :base)
+    end
 
-      assert Robot.child_joints(robot, :end_effector) == []
+    test "child_joints/2 distinguishes no children from no such link" do
+      robot = SimpleArm.robot()
+
+      assert {:ok, []} = Robot.child_joints(robot, :end_effector)
+      assert {:error, %UnknownLink{link: :nope}} = Robot.child_joints(robot, :nope)
     end
 
     test "path_to/2 returns path from root" do
       robot = SimpleArm.robot()
-      assert Robot.path_to(robot, :base) == [:base]
-      assert Robot.path_to(robot, :shoulder) == [:base, :shoulder]
-      assert Robot.path_to(robot, :upper_arm) == [:base, :shoulder, :upper_arm]
+      assert Robot.path_to(robot, :base) == {:ok, [:base]}
+      assert Robot.path_to(robot, :shoulder) == {:ok, [:base, :shoulder]}
+      assert Robot.path_to(robot, :upper_arm) == {:ok, [:base, :shoulder, :upper_arm]}
 
-      assert Robot.path_to(robot, :end_effector) == [
-               :base,
-               :shoulder,
-               :upper_arm,
-               :elbow,
-               :forearm,
-               :wrist,
-               :end_effector
-             ]
+      assert Robot.path_to(robot, :end_effector) ==
+               {:ok,
+                [
+                  :base,
+                  :shoulder,
+                  :upper_arm,
+                  :elbow,
+                  :forearm,
+                  :wrist,
+                  :end_effector
+                ]}
+    end
+
+    test "path_to/2 errors on an unknown link" do
+      assert {:error, %UnknownLink{link: :nope}} = Robot.path_to(SimpleArm.robot(), :nope)
+    end
+
+    test "path_between/3 drops the prefix above the source" do
+      robot = SimpleArm.robot()
+
+      assert Robot.path_between(robot, :upper_arm, :end_effector) ==
+               {:ok, [:upper_arm, :elbow, :forearm, :wrist, :end_effector]}
+    end
+
+    test "path_between/3 from the root agrees with path_to/2" do
+      robot = SimpleArm.robot()
+
+      assert Robot.path_between(robot, Robot.root_link(robot), :end_effector) ==
+               Robot.path_to(robot, :end_effector)
+    end
+
+    test "path_between/3 from a link to itself is that link alone" do
+      assert Robot.path_between(SimpleArm.robot(), :forearm, :forearm) == {:ok, [:forearm]}
+    end
+
+    # Reversing the ends is the easy mistake, and the error should say which
+    # link the caller should have passed rather than just reporting a failure.
+    test "path_between/3 reports the nearest common ancestor when the source is below the target" do
+      robot = SimpleArm.robot()
+
+      assert {:error,
+              %NotAnAncestor{
+                source_link: :end_effector,
+                target_link: :upper_arm,
+                common_ancestor: :upper_arm
+              }} = Robot.path_between(robot, :end_effector, :upper_arm)
+    end
+
+    test "path_between/3 attributes an unknown link to the right end" do
+      robot = SimpleArm.robot()
+
+      assert {:error, %UnknownLink{link: :nope, role: :source}} =
+               Robot.path_between(robot, :nope, :forearm)
+
+      assert {:error, %UnknownLink{link: :nope, role: :target}} =
+               Robot.path_between(robot, :forearm, :nope)
+    end
+
+    # A single chain can't produce a branch point, so the sibling case needs a
+    # topology that actually branches.
+    test "path_between/3 names the branch point for two siblings" do
+      robot = BB.ExampleRobots.DifferentialDriveRobot.robot()
+
+      assert {:error,
+              %NotAnAncestor{
+                source_link: :left_wheel,
+                target_link: :right_wheel,
+                common_ancestor: :base_link
+              }} = Robot.path_between(robot, :left_wheel, :right_wheel)
+    end
+
+    test "path_between/3 descends into one branch without picking up the others" do
+      robot = BB.ExampleRobots.DifferentialDriveRobot.robot()
+
+      assert Robot.path_between(robot, :base_link, :right_wheel) ==
+               {:ok, [:base_link, :right_wheel_joint, :right_wheel]}
     end
 
     test "links_in_order/1 returns links in topological order" do
@@ -168,7 +266,7 @@ defmodule BB.RobotTest do
   describe "Link struct" do
     test "has parent and child references" do
       robot = SimpleArm.robot()
-      upper_arm = Robot.get_link(robot, :upper_arm)
+      {:ok, upper_arm} = Robot.get_link(robot, :upper_arm)
 
       assert upper_arm.parent_joint == :shoulder
       assert upper_arm.child_joints == [:elbow]
@@ -176,7 +274,7 @@ defmodule BB.RobotTest do
 
     test "root link has no parent" do
       robot = SimpleArm.robot()
-      base = Robot.get_link(robot, :base)
+      {:ok, base} = Robot.get_link(robot, :base)
 
       assert base.parent_joint == nil
       assert base.child_joints == [:shoulder]
@@ -184,14 +282,14 @@ defmodule BB.RobotTest do
 
     test "leaf link has no children" do
       robot = SimpleArm.robot()
-      end_effector = Robot.get_link(robot, :end_effector)
+      {:ok, end_effector} = Robot.get_link(robot, :end_effector)
 
       assert end_effector.child_joints == []
     end
 
     test "mass is converted to kilograms" do
       robot = SimpleArm.robot()
-      base = Robot.get_link(robot, :base)
+      {:ok, base} = Robot.get_link(robot, :base)
 
       assert base.mass == 5.0
     end
@@ -200,7 +298,7 @@ defmodule BB.RobotTest do
   describe "Joint struct" do
     test "has parent and child link references" do
       robot = SimpleArm.robot()
-      elbow = Robot.get_joint(robot, :elbow)
+      {:ok, elbow} = Robot.get_joint(robot, :elbow)
 
       assert elbow.parent_link == :upper_arm
       assert elbow.child_link == :forearm
@@ -208,7 +306,7 @@ defmodule BB.RobotTest do
 
     test "origin is converted to meters and radians" do
       robot = SimpleArm.robot()
-      shoulder = Robot.get_joint(robot, :shoulder)
+      {:ok, shoulder} = Robot.get_joint(robot, :shoulder)
 
       assert shoulder.origin.position == {0.0, 0.0, 0.1}
       assert shoulder.origin.orientation == {0.0, 0.0, 0.0}
@@ -216,14 +314,14 @@ defmodule BB.RobotTest do
 
     test "axis is normalised" do
       robot = SimpleArm.robot()
-      shoulder = Robot.get_joint(robot, :shoulder)
+      {:ok, shoulder} = Robot.get_joint(robot, :shoulder)
 
       assert shoulder.axis == {0.0, 0.0, 1.0}
     end
 
     test "limits are converted to radians" do
       robot = SimpleArm.robot()
-      shoulder = Robot.get_joint(robot, :shoulder)
+      {:ok, shoulder} = Robot.get_joint(robot, :shoulder)
 
       assert_in_delta shoulder.limits.lower, -:math.pi() / 2, 0.001
       assert_in_delta shoulder.limits.upper, :math.pi() / 2, 0.001
@@ -231,7 +329,7 @@ defmodule BB.RobotTest do
 
     test "velocity is converted to radians per second" do
       robot = SimpleArm.robot()
-      shoulder = Robot.get_joint(robot, :shoulder)
+      {:ok, shoulder} = Robot.get_joint(robot, :shoulder)
 
       expected = 2.0 * :math.pi() / 180.0
       assert_in_delta shoulder.limits.velocity, expected, 0.0001
@@ -239,13 +337,13 @@ defmodule BB.RobotTest do
 
     test "rotational?/1 returns true for revolute joints" do
       robot = SimpleArm.robot()
-      shoulder = Robot.get_joint(robot, :shoulder)
+      {:ok, shoulder} = Robot.get_joint(robot, :shoulder)
       assert Joint.rotational?(shoulder)
     end
 
     test "movable?/1 returns true for non-fixed joints" do
       robot = SimpleArm.robot()
-      shoulder = Robot.get_joint(robot, :shoulder)
+      {:ok, shoulder} = Robot.get_joint(robot, :shoulder)
       assert Joint.movable?(shoulder)
     end
   end
@@ -255,10 +353,16 @@ defmodule BB.RobotTest do
       robot = SimpleArm.robot()
       topology = robot.topology
 
-      assert Topology.depth_of(topology, :base) == 0
-      assert Topology.depth_of(topology, :shoulder) == 1
-      assert Topology.depth_of(topology, :upper_arm) == 1
-      assert Topology.depth_of(topology, :elbow) == 2
+      assert Topology.depth_of(topology, :base) == {:ok, 0}
+      assert Topology.depth_of(topology, :shoulder) == {:ok, 1}
+      assert Topology.depth_of(topology, :upper_arm) == {:ok, 1}
+      assert Topology.depth_of(topology, :elbow) == {:ok, 2}
+    end
+
+    test "depth_of/2 errors on an unknown node" do
+      topology = SimpleArm.robot().topology
+
+      assert {:error, %UnknownLink{link: :nope}} = Topology.depth_of(topology, :nope)
     end
 
     test "max_depth/1 returns maximum depth" do
@@ -551,7 +655,7 @@ defmodule BB.RobotTest do
     test "raises for unknown link" do
       robot = SimpleArm.robot()
 
-      assert_raise ArgumentError, ~r/Unknown link/, fn ->
+      assert_raise UnknownLink, ~r/Unknown link: :nonexistent/, fn ->
         Kinematics.forward_kinematics(robot, %{}, :nonexistent)
       end
     end

--- a/test/bb/robot_test.exs
+++ b/test/bb/robot_test.exs
@@ -6,11 +6,14 @@ defmodule BB.RobotTest do
   use ExUnit.Case, async: true
   import BB.Unit
 
+  alias BB.Error.Invalid.JointConfig
   alias BB.Error.Kinematics.NoParentJoint
   alias BB.Error.Kinematics.NotAnAncestor
   alias BB.Error.Kinematics.UnknownJoint
   alias BB.Error.Kinematics.UnknownLink
+  alias BB.ExampleRobots.DifferentialDriveRobot
   alias BB.Math.Transform
+  alias BB.Math.Transform2D
   alias BB.Math.Vec3
   alias BB.Robot
   alias BB.Robot.{Joint, Kinematics, Link, State, Topology}
@@ -231,7 +234,7 @@ defmodule BB.RobotTest do
     # A single chain can't produce a branch point, so the sibling case needs a
     # topology that actually branches.
     test "path_between/3 names the branch point for two siblings" do
-      robot = BB.ExampleRobots.DifferentialDriveRobot.robot()
+      robot = DifferentialDriveRobot.robot()
 
       assert {:error,
               %NotAnAncestor{
@@ -242,7 +245,7 @@ defmodule BB.RobotTest do
     end
 
     test "path_between/3 descends into one branch without picking up the others" do
-      robot = BB.ExampleRobots.DifferentialDriveRobot.robot()
+      robot = DifferentialDriveRobot.robot()
 
       assert Robot.path_between(robot, :base_link, :right_wheel) ==
                {:ok, [:base_link, :right_wheel_joint, :right_wheel]}
@@ -491,92 +494,90 @@ defmodule BB.RobotTest do
   end
 
   describe "State" do
-    test "new/1 creates state with zero positions" do
-      robot = SimpleArm.robot()
-      {:ok, state} = State.new(robot)
+    # The table is owned by the test process and freed when it exits, so there is
+    # nothing to tear down.
+    setup do
+      {:ok, state} = State.new(SimpleArm.robot())
 
-      assert State.get_joint_position(state, :shoulder) == 0.0
-      assert State.get_joint_position(state, :elbow) == 0.0
-      assert State.get_joint_position(state, :wrist) == 0.0
-
-      State.delete(state)
+      %{state: state}
     end
 
-    test "set_joint_position/3 and get_joint_position/2" do
-      robot = SimpleArm.robot()
-      {:ok, state} = State.new(robot)
-
-      State.set_joint_position(state, :shoulder, 0.5)
-      assert State.get_joint_position(state, :shoulder) == 0.5
-
-      State.delete(state)
+    test "new/1 creates state with zero configurations", %{state: state} do
+      assert State.get_configuration(state, :shoulder) == {:ok, 0.0}
+      assert State.get_configuration(state, :elbow) == {:ok, 0.0}
+      assert State.get_configuration(state, :wrist) == {:ok, 0.0}
     end
 
-    test "set_joint_velocity/3 and get_joint_velocity/2" do
-      robot = SimpleArm.robot()
-      {:ok, state} = State.new(robot)
-
-      State.set_joint_velocity(state, :shoulder, 1.5)
-      assert State.get_joint_velocity(state, :shoulder) == 1.5
-
-      State.delete(state)
+    test "set_configuration/3 and get_configuration/2", %{state: state} do
+      assert :ok = State.set_configuration(state, :shoulder, 0.5)
+      assert State.get_configuration(state, :shoulder) == {:ok, 0.5}
     end
 
-    test "get_all_positions/1 returns all joint positions" do
-      robot = SimpleArm.robot()
-      {:ok, state} = State.new(robot)
-
-      State.set_joint_position(state, :shoulder, 0.1)
-      State.set_joint_position(state, :elbow, 0.2)
-      State.set_joint_position(state, :wrist, 0.3)
-
-      positions = State.get_all_positions(state)
-      assert positions == %{shoulder: 0.1, elbow: 0.2, wrist: 0.3}
-
-      State.delete(state)
+    test "set_velocity/3 and get_velocity/2", %{state: state} do
+      assert :ok = State.set_velocity(state, :shoulder, 1.5)
+      assert State.get_velocity(state, :shoulder) == {:ok, 1.5}
     end
 
-    test "set_positions/2 sets multiple positions at once" do
-      robot = SimpleArm.robot()
-      {:ok, state} = State.new(robot)
-
-      State.set_positions(state, %{shoulder: 0.5, elbow: 1.0})
-
-      assert State.get_joint_position(state, :shoulder) == 0.5
-      assert State.get_joint_position(state, :elbow) == 1.0
-
-      State.delete(state)
+    test "accessors report an unknown joint rather than returning nil", %{state: state} do
+      assert {:error, %UnknownJoint{joint: :nope}} = State.get_configuration(state, :nope)
+      assert {:error, %UnknownJoint{joint: :nope}} = State.get_velocity(state, :nope)
+      assert {:error, %UnknownJoint{joint: :nope}} = State.set_configuration(state, :nope, 0.5)
+      assert {:error, %UnknownJoint{joint: :nope}} = State.set_velocity(state, :nope, 0.5)
     end
 
-    test "reset/1 resets all positions to zero" do
-      robot = SimpleArm.robot()
-      {:ok, state} = State.new(robot)
+    test "get_all_configurations/1 returns every joint", %{state: state} do
+      :ok = State.set_configuration(state, :shoulder, 0.1)
+      :ok = State.set_configuration(state, :elbow, 0.2)
+      :ok = State.set_configuration(state, :wrist, 0.3)
 
-      State.set_joint_position(state, :shoulder, 0.5)
-      State.reset(state)
-
-      assert State.get_joint_position(state, :shoulder) == 0.0
-
-      State.delete(state)
+      assert State.get_all_configurations(state) == %{shoulder: 0.1, elbow: 0.2, wrist: 0.3}
     end
 
-    test "get_chain_positions/2 returns positions along path" do
-      robot = SimpleArm.robot()
-      {:ok, state} = State.new(robot)
+    test "set_configurations/2 sets multiple configurations at once", %{state: state} do
+      assert :ok = State.set_configurations(state, %{shoulder: 0.5, elbow: 1.0})
 
-      State.set_joint_position(state, :shoulder, 0.1)
-      State.set_joint_position(state, :elbow, 0.2)
-      State.set_joint_position(state, :wrist, 0.3)
+      assert State.get_configuration(state, :shoulder) == {:ok, 0.5}
+      assert State.get_configuration(state, :elbow) == {:ok, 1.0}
+    end
 
-      positions = State.get_chain_positions(state, :end_effector)
+    # A bulk write that applied its valid half would leave the robot in a
+    # configuration nobody asked for.
+    test "set_configurations/2 writes nothing when any entry is rejected", %{state: state} do
+      :ok = State.set_configuration(state, :shoulder, 0.5)
 
-      assert positions == [
+      assert {:error, %UnknownJoint{}} =
+               State.set_configurations(state, %{elbow: 1.0, nope: 2.0})
+
+      assert State.get_configuration(state, :shoulder) == {:ok, 0.5}
+      assert State.get_configuration(state, :elbow) == {:ok, 0.0}
+    end
+
+    test "reset/1 resets all configurations to zero", %{state: state} do
+      :ok = State.set_configuration(state, :shoulder, 0.5)
+      :ok = State.reset(state)
+
+      assert State.get_configuration(state, :shoulder) == {:ok, 0.0}
+    end
+
+    test "get_chain_configurations/2 returns configurations along path", %{state: state} do
+      :ok = State.set_configuration(state, :shoulder, 0.1)
+      :ok = State.set_configuration(state, :elbow, 0.2)
+      :ok = State.set_configuration(state, :wrist, 0.3)
+
+      assert State.get_chain_configurations(state, :end_effector) == [
                {:shoulder, 0.1},
                {:elbow, 0.2},
                {:wrist, 0.3}
              ]
+    end
 
-      State.delete(state)
+    test "rejects a value whose shape doesn't match the joint type", %{state: state} do
+      assert {:error,
+              %JointConfig{
+                joint: :shoulder,
+                field: :configuration,
+                expected: :float
+              }} = State.set_configuration(state, :shoulder, Transform2D.new(1.0, 2.0, 0.3))
     end
   end
 
@@ -599,7 +600,7 @@ defmodule BB.RobotTest do
       robot = SimpleArm.robot()
       {:ok, state} = State.new(robot)
 
-      State.set_joint_position(state, :shoulder, :math.pi() / 2)
+      State.set_configuration(state, :shoulder, :math.pi() / 2)
 
       transform = Kinematics.forward_kinematics(robot, state, :upper_arm)
       pos = Transform.get_translation(transform)

--- a/test/support/example_robots.ex
+++ b/test/support/example_robots.ex
@@ -1059,4 +1059,98 @@ defmodule BB.ExampleRobots do
       end
     end
   end
+
+  defmodule PlanarRover do
+    @moduledoc """
+    A rover whose base moves in the ground plane, plus a revolute mast.
+
+    The `:base` joint is `:planar` with a vertical surface normal, so the chassis
+    has three degrees of freedom — two in-plane translations and yaw. The mast
+    above it is an ordinary revolute joint, which makes this a chain where a
+    multi-DoF joint and a single-DoF joint compose.
+    """
+    use BB
+    import BB.Unit
+
+    settings do
+      name(:planar_rover)
+    end
+
+    topology do
+      link :odom do
+        joint :base do
+          type(:planar)
+
+          axis do
+          end
+
+          link :chassis do
+            joint :mast do
+              type(:revolute)
+
+              origin do
+                z(~u(0.2 meter))
+              end
+
+              axis do
+              end
+
+              limit do
+                effort(~u(10 newton_meter))
+                velocity(~u(90 degree_per_second))
+              end
+
+              link(:sensor_head)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  defmodule FloatingDrone do
+    @moduledoc """
+    An airframe with a fully free base, plus a revolute gimbal.
+
+    The `:base` joint is `:floating`, so the airframe has all six degrees of
+    freedom. The gimbal below it is revolute, and its origin is deliberately
+    offset on two axes so that composing the two does not commute.
+    """
+    use BB
+    import BB.Unit
+
+    settings do
+      name(:floating_drone)
+    end
+
+    topology do
+      link :world do
+        joint :base do
+          type(:floating)
+
+          link :airframe do
+            joint :gimbal do
+              type(:revolute)
+
+              origin do
+                x(~u(0.1 meter))
+                z(~u(-0.05 meter))
+              end
+
+              axis do
+                roll(~u(-90 degree))
+              end
+
+              limit do
+                effort(~u(2 newton_meter))
+                velocity(~u(180 degree_per_second))
+              end
+
+              link(:camera)
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/test/support/mock_solver.ex
+++ b/test/support/mock_solver.ex
@@ -7,7 +7,7 @@ defmodule BB.Test.MockSolver do
   Mock IK solver for testing BB.Motion without real IK computations.
 
   Configure behaviour via process dictionary:
-  - `:mock_solver_result` - the result to return from solve/5
+  - `:mock_solver_result` - the result to return from solve/6
 
   ## Examples
 
@@ -20,7 +20,7 @@ defmodule BB.Test.MockSolver do
   alias BB.Error.Kinematics.Unreachable
 
   @doc """
-  Set the result that solve/5 will return.
+  Set the result that solve/6 will return.
   """
   def set_result(result) do
     Process.put(:mock_solver_result, result)
@@ -48,8 +48,11 @@ defmodule BB.Test.MockSolver do
   end
 
   @impl BB.IK.Solver
-  def solve(robot, state_or_positions, target_link, target, opts) do
-    Process.put(:mock_solver_last_call, {robot, state_or_positions, target_link, target, opts})
+  def solve(robot, state_or_configurations, source_link, target_link, target, opts) do
+    Process.put(
+      :mock_solver_last_call,
+      {robot, state_or_configurations, source_link, target_link, target, opts}
+    )
 
     case Process.get(:mock_solver_result) do
       nil ->

--- a/usage-rules/anti-patterns.md
+++ b/usage-rules/anti-patterns.md
@@ -67,8 +67,9 @@ BB.Robot.Kinematics.link_position(MyRobot.Robot.robot(), positions, :tip)
 
 Current, easily-confused signatures:
 
-- Current joint positions: `BB.Robot.Runtime.positions/1` (not
-  `joint_positions/1`).
+- Current joint configurations: `BB.Robot.Runtime.configurations/1` (not
+  `positions/1` or `joint_positions/1` — a joint's configuration is a float only
+  when it has one degree of freedom).
 - Command callback is `handle_command/3` (goal, context, state) — not `/2`.
 - IK goes through `BB.Motion.move_to/4` with a required `:solver:`; there is no
   default solver in core.

--- a/usage-rules/anti-patterns.md
+++ b/usage-rules/anti-patterns.md
@@ -71,8 +71,10 @@ Current, easily-confused signatures:
   `positions/1` or `joint_positions/1` — a joint's configuration is a float only
   when it has one degree of freedom).
 - Command callback is `handle_command/3` (goal, context, state) — not `/2`.
-- IK goes through `BB.Motion.move_to/4` with a required `:solver:`; there is no
-  default solver in core.
+- IK goes through `BB.Motion.move_to/4` with required `:solver` and
+  `:source_link` options; there is no default solver in core, and no default
+  source link either — pass `BB.Robot.root_link(robot)` if you mean the whole
+  tree.
 
 When unsure, `mix usage_rules.search_docs "<topic>" -p bb` rather than
 inventing a function.

--- a/usage-rules/kinematics.md
+++ b/usage-rules/kinematics.md
@@ -10,25 +10,28 @@ SPDX-License-Identifier: Apache-2.0
 
 `BB.Robot.Kinematics` works on the **compiled `%BB.Robot{}` struct**, not the
 robot module. Get the struct with `MyRobot.Robot.robot()`, and current joint
-positions from the runtime with `BB.Robot.Runtime.positions/1`:
+configurations from the runtime with `BB.Robot.Runtime.configurations/1`:
 
 ```elixir
 robot = MyRobot.Robot.robot()
-positions = BB.Robot.Runtime.positions(MyRobot.Robot)   # %{joint_name => radians}
+configurations = BB.Robot.Runtime.configurations(MyRobot.Robot)
 
 # Cartesian position of a link:
-{x, y, z} = BB.Robot.Kinematics.link_position(robot, positions, :camera_link)
+{x, y, z} = BB.Robot.Kinematics.link_position(robot, configurations, :camera_link)
 
 # Full 4x4 pose (position + orientation):
-transform = BB.Robot.Kinematics.forward_kinematics(robot, positions, :camera_link)
+transform = BB.Robot.Kinematics.forward_kinematics(robot, configurations, :camera_link)
 
 # Every link at once (more efficient than repeated calls):
-transforms = BB.Robot.Kinematics.all_link_transforms(robot, positions)
+transforms = BB.Robot.Kinematics.all_link_transforms(robot, configurations)
 ```
 
-You can also pass an explicit `%{joint => radians}` map instead of the live
-positions to ask "where *would* this link be". Transforms are
-`BB.Math.Transform` 4x4 matrices; angles are radians throughout.
+You can also pass an explicit configuration map instead of the live one to ask
+"where *would* this link be". A single-DoF joint's configuration is a bare float
+— radians for revolute, metres for prismatic — while `:planar` and `:floating`
+joints carry a `BB.Math.Transform2D` and a `BB.Math.Transform` respectively. See
+`BB.Robot.State` for the full table. Transforms are `BB.Math.Transform` 4x4
+matrices; angles are radians throughout.
 
 ## Inverse kinematics — "what joint angles reach this point?"
 

--- a/usage-rules/kinematics.md
+++ b/usage-rules/kinematics.md
@@ -41,11 +41,18 @@ IK solvers are **pluggable** and ship in satellite packages (`bb_ik_dls`,
 
 ```elixir
 {:ok, meta} =
-  BB.Motion.move_to(MyRobot.Robot, :gripper, {0.3, 0.2, 0.1}, solver: BB.IK.FABRIK)
+  BB.Motion.move_to(MyRobot.Robot, :gripper, {0.3, 0.2, 0.1},
+    source_link: :base_link,
+    solver: BB.IK.FABRIK
+  )
 ```
 
 - **`:solver` is required** — core ships no default. Add a solver package and
   pass its module.
+- **`:source_link` is required too**, and has no default. The root is right for a
+  fixed-base arm and silently wrong for a robot whose base floats, where it drags
+  a 6-DoF joint into a problem that has no business containing one. Pass
+  `BB.Robot.root_link(robot)` when you do mean the whole tree.
 - Targets are `{x, y, z}` in metres.
 - Use `BB.Motion.solve_only/4` to compute angles without moving.
 - Solver options (`:max_iterations`, `:tolerance`, `:respect_limits`) are


### PR DESCRIPTION
Implements [proposal 0022](https://github.com/beam-bots/proposals/blob/main/accepted/0022-multi-dof-joints.md).

`:floating` and `:planar` were already in the joint-type enum and both silently
returned `Transform.identity()` from forward kinematics. A user could declare one,
get no warning at compile time or runtime, and receive kinematics that treated the
joint as welded — every downstream pose wrong, nothing saying so. This finishes
both types.

## What changed

Seven commits, each self-contained:

| Commit | |
|---|---|
| `feat:` planar value types | `BB.Math.Transform2D`, `BB.Message.Geometry.Twist2D`/`Wrench2D` |
| `feat!:` kinematics error types | `UnknownJoint`, `UnknownActuator`, `NoParentJoint`, `NotAnAncestor`; `:role` on `UnknownLink` |
| `feat!:` result-tuple lookups | Eight introspection functions; `path_between/3`; `root_link/1` |
| `feat!:` multi-DoF state | Configuration storage, `positions` → `configurations` |
| `feat!:` FK and Jacobians | The kernel refactor; per-DoF Jacobian columns |
| `feat!:` `source_link` | `BB.IK.Solver.solve/6` |
| `feat!:` `JointState` + DSL | Type-appropriate message values; joint-axis validation |

## The design decision worth reviewing

The proposal's Option C says a multi-DoF joint expands "to the vectorised scalar
form *only* inside `chain_tensors/3`". Taken literally that reintroduces exactly
what Option B was rejected for: feeding `fk_chain` six scalars requires
decomposing the stored rotation into three angles about three axes, which is an
Euler decomposition — lossy, non-unique, gimbal-locked.

So the kernel takes per-joint **motion matrices**, and each joint contributes:

```
origin · scalar_motion(q) · stored · (I + hat(delta))
```

`delta` is the differentiable parameter the Jacobian needs and is **only ever
evaluated at zero**, which makes the first-order factor exactly right for both
jobs: at zero it *is* the identity, so forward kinematics through a floating base
is bit-exact; and since `exp(delta) = I + hat(delta) + O(delta²)`, its derivative
at zero matches the true exponential's.

A real `se(3)` exponential was tried first and is worse — `(1 - cos θ)/θ²` is a
literal 0/0 at the only point ever evaluated, which came back as `:nan` gradients.
Differentiating at the identity also means an Euler chart's singularities are never
visited, so there is no gimbal lock to regularise.

This resolves the proposal's open questions 1 and 2: `defn.ex` does change (more
than `chain_tensors/3`), and the Jacobian columns come out in the joint's **local
frame**, because that is what needs no special-casing.

The payoff is that single-DoF joints need no special case at all — `stored = I`
and `delta = 0` collapses the expression to exactly what it was, so the
fixed-base regression requirement is structural rather than something to test for.

## Verification

Correctness is established independently of the code under test:

- **FK against hand-computed poses**, not round-trips. A round-trip is
  self-consistent — a systematically wrong composition order passes it perfectly.
- **Jacobian against central finite differences of true rigid motions** (real
  `from_axis_angle`/`translation` perturbations composed into the chain, not of the
  linearisation). Max error 2.1e-10.
- **Composition-order test** where a floating base and a revolute joint do not
  commute, so swapping them is detectable rather than coincidentally equal.
- **`:planar` with a Y surface normal**, asserting both that the plane follows
  `axis` and that the chassis leaves the XY plane — proving XY is not assumed.
- **Bit-exact ETS round-trip** for a floating configuration, over 25 reads, using
  a deliberately awkward transform. A quaternion decomposition would fail this.

1312 tests, `mix check` green. `BB_VERSION=local ./bin/bb-check` is green in 20 of
21 workspace repos; the exception is `bb_example_so101`'s dialyzer, which fails
identically on `main` against published `bb` (274 pre-existing `unknown_function`
warnings in a mix task).

### Not done

**FK is not cross-checked against a known-good external implementation.** The
proposal asks for this in addition to hand-computed cases, and it is the one
acceptance criterion unmet.

## Beyond the proposal

Four changes the proposal does not list, each because the alternative preserved
something it was trying to remove:

- **`child_joints/2` returns a result tuple.** It calls both converted lookups, and
  returning `[]` for a missing link preserves the "no children" vs "no such link"
  conflation.
- **`Runtime.positions/1` → `configurations/1`.** A thin delegate whose map can now
  contain transforms; keeping the name reproduces the lying-API problem one layer
  up.
- **A fixed joint accepts `0.0`, not nothing.** Its configuration space is a single
  point, so that point is assignable — rejecting it broke read-modify-write, since
  `get_all_configurations/1` includes fixed joints. A nonzero angle or a
  `Transform` is still rejected.
- **An unknown joint in `joint_names` raises rather than yielding a zero column.**
  That silently swallowed typos and cannot survive per-DoF columns anyway.

Also fixes a pre-existing bug found on the way: `TopologyTransformer`'s
fixed-joint axis rule built its error with `module:` where `message:` was meant, so
its diagnostic printed as `nil`.

## Merge order

This must merge and publish before the satellite PRs can pass CI — the shared
workflow does not set `BB_VERSION`, so they currently compile against published
0.26.0. Their `~> 0.26` pins already admit 0.27.0, so no dependency edit is needed.
