### PR TITLE
fix: break the compile-time cycle that deadlocks the Elixir 1.19 compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   CI:
-    uses: beam-bots/.github/.github/workflows/elixir-ci.yml@a84e0bc763d8ffd8e88b17843847e4e5490a25f8 # main
+    uses: beam-bots/.github/.github/workflows/elixir-ci.yml@15faf010d76683ee1fc1c79ae0697becc0f7af4b # main
     with:
       enable-spark-formatter: true
       enable-spark-cheat-sheets: true

--- a/lib/bb/message/option.ex
+++ b/lib/bb/message/option.ex
@@ -274,13 +274,17 @@ defmodule BB.Message.Option do
   defp configuration?(%Transform{}), do: true
   defp configuration?(_), do: false
 
+  # `is_struct/2` rather than a `%Twist{}` pattern: the message modules below
+  # `BB.Message.Geometry` import this one, so matching their structs here would
+  # close a compile-time cycle. Elixir 1.20 tolerates it, 1.19 deadlocks the
+  # parallel compiler. A module in a guard is only a runtime reference.
   defp velocity?(value) when is_float(value), do: true
-  defp velocity?(%Twist2D{}), do: true
-  defp velocity?(%Twist{}), do: true
+  defp velocity?(value) when is_struct(value, Twist2D), do: true
+  defp velocity?(value) when is_struct(value, Twist), do: true
   defp velocity?(_), do: false
 
   defp effort?(value) when is_float(value), do: true
-  defp effort?(%Wrench2D{}), do: true
-  defp effort?(%Wrench{}), do: true
+  defp effort?(value) when is_struct(value, Wrench2D), do: true
+  defp effort?(value) when is_struct(value, Wrench), do: true
   defp effort?(_), do: false
 end


### PR DESCRIPTION
Fixes #222.

## Root cause

A genuine compile-time cycle, two edges:

- `lib/bb/message/geometry/twist.ex:22` and `wrench.ex:22` — `import BB.Message.Option`, which blocks until `BB.Message.Option` is fully compiled.
- `lib/bb/message/option.ex:279` and `:284` — `defp velocity?(%Twist{})` and `defp effort?(%Wrench{})`, which under 1.19 block until those structs are defined.

Neither side can move. `Twist` and `Wrench` suspend on the `import` at line 22, *before* their own `defstruct` on line 26, so the struct `Option` is waiting for never gets announced. Moving `defstruct` above the `import` does not help — I checked; 1.19 doesn't publish a struct until the module finishes compiling.

Everything else in the reported deadlock list is collateral: `transmission.ex`, `robot/state.ex`, `robot/runtime.ex`, `command/move_to.ex`, `sensor/mimic.ex` and the other seven message modules are all just waiting on message structs that can't be produced while those two files are stuck. Breaking the one cycle clears all of them.

## Why 1.19 fails and 1.20 doesn't

Not a 1.19 bug that 1.20 fixed — 1.20 narrowed when a struct reference *blocks*. Two-file repro, `A` imports `B` and `B` refers to `%A{}`:

| `%A{}` appears as | 1.19.5 | 1.20.2 |
|---|---|---|
| pattern, no fields | deadlock | compiles |
| pattern, with fields (`%A{x: 1}`) | deadlock | compiles |
| expression / construction | deadlock | **deadlock** |

1.20 defers struct-key validation in patterns; construction still blocks. So the cycle here is real and 1.20 was masking it, which is why the fix is to remove the cycle rather than to move the `elixir:` requirement to `~> 1.20`.

## The fix

`is_struct/2` names the module in a guard, which is only a runtime reference, so no compile-time struct dependency is created.

`configuration?/1` keeps its `%Transform2D{}` / `%Transform{}` patterns: `BB.Math.Transform*` sits below the message layer and doesn't import back into it, so there's no cycle. That asymmetry is deliberate and there's a comment saying why, since it otherwise looks like an oversight.

`Twist2D` and `Wrench2D` don't import `BB.Message.Option` either — their schemas are plain `:float` — but they're converted alongside their 3D counterparts because the hazard is layer-wide and a mixed style within one predicate invites someone to "tidy" it back.

## Verification

- Reproduced against hex `bb` 0.28.0 in a clean project on Elixir 1.19.5/OTP 28: `mix deps.compile` fails with the exact deadlock from the issue.
- With this change, the same tree compiles clean and the full suite passes on 1.19.5/OTP 28: 38 doctests, 1275 tests, 0 failures.
- Unchanged on the pinned toolchain: `mix check --no-retry` fully green on 1.20.2/OTP 29 (dialyzer included — `is_struct/2` costs no type information here, since these clauses only return `true`).

## Why CI didn't catch it

`install-elixir` installs a single version from `.tool-versions` (1.20.2). The `elixir: "~> 1.19"` in `mix.exs` was never exercised. beam-bots/.github#37 adds a matrix over the Elixir minors between the declared floor and the pinned version — for this repo, one extra leg on 1.19.5/OTP 28.

The second commit here temporarily points `uses:` at that PR's branch so the new leg runs against this fix. **It reverts to a pinned SHA before either merges.**