### PR TITLE
fix!: waypoint rates are optional, and survive a transmission

### DIFF
--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -713,6 +713,9 @@ defmodule BB.Actuator do
     BB.call(robot, actuator_name, {:command, message}, timeout)
   end
 
+  defp as_float(nil), do: nil
+  defp as_float(value), do: value * 1.0
+
   defp build_trajectory_message(frame_id, waypoints, opts) do
     frame_id = if is_list(frame_id), do: List.last(frame_id), else: frame_id
 
@@ -722,8 +725,8 @@ defmodule BB.Actuator do
 
         [
           position: wp[:position] * 1.0,
-          velocity: wp[:velocity] * 1.0,
-          acceleration: wp[:acceleration] * 1.0,
+          velocity: as_float(wp[:velocity]),
+          acceleration: as_float(wp[:acceleration]),
           time_from_start: wp[:time_from_start]
         ]
       end)

--- a/lib/bb/message/actuator/command/trajectory.ex
+++ b/lib/bb/message/actuator/command/trajectory.ex
@@ -20,8 +20,10 @@ defmodule BB.Message.Actuator.Command.Trajectory do
   Each waypoint is a map with:
 
   - `position` - Position at this waypoint (radians or metres)
-  - `velocity` - Velocity at this waypoint (rad/s or m/s)
-  - `acceleration` - Acceleration at this waypoint (rad/s² or m/s²)
+  - `velocity` - Velocity at this waypoint (rad/s or m/s). Optional; omitted
+    leaves the pace to the driver, which will generally work out the speed
+    needed to arrive by `time_from_start`.
+  - `acceleration` - Acceleration at this waypoint (rad/s² or m/s²). Optional.
   - `time_from_start` - Time from trajectory start (milliseconds)
 
   ## Examples
