### PR TITLE
improvement: enforce `min`/`max` bounds on parameters

### DIFF
--- a/documentation/dsls/DSL-BB.md
+++ b/documentation/dsls/DSL-BB.md
@@ -1782,8 +1782,8 @@ A runtime-adjustable parameter.
 |------|------|---------|------|
 | [`type`](#parameters-group-param-type){: #parameters-group-param-type .spark-required} | `any` |  | The parameter value type (:float, :integer, :boolean, :string, :atom, or {:unit, unit_type}) |
 | [`default`](#parameters-group-param-default){: #parameters-group-param-default } | `any` |  | Default value for the parameter |
-| [`min`](#parameters-group-param-min){: #parameters-group-param-min } | `number` |  | Minimum value for numeric parameters |
-| [`max`](#parameters-group-param-max){: #parameters-group-param-max } | `number` |  | Maximum value for numeric parameters |
+| [`min`](#parameters-group-param-min){: #parameters-group-param-min } | `number \| Localize.Unit` |  | Smallest value the parameter accepts. Only for numeric types: a number for `:float`/`:integer`, a unit for `{:unit, unit_type}` |
+| [`max`](#parameters-group-param-max){: #parameters-group-param-max } | `number \| Localize.Unit` |  | Largest value the parameter accepts. Only for numeric types: a number for `:float`/`:integer`, a unit for `{:unit, unit_type}` |
 | [`doc`](#parameters-group-param-doc){: #parameters-group-param-doc } | `String.t` |  | Documentation for the parameter |
 
 
@@ -1824,8 +1824,8 @@ A runtime-adjustable parameter.
 |------|------|---------|------|
 | [`type`](#parameters-param-type){: #parameters-param-type .spark-required} | `any` |  | The parameter value type (:float, :integer, :boolean, :string, :atom, or {:unit, unit_type}) |
 | [`default`](#parameters-param-default){: #parameters-param-default } | `any` |  | Default value for the parameter |
-| [`min`](#parameters-param-min){: #parameters-param-min } | `number` |  | Minimum value for numeric parameters |
-| [`max`](#parameters-param-max){: #parameters-param-max } | `number` |  | Maximum value for numeric parameters |
+| [`min`](#parameters-param-min){: #parameters-param-min } | `number \| Localize.Unit` |  | Smallest value the parameter accepts. Only for numeric types: a number for `:float`/`:integer`, a unit for `{:unit, unit_type}` |
+| [`max`](#parameters-param-max){: #parameters-param-max } | `number \| Localize.Unit` |  | Largest value the parameter accepts. Only for numeric types: a number for `:float`/`:integer`, a unit for `{:unit, unit_type}` |
 | [`doc`](#parameters-param-doc){: #parameters-param-doc } | `String.t` |  | Documentation for the parameter |
 
 

--- a/documentation/tutorials/07-parameters.md
+++ b/documentation/tutorials/07-parameters.md
@@ -53,6 +53,27 @@ Each `param` declaration takes:
 - `min`/`max` - Optional bounds for numeric types
 - `doc` - Description for documentation
 
+### Bounds
+
+`min` and `max` are enforced on every write - at startup, from `set/3`, and
+through a bridge - so a parameter that stands for a hardware register can't be
+handed a value the hardware doesn't have room for. Either bound can be given on
+its own, and bounds on a `{:unit, unit_type}` parameter are units rather than
+bare numbers:
+
+```elixir
+parameters do
+  param :tap_duration, type: :integer, default: 4, max: 127,
+    doc: "Tap detection window, a 7-bit register field"
+
+  param :reach, type: {:unit, :meter}, default: ~u(0.5 meter),
+    min: ~u(0 meter), max: ~u(1.2 meter)
+end
+```
+
+Bounds on a non-numeric type, a `min` above its `max`, or a `default` outside
+its own bounds are compile errors rather than surprises at runtime.
+
 ## Organising Parameters with Groups
 
 Use `group` to organise related parameters:
@@ -163,8 +184,8 @@ Enumerate all parameters or filter by prefix:
 ```elixir
 iex> BB.Parameter.list(MyRobot.Robot)
 [
-  {[:motion, :max_linear_speed], %{value: 1.0, type: :float, ...}},
-  {[:motion, :max_angular_speed], %{value: 0.5, type: :float, ...}},
+  {[:motion, :max_linear_speed], %{value: 1.0, type: :float, min: 0.0, max: 5.0, ...}},
+  {[:motion, :max_angular_speed], %{value: 0.5, type: :float, min: 0.0, max: 2.0, ...}},
   {[:safety, :collision_distance], %{value: 0.3, type: :float, ...}},
   ...
 ]
@@ -192,11 +213,18 @@ Values are validated against the schema. Invalid values are rejected:
 
 ```elixir
 iex> BB.Parameter.set(MyRobot.Robot, [:motion, :max_linear_speed], -1.0)
-{:error, "must be at least 0.0"}
+{:error, %Spark.Options.ValidationError{
+  message: "invalid value for :max_linear_speed option: expected value to be at least 0.0, got: -1.0"
+}}
 
 iex> BB.Parameter.set(MyRobot.Robot, [:motion, :max_linear_speed], "fast")
-{:error, "expected float, got \"fast\""}
+{:error, %Spark.Options.ValidationError{
+  message: "invalid value for :max_linear_speed option: expected float, got: \"fast\""
+}}
 ```
+
+The stored value is left alone when validation fails, so a rejected `set/3`
+can't leave a component reading a value its hardware won't accept.
 
 ## Atomic Batch Updates
 

--- a/lib/bb/dsl.ex
+++ b/lib/bb/dsl.ex
@@ -189,14 +189,16 @@ defmodule BB.Dsl do
         doc: "Default value for the parameter"
       ],
       min: [
-        type: :number,
+        type: {:or, [:number, {:struct, Localize.Unit}]},
         required: false,
-        doc: "Minimum value for numeric parameters"
+        doc:
+          "Smallest value the parameter accepts. Only for numeric types: a number for `:float`/`:integer`, a unit for `{:unit, unit_type}`"
       ],
       max: [
-        type: :number,
+        type: {:or, [:number, {:struct, Localize.Unit}]},
         required: false,
-        doc: "Maximum value for numeric parameters"
+        doc:
+          "Largest value the parameter accepts. Only for numeric types: a number for `:float`/`:integer`, a unit for `{:unit, unit_type}`"
       ],
       doc: [
         type: :string,

--- a/lib/bb/dsl/parameter_transformer.ex
+++ b/lib/bb/dsl/parameter_transformer.ex
@@ -12,11 +12,16 @@ defmodule BB.Dsl.ParameterTransformer do
 
   At runtime, these are used by `BB.Robot.Runtime` to register parameters with
   proper validation schemas.
+
+  A parameter's `min`/`max` bounds are folded into its generated type by
+  `BB.Parameter.Type.option_type/3`; bounds which can't be enforced - or a
+  default which doesn't satisfy them - fail the robot's compilation.
   """
   use Spark.Dsl.Transformer
   alias BB.Dsl.{Param, ParamGroup}
-  alias BB.Unit
+  alias BB.Parameter.Type
   alias Spark.Dsl.Transformer
+  alias Spark.Error.DslError
 
   @doc false
   @impl true
@@ -31,67 +36,81 @@ defmodule BB.Dsl.ParameterTransformer do
   @doc false
   @impl true
   def transform(dsl) do
-    {schema_opts, defaults} =
-      dsl
-      |> Transformer.get_entities([:parameters])
-      |> collect_parameters([])
+    module = Transformer.get_persisted(dsl, :module)
 
-    if Enum.empty?(schema_opts) do
-      inject_empty_functions(dsl)
-    else
-      inject_parameter_functions(dsl, schema_opts, defaults)
+    with {:ok, schema_opts, defaults} <-
+           dsl |> Transformer.get_entities([:parameters]) |> collect_parameters([], module) do
+      if Enum.empty?(schema_opts) do
+        inject_empty_functions(dsl)
+      else
+        inject_parameter_functions(dsl, schema_opts, defaults)
+      end
     end
   end
 
-  defp collect_parameters(entities, path_prefix) do
-    Enum.reduce(entities, {[], []}, fn entity, {schema_acc, defaults_acc} ->
-      case entity do
-        %Param{} = param ->
-          {param_schema, param_defaults} = process_param(param, path_prefix)
-          {schema_acc ++ param_schema, defaults_acc ++ param_defaults}
+  defp collect_parameters(entities, path_prefix, module) do
+    Enum.reduce_while(entities, {:ok, [], []}, fn entity, {:ok, schema_acc, defaults_acc} ->
+      case collect_entity(entity, path_prefix, module) do
+        {:ok, schema, defaults} ->
+          {:cont, {:ok, schema_acc ++ schema, defaults_acc ++ defaults}}
 
-        %ParamGroup{} = group ->
-          group_path = path_prefix ++ [group.name]
-
-          {nested_schema, nested_defaults} =
-            collect_parameters(group.params ++ group.groups, group_path)
-
-          {schema_acc ++ nested_schema, defaults_acc ++ nested_defaults}
-
-        _ ->
-          {schema_acc, defaults_acc}
+        {:error, error} ->
+          {:halt, {:error, error}}
       end
     end)
   end
 
-  defp process_param(%Param{} = param, path_prefix) do
+  defp collect_entity(%Param{} = param, path_prefix, module) do
     path = path_prefix ++ [param.name]
-    schema_opts = build_schema_opts(param)
 
-    defaults =
-      if param.default != nil do
-        [{path, param.default}]
-      else
-        []
-      end
-
-    {[{path, schema_opts}], defaults}
+    with {:ok, schema_opts} <- build_schema_opts(param, path, module) do
+      {:ok, [{path, schema_opts}], defaults_for(param, path)}
+    end
   end
 
-  defp build_schema_opts(%Param{} = param) do
-    opts = [type: convert_param_type(param.type)]
-
-    opts = if param.doc, do: Keyword.put(opts, :doc, param.doc), else: opts
-    opts = if param.default != nil, do: Keyword.put(opts, :default, param.default), else: opts
-
-    opts
+  defp collect_entity(%ParamGroup{} = group, path_prefix, module) do
+    collect_parameters(group.params ++ group.groups, path_prefix ++ [group.name], module)
   end
 
-  defp convert_param_type({:unit, unit_type}) do
-    Unit.Option.unit_type(compatible: unit_type)
+  defp collect_entity(_entity, _path_prefix, _module), do: {:ok, [], []}
+
+  defp defaults_for(%Param{default: nil}, _path), do: []
+  defp defaults_for(%Param{default: default}, path), do: [{path, default}]
+
+  defp build_schema_opts(%Param{} = param, path, module) do
+    with {:ok, type} <- option_type(param, path, module),
+         :ok <- validate_default(param, type, path, module) do
+      opts = [type: type]
+
+      opts = if param.doc, do: Keyword.put(opts, :doc, param.doc), else: opts
+      opts = if param.default != nil, do: Keyword.put(opts, :default, param.default), else: opts
+
+      {:ok, opts}
+    end
   end
 
-  defp convert_param_type(type), do: type
+  defp option_type(%Param{} = param, path, module) do
+    case Type.option_type(param.type, param.min, param.max) do
+      {:ok, type} -> {:ok, type}
+      {:error, message} -> {:error, dsl_error(path, module, message)}
+    end
+  end
+
+  defp validate_default(%Param{default: nil}, _type, _path, _module), do: :ok
+  defp validate_default(%Param{min: nil, max: nil}, _type, _path, _module), do: :ok
+
+  # Bounding a parameter always produces a custom validator, so the declared
+  # default can be run through it directly.
+  defp validate_default(%Param{default: default}, {:custom, mod, fun, args}, path, module) do
+    case apply(mod, fun, [default | args]) do
+      {:ok, _default} -> :ok
+      {:error, message} -> {:error, dsl_error(path, module, "invalid `default`: #{message}")}
+    end
+  end
+
+  defp dsl_error(path, module, message) do
+    DslError.exception(module: module, path: [:parameters | path], message: message)
+  end
 
   defp inject_empty_functions(dsl) do
     {:ok,

--- a/lib/bb/parameter.ex
+++ b/lib/bb/parameter.ex
@@ -144,8 +144,9 @@ defmodule BB.Parameter do
   @doc """
   List all parameters, optionally filtered by path prefix.
 
-  Returns a list of `{path, metadata}` tuples where metadata includes
-  the current value, type, and other schema information.
+  Returns a list of `{path, metadata}` tuples whose metadata carries the current
+  `value`, the declared `type`, its `min`/`max` bounds (`nil` when unbounded),
+  the `doc` and the `default`.
 
   ## Options
 

--- a/lib/bb/parameter/type.ex
+++ b/lib/bb/parameter/type.ex
@@ -8,11 +8,21 @@ defmodule BB.Parameter.Type do
 
   Parameters can have simple types (`:float`, `:integer`, etc.) or unit types
   like `{:unit, :meter}`.
+
+  Numeric parameters - `:float`, `:integer` and unit types - can also declare
+  `min`/`max` bounds. `option_type/3` folds those bounds into the
+  `Spark.Options` type generated for the parameter so that they are enforced
+  wherever a value is validated, and `describe/1` recovers them from a
+  generated type for display.
   """
 
   alias BB.Unit
 
   @simple_types [:float, :integer, :boolean, :string, :atom]
+  @numeric_types [:float, :integer]
+
+  @type t :: :float | :integer | :boolean | :string | :atom | {:unit, atom}
+  @type bound :: number | Localize.Unit.t() | nil
 
   @doc """
   Validates a parameter type specification.
@@ -35,7 +45,7 @@ defmodule BB.Parameter.Type do
       iex> BB.Parameter.Type.validate(:invalid)
       {:error, "Expected one of [:float, :integer, :boolean, :string, :atom] or {:unit, unit_type}, got: :invalid"}
   """
-  @spec validate(term()) :: {:ok, atom() | {:unit, atom()}} | {:error, String.t()}
+  @spec validate(term()) :: {:ok, t} | {:error, String.t()}
   def validate(type) when type in @simple_types, do: {:ok, type}
 
   def validate({:unit, unit_type}) when is_atom(unit_type) do
@@ -48,5 +58,187 @@ defmodule BB.Parameter.Type do
   def validate(other) do
     {:error,
      "Expected one of #{inspect(@simple_types)} or {:unit, unit_type}, got: #{inspect(other)}"}
+  end
+
+  @doc """
+  Builds the `Spark.Options` type for a parameter of `type`, bounded by `min`
+  and `max`.
+
+  Either bound may be `nil`. Numeric bounds are plain numbers, bounds on a unit
+  type are `Localize.Unit` values compatible with the parameter's unit.
+
+  ## Examples
+
+  An unbounded type is used as-is:
+
+      iex> BB.Parameter.Type.option_type(:float, nil, nil)
+      {:ok, :float}
+
+  Bounds wrap the type in a custom validator:
+
+      iex> BB.Parameter.Type.option_type(:integer, 0, 127)
+      {:ok, {:custom, BB.Parameter.Type, :validate_bounds, [[type: :integer, min: 0, max: 127]]}}
+
+  Only one of the two is needed:
+
+      iex> BB.Parameter.Type.option_type(:float, 0.0, nil)
+      {:ok, {:custom, BB.Parameter.Type, :validate_bounds, [[type: :float, min: 0.0, max: nil]]}}
+
+  Bounds on a unit type become unit constraints:
+
+      iex> BB.Parameter.Type.option_type({:unit, :meter}, nil, Localize.Unit.new!(1, "meter"))
+      {:ok, {:custom, BB.Unit.Option, :validate, [[compatible: :meter, max: Localize.Unit.new!(1, "meter")]]}}
+
+  Non-numeric types cannot be bounded:
+
+      iex> BB.Parameter.Type.option_type(:string, 0, nil)
+      {:error, "`min` and `max` are only supported for numeric parameter types (:float, :integer or {:unit, unit_type}), got: :string"}
+  """
+  @spec option_type(t, bound, bound) :: {:ok, Spark.Options.type()} | {:error, String.t()}
+  def option_type(type, min, max)
+
+  def option_type({:unit, unit_type}, nil, nil),
+    do: {:ok, Unit.Option.unit_type(compatible: unit_type)}
+
+  def option_type(type, nil, nil), do: {:ok, type}
+
+  def option_type({:unit, unit_type}, min, max) do
+    with :ok <- validate_unit_bound(:min, min, unit_type),
+         :ok <- validate_unit_bound(:max, max, unit_type),
+         :ok <- validate_ordering(min, max) do
+      bounds = Enum.reject([min: min, max: max], fn {_key, bound} -> is_nil(bound) end)
+      {:ok, Unit.Option.unit_type([compatible: unit_type] ++ bounds)}
+    end
+  end
+
+  def option_type(type, min, max) when type in @numeric_types do
+    with :ok <- validate_numeric_bound(:min, min),
+         :ok <- validate_numeric_bound(:max, max),
+         :ok <- validate_ordering(min, max) do
+      {:ok, {:custom, __MODULE__, :validate_bounds, [[type: type, min: min, max: max]]}}
+    end
+  end
+
+  def option_type(type, _min, _max) do
+    {:error,
+     "`min` and `max` are only supported for numeric parameter types " <>
+       "(:float, :integer or {:unit, unit_type}), got: #{inspect(type)}"}
+  end
+
+  @doc """
+  Validates a value against a bounded numeric parameter's type and bounds.
+
+  This is the validator used by the type `option_type/3` builds for a bounded
+  `:float` or `:integer` parameter.
+
+  ## Examples
+
+      iex> BB.Parameter.Type.validate_bounds(0.5, type: :float, min: 0.0, max: 1.0)
+      {:ok, 0.5}
+
+      iex> BB.Parameter.Type.validate_bounds(2.0, type: :float, min: 0.0, max: 1.0)
+      {:error, "expected value to be at most 1.0, got: 2.0"}
+
+      iex> BB.Parameter.Type.validate_bounds(-1.0, type: :float, min: 0.0, max: nil)
+      {:error, "expected value to be at least 0.0, got: -1.0"}
+
+      iex> BB.Parameter.Type.validate_bounds("nope", type: :float, min: 0.0, max: 1.0)
+      {:error, "expected float, got: \\"nope\\""}
+  """
+  @spec validate_bounds(term, keyword) :: {:ok, number} | {:error, String.t()}
+  def validate_bounds(value, bounds) do
+    with {:ok, value} <- validate_numeric_type(bounds[:type], value),
+         {:ok, value} <- validate_at_least(value, bounds[:min]) do
+      validate_at_most(value, bounds[:max])
+    end
+  end
+
+  @doc """
+  Recovers the declared parameter type and its bounds from a generated
+  `Spark.Options` type.
+
+  Types which don't carry bounds - including the hand-written schemas of
+  components which `use BB.Parameter` - are returned unchanged with `nil`
+  bounds.
+
+  ## Examples
+
+      iex> BB.Parameter.Type.describe(:float)
+      {:float, nil, nil}
+
+      iex> {:ok, type} = BB.Parameter.Type.option_type(:integer, 0, 127)
+      iex> BB.Parameter.Type.describe(type)
+      {:integer, 0, 127}
+
+      iex> {:ok, type} = BB.Parameter.Type.option_type({:unit, :meter}, nil, Localize.Unit.new!(1, "meter"))
+      iex> BB.Parameter.Type.describe(type)
+      {{:unit, :meter}, nil, Localize.Unit.new!(1, "meter")}
+  """
+  @spec describe(Spark.Options.type() | nil) :: {t | Spark.Options.type() | nil, bound, bound}
+  def describe({:custom, __MODULE__, :validate_bounds, [bounds]}),
+    do: {bounds[:type], bounds[:min], bounds[:max]}
+
+  def describe({:custom, Unit.Option, :validate, [options]}),
+    do: {{:unit, options[:compatible]}, options[:min], options[:max]}
+
+  def describe(type), do: {type, nil, nil}
+
+  defp validate_numeric_type(:float, value) when is_float(value), do: {:ok, value}
+  defp validate_numeric_type(:integer, value) when is_integer(value), do: {:ok, value}
+
+  defp validate_numeric_type(type, value),
+    do: {:error, "expected #{type}, got: #{inspect(value)}"}
+
+  defp validate_at_least(value, nil), do: {:ok, value}
+  defp validate_at_least(value, min) when value >= min, do: {:ok, value}
+
+  defp validate_at_least(value, min),
+    do: {:error, "expected value to be at least #{inspect(min)}, got: #{inspect(value)}"}
+
+  defp validate_at_most(value, nil), do: {:ok, value}
+  defp validate_at_most(value, max) when value <= max, do: {:ok, value}
+
+  defp validate_at_most(value, max),
+    do: {:error, "expected value to be at most #{inspect(max)}, got: #{inspect(value)}"}
+
+  defp validate_numeric_bound(_key, bound) when is_number(bound) or is_nil(bound), do: :ok
+
+  defp validate_numeric_bound(key, bound),
+    do: {:error, "`#{key}` must be a number, got: #{inspect(bound)}"}
+
+  defp validate_unit_bound(_key, nil, _unit_type), do: :ok
+
+  defp validate_unit_bound(key, bound, unit_type) when is_struct(bound, Localize.Unit) do
+    if Unit.compatible?(bound, unit_type) do
+      :ok
+    else
+      {:error,
+       "`#{key}` must be compatible with `#{unit_type}`, got: #{Unit.to_string!(bound, style: :narrow)}"}
+    end
+  end
+
+  defp validate_unit_bound(key, bound, unit_type) do
+    {:error,
+     "`#{key}` must be a `Localize.Unit` compatible with `#{unit_type}`, got: #{inspect(bound)}"}
+  end
+
+  defp validate_ordering(nil, _max), do: :ok
+  defp validate_ordering(_min, nil), do: :ok
+
+  defp validate_ordering(min, max) when is_number(min) and is_number(max) do
+    if min <= max do
+      :ok
+    else
+      {:error, "`min` must not be greater than `max`, got: #{inspect(min)} and #{inspect(max)}"}
+    end
+  end
+
+  defp validate_ordering(min, max) do
+    if Unit.compare(min, max) in [:lt, :eq] do
+      :ok
+    else
+      {:error,
+       "`min` must not be greater than `max`, got: #{Unit.to_string!(min, style: :narrow)} and #{Unit.to_string!(max, style: :narrow)}"}
+    end
   end
 end

--- a/lib/bb/robot/state.ex
+++ b/lib/bb/robot/state.ex
@@ -60,6 +60,7 @@ defmodule BB.Robot.State do
   alias BB.Math.Vec3
   alias BB.Message.Geometry.Twist
   alias BB.Message.Geometry.Twist2D
+  alias BB.Parameter.Type, as: ParameterType
   alias BB.Robot
 
   defstruct [:table, :robot]
@@ -402,10 +403,13 @@ defmodule BB.Robot.State do
       |> List.first()
 
     param_opts = Keyword.get(schema_opts, param_name, [])
+    {type, min, max} = ParameterType.describe(Keyword.get(param_opts, :type))
 
     %{
       value: value,
-      type: Keyword.get(param_opts, :type),
+      type: type,
+      min: min,
+      max: max,
       doc: Keyword.get(param_opts, :doc),
       default: Keyword.get(param_opts, :default)
     }

--- a/test/bb/dsl/parameter_test.exs
+++ b/test/bb/dsl/parameter_test.exs
@@ -80,6 +80,23 @@ defmodule BB.Dsl.ParameterTest do
     end
   end
 
+  defmodule RobotWithBoundedParams do
+    @moduledoc false
+    use BB
+
+    parameters do
+      param :gain, type: :float, default: 0.5, min: 0.0, max: 1.0
+      param :offset, type: :float, default: 0.0, min: -1.0
+      param :tap_duration, type: :integer, default: 4, max: 127
+      param :reach, type: {:unit, :meter}, default: ~u(0.5 meter), max: ~u(1 meter)
+    end
+
+    topology do
+      link :base_link do
+      end
+    end
+  end
+
   describe "generated functions" do
     test "robot module has __bb_parameter_schema__/0" do
       assert function_exported?(RobotWithParameters, :__bb_parameter_schema__, 0)
@@ -122,6 +139,16 @@ defmodule BB.Dsl.ParameterTest do
       assert [:controller, :pid, :kp] in paths
       assert [:controller, :pid, :ki] in paths
       assert [:controller, :pid, :kd] in paths
+    end
+
+    test "bounds are folded into the generated type" do
+      schema = RobotWithBoundedParams.__bb_parameter_schema__()
+
+      {[:gain], opts} = Enum.find(schema, fn {path, _} -> path == [:gain] end)
+
+      assert Keyword.get(opts, :type) ==
+               {:custom, BB.Parameter.Type, :validate_bounds,
+                [[type: :float, min: 0.0, max: 1.0]]}
     end
 
     test "robot with no parameters has empty functions" do
@@ -323,6 +350,212 @@ defmodule BB.Dsl.ParameterTest do
     end
   end
 
+  describe "bounded parameters" do
+    setup do
+      start_supervised!(RobotWithBoundedParams)
+      :ok
+    end
+
+    test "values within the bounds are accepted" do
+      assert :ok = Parameter.set(RobotWithBoundedParams, [:gain], 0.75)
+      assert {:ok, 0.75} = Parameter.get(RobotWithBoundedParams, [:gain])
+    end
+
+    test "values below min are rejected" do
+      assert {:error, error} = Parameter.set(RobotWithBoundedParams, [:gain], -0.5)
+
+      assert Exception.message(error) =~
+               "invalid value for :gain option: expected value to be at least 0.0, got: -0.5"
+
+      assert {:ok, 0.5} = Parameter.get(RobotWithBoundedParams, [:gain])
+    end
+
+    test "values above max are rejected" do
+      assert {:error, error} = Parameter.set(RobotWithBoundedParams, [:gain], 1000.0)
+
+      assert Exception.message(error) =~
+               "invalid value for :gain option: expected value to be at most 1.0, got: 1000.0"
+
+      assert {:ok, 0.5} = Parameter.get(RobotWithBoundedParams, [:gain])
+    end
+
+    test "min on its own bounds one end only" do
+      assert {:error, _} = Parameter.set(RobotWithBoundedParams, [:offset], -2.0)
+      assert :ok = Parameter.set(RobotWithBoundedParams, [:offset], 1_000_000.0)
+    end
+
+    test "max on its own bounds one end only" do
+      assert {:error, _} = Parameter.set(RobotWithBoundedParams, [:tap_duration], 128)
+      assert :ok = Parameter.set(RobotWithBoundedParams, [:tap_duration], -1_000_000)
+    end
+
+    test "type validation still applies to bounded parameters" do
+      assert {:error, error} = Parameter.set(RobotWithBoundedParams, [:gain], "nope")
+
+      assert Exception.message(error) =~
+               "invalid value for :gain option: expected float, got: \"nope\""
+
+      assert {:error, _} = Parameter.set(RobotWithBoundedParams, [:tap_duration], 1.5)
+    end
+
+    test "unit parameters are bounded by unit values" do
+      assert {:error, _} = Parameter.set(RobotWithBoundedParams, [:reach], ~u(3 meter))
+      assert :ok = Parameter.set(RobotWithBoundedParams, [:reach], ~u(30 centimeter))
+    end
+
+    test "set_many rejects the whole batch when one value is out of bounds" do
+      assert {:error, [{[:tap_duration], _}]} =
+               Parameter.set_many(RobotWithBoundedParams, [
+                 {[:gain], 0.9},
+                 {[:tap_duration], 999}
+               ])
+
+      assert {:ok, 0.5} = Parameter.get(RobotWithBoundedParams, [:gain])
+    end
+
+    test "bounds are reported in parameter metadata" do
+      params = Parameter.list(RobotWithBoundedParams)
+
+      {_path, gain} = Enum.find(params, fn {path, _} -> path == [:gain] end)
+      assert gain.type == :float
+      assert gain.min == 0.0
+      assert gain.max == 1.0
+
+      {_path, offset} = Enum.find(params, fn {path, _} -> path == [:offset] end)
+      assert offset.min == -1.0
+      assert offset.max == nil
+
+      {_path, reach} = Enum.find(params, fn {path, _} -> path == [:reach] end)
+      assert reach.type == {:unit, :meter}
+      assert Localize.Unit.compare(reach.max, ~u(1 meter)) == :eq
+    end
+  end
+
+  describe "invalid bound declarations" do
+    test "bounds on a non-numeric type are rejected at compile time" do
+      error =
+        assert_raise Spark.Error.DslError, fn ->
+          defmodule BoundedString do
+            use BB
+
+            parameters do
+              param :name, type: :string, default: "x", min: 0
+            end
+
+            topology do
+              link :base_link do
+              end
+            end
+          end
+        end
+
+      assert Exception.message(error) =~
+               "`min` and `max` are only supported for numeric parameter types"
+    end
+
+    test "min greater than max is rejected at compile time" do
+      error =
+        assert_raise Spark.Error.DslError, fn ->
+          defmodule InvertedBounds do
+            use BB
+
+            parameters do
+              param :gain, type: :float, default: 0.5, min: 1.0, max: 0.0
+            end
+
+            topology do
+              link :base_link do
+              end
+            end
+          end
+        end
+
+      assert Exception.message(error) =~ "`min` must not be greater than `max`"
+    end
+
+    test "a default outside its own bounds is rejected at compile time" do
+      error =
+        assert_raise Spark.Error.DslError, fn ->
+          defmodule DefaultBelowMin do
+            use BB
+
+            parameters do
+              param :gain, type: :float, default: -1.0, min: 0.0, max: 1.0
+            end
+
+            topology do
+              link :base_link do
+              end
+            end
+          end
+        end
+
+      assert Exception.message(error) =~ "invalid `default`: expected value to be at least 0.0"
+    end
+
+    test "bounds in a nested group name the full parameter path" do
+      error =
+        assert_raise Spark.Error.DslError, fn ->
+          defmodule BoundedGroupParam do
+            use BB
+
+            parameters do
+              group :motion do
+                param :mode, type: :atom, default: :fast, max: 10
+              end
+            end
+
+            topology do
+              link :base_link do
+              end
+            end
+          end
+        end
+
+      assert Exception.message(error) =~ "parameters -> motion -> mode"
+    end
+
+    test "a numeric bound on a unit parameter is rejected at compile time" do
+      error =
+        assert_raise Spark.Error.DslError, fn ->
+          defmodule NumericBoundOnUnit do
+            use BB
+
+            parameters do
+              param :reach, type: {:unit, :meter}, default: ~u(1 meter), max: 2.0
+            end
+
+            topology do
+              link :base_link do
+              end
+            end
+          end
+        end
+
+      assert Exception.message(error) =~ "`max` must be a `Localize.Unit` compatible with `meter`"
+    end
+
+    test "an incompatible unit bound is rejected at compile time" do
+      error =
+        assert_raise Spark.Error.DslError, fn ->
+          defmodule IncompatibleUnitBound do
+            use BB
+
+            parameters do
+              param :reach, type: {:unit, :meter}, default: ~u(1 meter), max: ~u(2 second)
+            end
+
+            topology do
+              link :base_link do
+              end
+            end
+          end
+        end
+
+      assert Exception.message(error) =~ "`max` must be compatible with `meter`"
+    end
+  end
+
   describe "start_link params" do
     test "params override defaults" do
       start_supervised!({RobotWithParameters, params: [motion: [max_speed: 5.0]]})
@@ -407,6 +640,19 @@ defmodule BB.Dsl.ParameterTest do
 
       assert {:ok, value} = Parameter.get(RobotWithUnitParams, [:motion, :max_speed])
       assert Localize.Unit.compare(value, ~u(3.0 meter_per_second)) == :eq
+    end
+
+    test "params outside a parameter's bounds cause startup failure" do
+      assert {:error, {{:shutdown, {:failed_to_start_child, _, reason}}, _}} =
+               start_supervised({RobotWithBoundedParams, params: [gain: 5.0]})
+
+      assert Exception.message(reason) =~ "expected value to be at most 1.0, got: 5.0"
+    end
+
+    test "params within a parameter's bounds are applied at startup" do
+      start_supervised!({RobotWithBoundedParams, params: [gain: 0.25]})
+
+      assert {:ok, 0.25} = Parameter.get(RobotWithBoundedParams, [:gain])
     end
 
     test "unit params with incompatible units cause startup failure" do

--- a/test/bb/parameter/type_test.exs
+++ b/test/bb/parameter/type_test.exs
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Parameter.TypeTest do
+  use ExUnit.Case, async: true
+  import BB.Unit
+
+  alias BB.Parameter.Type
+
+  doctest BB.Parameter.Type
+
+  describe "option_type/3" do
+    test "leaves an unbounded simple type alone" do
+      assert {:ok, :boolean} = Type.option_type(:boolean, nil, nil)
+    end
+
+    test "converts an unbounded unit type to a unit constraint" do
+      assert {:ok, {:custom, BB.Unit.Option, :validate, [[compatible: :meter]]}} =
+               Type.option_type({:unit, :meter}, nil, nil)
+    end
+
+    test "keeps only the bound that was given" do
+      assert {:ok, {:custom, Type, :validate_bounds, [[type: :float, min: nil, max: 1.0]]}} =
+               Type.option_type(:float, nil, 1.0)
+    end
+
+    test "rejects a bound which is not a number" do
+      assert {:error, message} = Type.option_type(:float, :nope, nil)
+      assert message =~ "`min` must be a number"
+    end
+
+    test "rejects bounds on a non-numeric type" do
+      for type <- [:boolean, :string, :atom] do
+        assert {:error, message} = Type.option_type(type, 0, 1)
+        assert message =~ "only supported for numeric parameter types"
+      end
+    end
+
+    test "rejects min greater than max" do
+      assert {:error, message} = Type.option_type(:integer, 10, 1)
+      assert message =~ "`min` must not be greater than `max`"
+    end
+
+    test "rejects unit bounds greater than max" do
+      assert {:error, message} =
+               Type.option_type({:unit, :meter}, ~u(3 meter), ~u(2 meter))
+
+      assert message =~ "`min` must not be greater than `max`"
+    end
+
+    test "accepts unit bounds in any compatible unit" do
+      assert {:ok, {:custom, BB.Unit.Option, :validate, [options]}} =
+               Type.option_type({:unit, :meter}, ~u(0 meter), ~u(150 centimeter))
+
+      assert options[:compatible] == :meter
+      assert Localize.Unit.compare(options[:max], ~u(1.5 meter)) == :eq
+    end
+  end
+
+  describe "validate_bounds/2" do
+    test "accepts a value on either bound" do
+      bounds = [type: :integer, min: 0, max: 127]
+
+      assert {:ok, 0} = Type.validate_bounds(0, bounds)
+      assert {:ok, 127} = Type.validate_bounds(127, bounds)
+    end
+
+    test "rejects a float for an integer parameter" do
+      assert {:error, "expected integer, got: 1.5"} =
+               Type.validate_bounds(1.5, type: :integer, min: 0, max: 127)
+    end
+
+    test "rejects an integer for a float parameter" do
+      assert {:error, "expected float, got: 1"} =
+               Type.validate_bounds(1, type: :float, min: 0.0, max: 2.0)
+    end
+  end
+
+  describe "describe/1" do
+    test "reports hand-written component schema types unchanged" do
+      assert {{:in, [:a, :b]}, nil, nil} = Type.describe({:in, [:a, :b]})
+      assert {nil, nil, nil} = Type.describe(nil)
+    end
+  end
+end

--- a/usage-rules/parameters.md
+++ b/usage-rules/parameters.md
@@ -23,7 +23,11 @@ end
 
 Each `param` needs a `type` (`:float`, `:integer`, `:boolean`, `:string`,
 `:atom`, or `{:unit, unit_type}` for physical quantities) and a `default`.
-`min`/`max` bound numeric types.
+
+`min`/`max` bound numeric types, and every write is checked against them —
+either bound can be given on its own. Bounds on a `{:unit, _}` parameter are
+units themselves (`min: ~u(0 meter)`); bounds on a non-numeric type, a `min`
+above its `max`, or a `default` outside its own bounds are compile errors.
 
 ## Reading and writing at runtime
 


### PR DESCRIPTION
Closes #230.

The `parameters` DSL accepted `min:`/`max:` on a `param` and `BB.Dsl.Param` stored
them, but `BB.Dsl.ParameterTransformer` copied only `:type`, `:doc` and `:default`
into the generated schema, so the bounds never reached validation. A declaration
that read as a constraint wasn't one, and the crash-loop in the issue followed
from that.

## Approach

`BB.Parameter.Type.option_type/3` now folds the bounds into the parameter's
generated `Spark.Options` type — the custom-check option from the issue:

- `:float`/`:integer` become `{:custom, BB.Parameter.Type, :validate_bounds, [[type: …, min: …, max: …]]}`,
  which validates the underlying type first and then the bounds.
- `{:unit, unit_type}` reuses `BB.Unit.Option`'s existing `min`/`max` unit
  constraints, so bounds on a unit parameter are units themselves
  (`min: ~u(0 meter)`) rather than ambiguous bare numbers. `~u` is already
  imported inside `param`.

Keeping the bounds in the schema means they apply everywhere a value is
validated — `set/3`, `set_many/2` (still all-or-nothing), and the `params:`
option at startup — rather than only in the one runtime function the
`validate_against_schema/3` alternative would have covered. Startup `params:`
go through `BB.Parameter.Schema.build_nested_schema/1`, which the alternative
wouldn't have touched at all.

Error output is Spark's `ValidationError`, the same shape type failures already
return, naming the parameter, the bound and the value.

## Compile-time checks

Bounds that can't be enforced now fail the robot's compilation with a
`Spark.Error.DslError` naming the parameter (nested groups included):

- bounds on a non-numeric type — `` `min` and `max` are only supported for numeric parameter types (:float, :integer or {:unit, unit_type}), got: :string ``
- `min` above `max`
- a bare number bounding a unit type, or a unit of the wrong category
- a `default` outside its own bounds — this is where a default is caught, rather
  than at runtime, since both are known at compile time.

Declaring bounds also makes the default's type checked (it's run through the
same validator). Defaults of unbounded parameters are still unchecked, as before.

## Reproduction from the issue

```elixir
defmodule BoundsRepro.Robot do
  use BB

  parameters do
    param :gain, type: :float, default: 0.5, min: 0.0, max: 1.0
  end

  topology do
    link :base_link do
    end
  end
end

{:ok, _pid} = BoundsRepro.Robot.start_link([])

BB.Parameter.get!(BoundsRepro.Robot, [:gain])
#=> 0.5

BB.Parameter.set(BoundsRepro.Robot, [:gain], 1000.0)
#=> {:error,
#=>  %Spark.Options.ValidationError{
#=>    message: "invalid value for :gain option: expected value to be at most 1.0, got: 1000.0",
#=>    key: :gain,
#=>    value: 1000.0,
#=>    keys_path: []
#=>  }}

BB.Parameter.get!(BoundsRepro.Robot, [:gain])
#=> 0.5          # unchanged

BB.Parameter.set(BoundsRepro.Robot, [:gain], "nope")
#=> {:error,
#=>  %Spark.Options.ValidationError{
#=>    message: "invalid value for :gain option: expected float, got: \"nope\"",
#=>    key: :gain,
#=>    value: "nope",
#=>    keys_path: []
#=>  }}
```

## Also in here

`BB.Parameter.list/2` metadata now reports the declared type plus `min`/`max`
instead of the raw validator tuple. `bb_liveview` and `bb_kino` already read
`meta[:min]`/`meta[:max]` to render a slider and already handle a `{:unit, _}`
type — both paths were unreachable because the bounds were dropped and the
generated unit type was opaque.

DSL docs were checked: `min`/`max` render as `number | Localize.Unit`, and the
`type` column is unchanged (it was already `any`, since the `param` entity's
`type:` has always been a custom check). Cheat sheets regenerated.

## Not fixed here

A parameter store's persisted values are applied on load without validation
(`apply_persisted_value/2`), so a store written before bounds were tightened —
or edited by hand — can still seed an out-of-range value. Whether to drop-and-warn
or refuse to boot is a behaviour decision, so I've left it alone.

## Tests

`mix check --no-retry` passes. The three `Mix.Tasks.Bb.AddNxBackendTest` failures
are pre-existing on `main` (`Rewrite.Error: no source found for "mix.exs"`).

New coverage: in-range, below-min, above-max, one-sided `min`, one-sided `max`,
unit bounds, unchanged value after a rejected write, `set_many/2` atomicity,
startup `params:` in and out of bounds, metadata bounds, the generated schema
shape, each compile-time rejection, and type validation on both bounded and
unbounded parameters. `BB.Parameter.Type`'s doctests are now actually run.
