### PR TITLE
fix: vectorise `link_transforms/9` over a batch axis

### DIFF
--- a/lib/bb/robot/kinematics/defn.ex
+++ b/lib/bb/robot/kinematics/defn.ex
@@ -103,6 +103,9 @@ defmodule BB.Robot.Kinematics.Defn do
   so it resolves to the identity. The per-joint inputs follow the same layout as
   `fk_chain/6`, describing each link's parent joint (identity-valued for the
   root). Returns `{n, 4, 4}`, one transform per link in input order.
+
+  Vectorises over a leading batch axis, so a fleet of identical chains — the legs
+  of a gait, say — resolves in one call with a lane per chain.
   """
   defn link_transforms(
          positions,
@@ -128,7 +131,12 @@ defmodule BB.Robot.Kinematics.Defn do
       )
 
     n = Nx.axis_size(joint_mats, 0)
-    init = Nx.broadcast(Nx.eye(4, type: :f64), {n, 4, 4})
+
+    # Derived from `joint_mats` rather than broadcast from a literal so that it
+    # carries whatever batch axis `positions` arrived with — `while` rejects an
+    # initial value shaped unlike the one its body produces, which made this
+    # unusable under `Nx.vectorize` (e.g. one lane per leg of a gait).
+    init = joint_mats |> Nx.multiply(0.0) |> Nx.add(Nx.eye(4, type: :f64))
 
     {result, _joint_mats, _parent_idx, _i} =
       while {acc = init, jm = joint_mats, parents = parent_idx, i = 0}, i < n do

--- a/test/bb/robot/kinematics_test.exs
+++ b/test/bb/robot/kinematics_test.exs
@@ -643,6 +643,51 @@ defmodule BB.Robot.KinematicsTest do
     end
   end
 
+  # Solving a fleet of identical chains at once — the legs of a gait — means one
+  # call with a lane per chain. The scan seeded its accumulator from a literal
+  # identity, which carries no batch axis, so `while` rejected the loop outright
+  # and the batched form could not run at all.
+  describe "link_transforms/9 vectorised over a batch of chains" do
+    setup do
+      rows = 3
+
+      # A root plus two revolute joints about Z, offset 0.3m then 0.2m along X.
+      solve = fn positions ->
+        Kinematics.Defn.link_transforms(
+          positions,
+          Nx.broadcast(0.0, {rows, 3}),
+          Nx.tensor([[0.0, 0.0, 0.0], [0.3, 0.0, 0.0], [0.2, 0.0, 0.0]], type: :f64),
+          Nx.tensor(List.duplicate([0.0, 0.0, 1.0], rows), type: :f64),
+          Nx.tensor([0.0, 1.0, 1.0], type: :f64),
+          Nx.broadcast(0.0, {rows}),
+          Nx.broadcast(Nx.eye(4, type: :f64), {rows, 4, 4}),
+          Nx.broadcast(0.0, {rows, 6}),
+          Nx.tensor([0, 0, 1], type: :s32)
+        )
+      end
+
+      %{solve: solve, lanes: [[0.0, 0.0, 0.0], [0.0, 0.3, 0.0], [0.0, 0.6, 0.3]]}
+    end
+
+    test "gives each lane the same answer as solving it alone", %{solve: solve, lanes: lanes} do
+      batched =
+        lanes
+        |> Nx.tensor(type: :f64)
+        |> Nx.vectorize(:chain)
+        |> solve.()
+        |> Nx.devectorize()
+
+      assert Nx.shape(batched) == {3, 3, 4, 4}
+
+      for {positions, lane} <- Enum.with_index(lanes) do
+        alone = solve.(Nx.tensor(positions, type: :f64))
+
+        assert Nx.all_close(batched[lane], alone) |> Nx.to_number() == 1,
+               "lane #{lane} disagrees with the same chain solved on its own"
+      end
+    end
+  end
+
   defp finite_difference_jacobian(robot, positions, target_link, joint_names) do
     epsilon = 1.0e-6
 


### PR DESCRIPTION
`BB.Robot.Kinematics.Defn.link_transforms/9` could not be used under
`Nx.vectorize/2`. It raised before running a single iteration:

```
expected all shapes to match {3, 3, *, 4, 3}, got unmatching shape: {3, 1, 3, 1, 4}
```

## Cause

The topological scan seeded its accumulator from a literal:

```elixir
init = Nx.broadcast(Nx.eye(4, type: :f64), {n, 4, 4})
```

A literal carries no vectorised axes. When `positions` arrives vectorised the
loop body produces a vectorised transform, `while` compares that against an
initial value shaped unlike it, and rejects the loop outright. So the batched
form did not merely run slowly — it could not run.

## Fix

Derive the identity from `joint_mats`, so it inherits whatever batch axis
`positions` came with. One line; the scan itself is untouched.

`fk_chain/8` was already fine — it composes via `chain_product/1`, a
`deftransform` that unrolls at trace time with no accumulator to mismatch. Only
the `while`-based scan was affected.

## Verification

A new test solves three chains as one batched call and checks each lane against
the same chain solved on its own — they agree exactly, and per-lane results are
independent. Full `mix check --no-retry` passes.

## Why now

This is the primitive a constrained IK solver needs: fitting a joint requires its
world axis and pivot under the values already chosen upstream, which means every
intermediate link transform rather than just the tip. Batching it is what lets a
fleet of identical chains — the legs of a gait — resolve in one call. Work in
`bb_ik_fabrik` depends on this landing first.