@@ -58,8 +60,16 @@ defmodule BB.Message.Actuator.Command.Trajectory do
 
   @waypoint_schema [
     position: [type: :float, required: true, doc: "Position (radians or metres)"],
-    velocity: [type: :float, required: true, doc: "Velocity (rad/s or m/s)"],
-    acceleration: [type: :float, required: true, doc: "Acceleration (rad/s² or m/s²)"],
+    velocity: [
+      type: {:or, [nil, :float]},
+      required: false,
+      doc: "Velocity (rad/s or m/s). Omitted means the driver decides."
+    ],
+    acceleration: [
+      type: {:or, [nil, :float]},
+      required: false,
+      doc: "Acceleration (rad/s² or m/s²). Omitted means the driver decides."
+    ],
     time_from_start: [
       type: :non_neg_integer,
       required: true,

--- a/lib/bb/transmission.ex
+++ b/lib/bb/transmission.ex
@@ -132,13 +132,14 @@ defmodule BB.Transmission do
 
   defp apply_to_payload(other, _t), do: other
 
-  defp apply_to_waypoint(%{position: p, velocity: v, acceleration: a} = wp, t) do
-    %{
-      wp
-      | position: apply_position(p, t),
-        velocity: apply_rate(v, t),
-        acceleration: apply_rate(a, t)
-    }
+  # Waypoints are keyword lists, per `BB.Message.Actuator.Command.Trajectory`,
+  # and their rates are optional — an omitted one stays omitted rather than
+  # becoming a zero, which would mean "do not move" to a driver reading it.
+  defp apply_to_waypoint(waypoint, t) do
+    waypoint
+    |> Keyword.replace_lazy(:position, &apply_position(&1, t))
+    |> Keyword.replace_lazy(:velocity, &maybe_apply_rate(&1, t))
+    |> Keyword.replace_lazy(:acceleration, &maybe_apply_rate(&1, t))
   end
 
   defp maybe_apply_rate(nil, _t), do: nil

--- a/test/bb/transmission_test.exs
+++ b/test/bb/transmission_test.exs
@@ -110,6 +110,62 @@ defmodule BB.TransmissionTest do
     end
   end
 
+  describe "apply_to_command/2 with a trajectory" do
+    alias BB.Message
+    alias BB.Message.Actuator.Command
+
+    defp trajectory(waypoints) do
+      {:ok, message} =
+        Message.new(Command.Trajectory, :joint, waypoints: waypoints, repeat: 1)
+
+      message
+    end
+
+    defp reversing, do: %{reduction: 1.0, offset: 0.0, reversed?: true}
+
+    test "waypoints are keyword lists, not maps" do
+      # apply_to_waypoint/2 used to pattern match a map, so any joint with a
+      # transmission crashed its actuator on the first waypoint
+      message =
+        trajectory([[position: 0.5, velocity: 0.3, acceleration: 0.1, time_from_start: 0]])
+
+      assert %Message{payload: %Command.Trajectory{waypoints: [waypoint]}} =
+               Transmission.apply_to_command(message, reversing())
+
+      assert waypoint[:position] == -0.5
+      assert waypoint[:velocity] == -0.3
+      assert waypoint[:acceleration] == -0.1
+    end
+
+    test "an omitted rate stays omitted rather than becoming zero" do
+      # zero would read as "do not move" to a driver; absent means "you decide"
+      message = trajectory([[position: 0.5, time_from_start: 0]])
+
+      assert %Message{payload: %Command.Trajectory{waypoints: [waypoint]}} =
+               Transmission.apply_to_command(message, reversing())
+
+      assert waypoint[:position] == -0.5
+      assert waypoint[:velocity] == nil
+      assert waypoint[:acceleration] == nil
+    end
+
+    test "time_from_start is untouched" do
+      message = trajectory([[position: 0.5, time_from_start: 250]])
+
+      assert %Message{payload: %Command.Trajectory{waypoints: [waypoint]}} =
+               Transmission.apply_to_command(message, reversing())
+
+      assert waypoint[:time_from_start] == 250
+    end
+
+    test "a nil transmission leaves the waypoints alone" do
+      waypoints = [[position: 0.5, velocity: 0.3, acceleration: 0.1, time_from_start: 0]]
+
+      assert %Message{payload: %Command.Trajectory{waypoints: ^waypoints}} =
+               Transmission.apply_to_command(trajectory(waypoints), nil)
+    end
+  end
+
   describe "unapply_to_payload/2" do
     alias BB.Message
     alias BB.Message.Actuator.BeginMotion


### PR DESCRIPTION
Two fixes, found together because the first exposed the second.

## Waypoint rates are optional

`Command.Trajectory` required `velocity` **and** `acceleration` on every waypoint. Positions and times is the ordinary way to describe a trajectory — it's what ROS-style planners emit — and a caller with only that had to invent rates to satisfy the schema.

Inventing is worse than omitting: a driver can't tell a made-up `0.0` from a deliberate standstill. Both fields are now optional, and absent means *you decide* — which a driver can act on by working out the speed needed to arrive by `time_from_start`.

`follow_trajectory/4` also stopped multiplying a nil rate by `1.0`.

## Trajectories were broken on any joint with a transmission

Found while testing the above. `Transmission.apply_to_waypoint/2` pattern-matched a waypoint as a **map**:

```elixir
defp apply_to_waypoint(%{position: p, velocity: v, acceleration: a} = wp, t) do
```

but the schema has always declared them as keyword lists (`{:list, {:keyword_list, @waypoint_schema}}`). So every trajectory sent to a joint with a transmission raised `FunctionClauseError` and took the actuator down:

```
with no transmission:  ok
with a transmission:   RAISED: no function clause matching in BB.Transmission.apply_to_waypoint/2
```

On an SO-101 that's five joints of six. Only the gripper works, because it has no transmission — which is exactly why this survived unnoticed, and why I only caught it when I went looking for something else.

It now handles keyword lists, and leaves an omitted rate omitted rather than turning it into a zero. There was already a `maybe_apply_rate/2` for precisely that; it just wasn't being used here.

## Breaking

`velocity` and `acceleration` on a waypoint may now be `nil`. Anything reading them straight out of a waypoint needs to cope — drivers treating them as always-present want a fallback. `bb_servo_feetech` already has one: an absent velocity falls back to the leg's time budget, then to the joint's velocity limit.

## Testing

`mix check --no-retry` passes; 1317 tests. Four new ones cover the keyword-list shape, an omitted rate surviving the transmission as `nil` rather than `0.0`, `time_from_start` being untouched, and the nil-transmission path.

Came out of hardware work on an SO-101 — [bb_servo_feetech#94](https://github.com/beam-bots/bb_servo_feetech/pull/94) unified its position and trajectory code paths, at which point the fallback for an absent velocity turned out to be unreachable through the public API.