### PR TITLE
improvement!: make `BB.Actuator.set_position/4` synchronous so a refusal reaches the caller

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -104,6 +104,7 @@ spark_locals_without_parens = [
   reversed?: 1,
   roll: 1,
   scale: 1,
+  sensor: 1,
   sensor: 2,
   sensor: 3,
   simulation: 1,

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -104,7 +104,6 @@ spark_locals_without_parens = [
   reversed?: 1,
   roll: 1,
   scale: 1,
-  sensor: 1,
   sensor: 2,
   sensor: 3,
   simulation: 1,

--- a/documentation/dsls/DSL-BB.md
+++ b/documentation/dsls/DSL-BB.md
@@ -1278,11 +1278,7 @@ An actuator attached to a joint.
 |------|------|---------|------|
 | [`name`](#topology-joint-actuator-name){: #topology-joint-actuator-name .spark-required} | `atom` |  | A unique name for the actuator |
 | [`child_spec`](#topology-joint-actuator-child_spec){: #topology-joint-actuator-child_spec .spark-required} | `module \| {module, keyword}` |  | The child specification for the actuator process. Either a module or `{module, keyword_list}` |
-### Options
 
-| Name | Type | Default | Docs |
-|------|------|---------|------|
-| [`sensor`](#topology-joint-actuator-sensor){: #topology-joint-actuator-sensor } | `boolean` | `true` | Whether this actuator needs a separate sensor to report where its joint actually is. Set it to `false` for hardware that reports its own position - a smart servo answering position queries on its bus - to say that the missing position sensor is deliberate. |
 
 
 ### topology.joint.actuator.transmission

--- a/documentation/dsls/DSL-BB.md
+++ b/documentation/dsls/DSL-BB.md
@@ -1278,7 +1278,11 @@ An actuator attached to a joint.
 |------|------|---------|------|
 | [`name`](#topology-joint-actuator-name){: #topology-joint-actuator-name .spark-required} | `atom` |  | A unique name for the actuator |
 | [`child_spec`](#topology-joint-actuator-child_spec){: #topology-joint-actuator-child_spec .spark-required} | `module \| {module, keyword}` |  | The child specification for the actuator process. Either a module or `{module, keyword_list}` |
+### Options
 
+| Name | Type | Default | Docs |
+|------|------|---------|------|
+| [`sensor`](#topology-joint-actuator-sensor){: #topology-joint-actuator-sensor } | `boolean` | `true` | Whether this actuator needs a separate sensor to report where its joint actually is. Set it to `false` for hardware that reports its own position - a smart servo answering position queries on its bus - to say that the missing position sensor is deliberate. |
 
 
 ### topology.joint.actuator.transmission

--- a/documentation/how-to/deploy-to-nerves.md
+++ b/documentation/how-to/deploy-to-nerves.md
@@ -171,7 +171,7 @@ alias MyRobotFirmware.Robot
 {:ok, :armed, _} = BB.Command.await(cmd)
 
 # Move joints
-BB.Actuator.set_position!(Robot, :servo, 0.5)
+:ok = BB.Actuator.set_position(Robot, :servo, 0.5)
 ```
 
 ## Network Control
@@ -217,7 +217,7 @@ defmodule MyRobotFirmware.RemoteControl do
   def handle_info({:tcp, _socket, data}, state) do
     case Jason.decode(data) do
       {:ok, %{"command" => "move", "joint" => joint, "position" => pos}} ->
-        BB.Actuator.set_position!(MyRobotFirmware.Robot, String.to_atom(joint), pos)
+        BB.Actuator.set_position(MyRobotFirmware.Robot, String.to_atom(joint), pos)
 
       _ ->
         :ok

--- a/documentation/how-to/troubleshoot-pubsub.md
+++ b/documentation/how-to/troubleshoot-pubsub.md
@@ -337,7 +337,7 @@ knowing the outcome is worth:
 :ok = BB.Actuator.set_position(MyRobot.Robot, :servo, position)
 
 # Cast and move on — a refusal then only reaches the log and telemetry
-BB.Actuator.set_position_async(MyRobot.Robot, :servo, position)
+BB.Actuator.set_position(MyRobot.Robot, :servo, position, delivery: :direct)
 ```
 
 ## Quick Reference

--- a/documentation/how-to/troubleshoot-pubsub.md
+++ b/documentation/how-to/troubleshoot-pubsub.md
@@ -329,14 +329,15 @@ end
 
 ### Use Direct Delivery for Low Latency
 
-For actuator commands where PubSub overhead matters:
+For actuator commands where the publication and the round trip cost more than
+knowing the outcome is worth:
 
 ```elixir
-# Instead of
-BB.Actuator.set_position(MyRobot.Robot, [:actuator, :servo], position)
+# Instead of publishing and waiting for the actuator to accept
+:ok = BB.Actuator.set_position(MyRobot.Robot, :servo, position)
 
-# Use direct
-BB.Actuator.set_position!(MyRobot.Robot, :servo, position)
+# Cast and move on — a refusal then only reaches the log and telemetry
+BB.Actuator.set_position_async(MyRobot.Robot, :servo, position)
 ```
 
 ## Quick Reference

--- a/documentation/how-to/use-urdf-with-ros.md
+++ b/documentation/how-to/use-urdf-with-ros.md
@@ -180,7 +180,7 @@ end
 defp handle_ros_command(msg) do
   for {name, position} <- Enum.zip(msg.name, msg.position) do
     joint = String.to_atom(name)
-    BB.Actuator.set_position!(MyRobot.Robot, joint, position)
+    BB.Actuator.set_position(MyRobot.Robot, joint, position)
   end
 end
 ```

--- a/documentation/reference/error-types.md
+++ b/documentation/reference/error-types.md
@@ -573,7 +573,7 @@ error = BB.Error.State.NotAllowed.exception(
 BB.Error.Severity.severity(error)  #=> :error
 
 # Get message
-BB.Error.message(error)  #=> "Command not allowed in state :disarmed..."
+Exception.message(error)  #=> "Command not allowed in state :disarmed..."
 ```
 
 Do **not** create error structs directly - this bypasses Splode's backtrace capture:

--- a/documentation/reference/error-types.md
+++ b/documentation/reference/error-types.md
@@ -179,7 +179,8 @@ Inverse kinematics found no solution.
 
 ### MultiFailed
 
-Multiple IK attempts failed.
+A multi-target IK operation failed on one of its targets. Returned by
+`BB.Motion.move_to_multi/3` and `BB.Motion.solve_only_multi/3`.
 
 **Module:** `BB.Error.Kinematics.MultiFailed`
 
@@ -187,8 +188,9 @@ Multiple IK attempts failed.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `attempts` | `integer` | Number of attempts |
-| `errors` | `[term]` | Individual errors |
+| `failed_link` | `atom` | The target link that could not be solved |
+| `error` | `term` | The underlying kinematics error |
+| `partial_results` | `map` | Results of the targets solved before the failure |
 
 **Severity:** `:error`
 

--- a/documentation/reference/telemetry-events.md
+++ b/documentation/reference/telemetry-events.md
@@ -89,7 +89,7 @@ Sending positions to actuators.
 |-----|------|-------------|
 | `robot` | `atom` | Robot module |
 | `joint_count` | `integer` | Number of joints updated |
-| `delivery` | `atom` | `:pubsub`, `:direct`, or `:sync` |
+| `delivery` | `atom` | `:pubsub` or `:direct` |
 
 ## Kinematics Events
 

--- a/documentation/tutorials/09-inverse-kinematics.md
+++ b/documentation/tutorials/09-inverse-kinematics.md
@@ -306,8 +306,11 @@ case Motion.move_to_multi(MyRobot.Robot, targets,
       IO.puts("#{link}: #{meta.iterations} iterations")
     end)
 
-  {:error, failed_link, reason, _results} ->
-    IO.puts("#{failed_link} failed: #{reason}")
+  {:error, %BB.Error.Kinematics.MultiFailed{failed_link: link} = error} ->
+    IO.puts("#{link} failed: #{BB.Error.message(error)}")
+
+  {:error, error} ->
+    IO.puts("An actuator refused its command: #{BB.Error.message(error)}")
 end
 ```
 

--- a/documentation/tutorials/09-inverse-kinematics.md
+++ b/documentation/tutorials/09-inverse-kinematics.md
@@ -307,10 +307,10 @@ case Motion.move_to_multi(MyRobot.Robot, targets,
     end)
 
   {:error, %BB.Error.Kinematics.MultiFailed{failed_link: link} = error} ->
-    IO.puts("#{link} failed: #{BB.Error.message(error)}")
+    IO.puts("#{link} failed: #{Exception.message(error)}")
 
   {:error, error} ->
-    IO.puts("An actuator refused its command: #{BB.Error.message(error)}")
+    IO.puts("An actuator refused its command: #{Exception.message(error)}")
 end
 ```
 

--- a/documentation/tutorials/09-inverse-kinematics.md
+++ b/documentation/tutorials/09-inverse-kinematics.md
@@ -267,7 +267,7 @@ case Motion.move_to(MyRobot.Robot, :tip, {0.3, 0.2, 0.1},
 end
 ```
 
-This solves IK, updates the robot state, and sends position commands to all actuators.
+This solves IK and sends position commands to all actuators. It does **not** write the solved positions into `BB.Robot.State` — a commanded position isn't a measured one. Where the joints actually end up is reported by their sensors, so a joint whose actuator has no position feedback needs a `BB.Sensor.OpenLoopPositionEstimator` (the DSL warns at compile time if one is missing).
 
 ### Using FABRIK Convenience Functions
 

--- a/documentation/tutorials/10-simulation.md
+++ b/documentation/tutorials/10-simulation.md
@@ -62,7 +62,7 @@ With your robot running in simulation (see [Starting in Simulation Mode](#starti
 :ok = BB.Safety.arm(MyRobot.Robot)
 
 # Send a position command
-BB.Actuator.set_position!(MyRobot.Robot, :shoulder_motor, 1.57)
+:ok = BB.Actuator.set_position(MyRobot.Robot, :shoulder_motor, 1.57)
 
 # The OpenLoopPositionEstimator will estimate position over time
 Process.sleep(500)
@@ -211,7 +211,7 @@ You can subscribe to motion messages from simulated actuators:
 BB.PubSub.subscribe(MyRobot.Robot, [:actuator, :base_link, :shoulder, :motor])
 
 # Send a command
-BB.Actuator.set_position!(MyRobot.Robot, :motor, 1.0)
+:ok = BB.Actuator.set_position(MyRobot.Robot, :motor, 1.0)
 
 # Receive the BeginMotion message
 receive do

--- a/documentation/tutorials/12-writing-an-actuator.md
+++ b/documentation/tutorials/12-writing-an-actuator.md
@@ -66,7 +66,7 @@ BB.Actuator.Server  ───►  refuses the command unless the robot is armed
 MyDriver.handle_command(motor_space_message, state)
 ```
 
-`set_position/4` also calls the actuator directly, so it can hand its caller the acceptance or refusal; the publication is there for whoever else is watching the topic. `set_position_async/4` casts and waits for nothing. Either way the server funnels every transport into `handle_command/2` — your driver never learns which one was used, and choosing one can't skip the checks.
+`set_position/4` also calls the actuator directly, so it can hand its caller the acceptance or refusal; the publication is there for whoever else is watching the topic. Pass `delivery: :direct` and it casts instead, waiting for nothing. Either way the server funnels every transport into `handle_command/2` — your driver never learns which one was used, and choosing one can't skip the checks.
 
 By the time a `Command.Position`, `Command.Velocity`, `Command.Effort`, or `Command.Trajectory` arrives in your driver's callback, every numeric value is already in motor-space. Your driver does no joint-to-motor maths.
 

--- a/documentation/tutorials/12-writing-an-actuator.md
+++ b/documentation/tutorials/12-writing-an-actuator.md
@@ -56,6 +56,7 @@ This means each attachment can declare its own relationship to the joint indepen
 BB.Actuator.set_position(MyRobot, :motor, 1.57)
        │
        │  name resolved to [:base, :shoulder, :motor], published to [:actuator | path]
+       │  for observers, and called on the actuator itself
        ▼
 BB.Actuator.Server  ───►  refuses the command unless the robot is armed
        │            ───►  applies transmission via BB.Transmission.apply_to_command
@@ -65,7 +66,7 @@ BB.Actuator.Server  ───►  refuses the command unless the robot is armed
 MyDriver.handle_command(motor_space_message, state)
 ```
 
-`set_position!/4` and `set_position_sync/5` take the same path — the server subscribes to the actuator's command topic itself and funnels all three transports into `handle_command/2`. Your driver never learns which one was used, and choosing one can't skip the checks.
+`set_position/4` also calls the actuator directly, so it can hand its caller the acceptance or refusal; the publication is there for whoever else is watching the topic. `set_position_async/4` casts and waits for nothing. Either way the server funnels every transport into `handle_command/2` — your driver never learns which one was used, and choosing one can't skip the checks.
 
 By the time a `Command.Position`, `Command.Velocity`, `Command.Effort`, or `Command.Trajectory` arrives in your driver's callback, every numeric value is already in motor-space. Your driver does no joint-to-motor maths.
 

--- a/lib/bb.ex
+++ b/lib/bb.ex
@@ -11,6 +11,7 @@ defmodule BB do
   defdelegate subscribe(module, path, opts \\ []), to: BB.PubSub
   defdelegate unsubscribe(module, path), to: BB.PubSub
   defdelegate publish(module, path, message), to: BB.PubSub
+  defdelegate publish(module, path, message, opts), to: BB.PubSub
 
   defdelegate call(module, name, message, timeout \\ 5000), to: BB.Process
   defdelegate cast(module, name, message), to: BB.Process

--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -30,6 +30,9 @@ defmodule BB.Actuator do
 
   ### Optional Callbacks
 
+  - `capabilities/0` - Declare that the driver reads position, velocity or
+    effort back from the hardware. Without it the framework assumes it doesn't,
+    and warns that the joint needs a sensor
   - `handle_options/2` - React to parameter changes at runtime
   - `handle_call/3`, `handle_cast/2`, `handle_info/2` - Standard GenServer-style
     callbacks, for the driver's own traffic
@@ -341,7 +344,43 @@ defmodule BB.Actuator do
   """
   @callback command_payloads(opts :: keyword()) :: [module()]
 
+  @typedoc """
+  Something an actuator can do beyond taking commands.
+
+  Each value names a field of `BB.Message.Sensor.JointState` the driver can
+  fill in for itself, having read it back from the hardware.
+  """
+  @type capability :: :position_feedback | :velocity_feedback | :effort_feedback
+
+  @doc """
+  What this actuator can do besides move.
+
+  Defaults to `[]` - the honest answer for a driver that only writes to its
+  hardware, like a PWM servo or a step/direction driver. Such a joint needs a
+  sensor to say where it ended up, and `BB.Dsl` warns at compile time when it
+  doesn't have one.
+
+  A driver that reads state back from the hardware - a smart servo answering
+  position queries on its bus - says so here, and publishes what it reads as
+  `BB.Message.Sensor.JointState` on its joint's sensor topic:
+
+      @impl BB.Actuator
+      def capabilities, do: [:position_feedback, :velocity_feedback]
+
+  Declaring `:position_feedback` tells the framework this actuator is its own
+  position sensor, so no warning is issued for the joint it drives. Declare it
+  only if the driver really does publish `JointState`: the warning exists
+  because `BB.Robot.State` is written from those messages and from nothing
+  else, so a joint nobody reports on never moves as far as the rest of the
+  framework is concerned.
+
+  Answered without options or state, because it describes the driver rather
+  than any one instance of it, and the DSL asks at compile time.
+  """
+  @callback capabilities() :: [capability()]
+
   @optional_callbacks [
+    capabilities: 0,
     command_payloads: 1,
     handle_options: 2,
     handle_call: 3,
@@ -381,6 +420,9 @@ defmodule BB.Actuator do
 
       # Default implementations - all overridable
       @impl BB.Actuator
+      def capabilities, do: []
+
+      @impl BB.Actuator
       def command_payloads(_opts), do: BB.Actuator.default_command_payloads()
 
       @impl BB.Actuator
@@ -401,7 +443,8 @@ defmodule BB.Actuator do
       @impl BB.Actuator
       def terminate(_reason, _state), do: :ok
 
-      defoverridable command_payloads: 1,
+      defoverridable capabilities: 0,
+                     command_payloads: 1,
                      handle_options: 2,
                      handle_call: 3,
                      handle_cast: 2,

--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -106,23 +106,28 @@ defmodule BB.Actuator do
 
   ## API
 
-  Supports both pubsub delivery (for orchestration, logging, replay) and
-  direct GenServer delivery (for time-critical control paths).
-
   ### Delivery Methods
 
-  - **Pubsub** (`set_position/4`, etc.) - Commands published to `[:actuator | path]`.
-    Enables logging, replay, and multi-subscriber patterns.
+  - **Acknowledged** (`set_position/4`) - The command is published to
+    `[:actuator | path]` so orchestration and logging can observe it, and
+    delivered to the actuator by a call. Returns `:ok` or `{:error, reason}`,
+    so a caller finds out that a joint isn't moving rather than assuming it is.
 
-  - **Direct** (`set_position!/4`, etc.) - Commands sent directly via `BB.Process.cast`.
-    Lower latency for time-critical control.
+  - **Fire-and-forget** (`set_position_async/4`, `set_velocity!/4`, etc.) -
+    Commands sent via `BB.Process.cast`. Lower latency for time-critical
+    control, at the price of a refusal that only the log and telemetry ever
+    see.
 
-  - **Synchronous** (`set_position_sync/5`, etc.) - Commands sent via `BB.Process.call`.
-    Returns acknowledgement or error.
+  - **Synchronous** (`set_velocity_sync/5`, etc.) - Commands sent via
+    `BB.Process.call`, without publishing. Returns acknowledgement or error.
 
-  All three converge on `c:handle_command/2`. Which transport a caller chose
+  All of them converge on `c:handle_command/2`. Which transport a caller chose
   is not something a driver has to know about, and choosing one cannot skip
   the checks `BB.Actuator.Server` applies on the way in.
+
+  Only the position commands have been through this treatment so far; the other
+  payloads still offer the older pubsub/`!`/`_sync` trio, in which the pubsub
+  form cannot report a refusal.
 
   ### Addressing
 
@@ -138,14 +143,11 @@ defmodule BB.Actuator do
 
   ### Examples
 
-      # Pubsub delivery (for kinematics/orchestration)
-      BB.Actuator.set_position(MyRobot, :shoulder_servo, 1.57)
+      # Published for observers, acknowledged by the actuator
+      :ok = BB.Actuator.set_position(MyRobot, :shoulder_servo, 1.57)
 
-      # Direct delivery (for time-critical control)
-      BB.Actuator.set_position!(MyRobot, :shoulder_servo, 1.57)
-
-      # Synchronous with acknowledgement
-      {:ok, :accepted} = BB.Actuator.set_position_sync(MyRobot, :shoulder_servo, 1.57)
+      # Fire-and-forget (for time-critical control)
+      BB.Actuator.set_position_async(MyRobot, :shoulder_servo, 1.57)
   """
 
   # ----------------------------------------------------------------------------
@@ -175,9 +177,11 @@ defmodule BB.Actuator do
   the robot is armed and translated the payload from joint-space into
   motor-space, so the values are ready to write to hardware.
 
-  The reply is used only by the synchronous transport (`set_position_sync/5`
-  and friends); it is discarded for pubsub and direct delivery. Returning
-  `{:noreply, state}` replies `{:ok, :accepted}` to a synchronous caller.
+  The reply is used only by callers that wait for one (`set_position/4`,
+  `set_velocity_sync/5` and friends); it is discarded for cast delivery.
+  Returning `{:noreply, state}` replies `{:ok, :accepted}` to such a caller,
+  which `set_position/4` reports as `:ok`. Only an `{:error, reason}` reply
+  tells a caller its command was refused.
 
       @impl BB.Actuator
       def handle_command(%BB.Message{payload: %Command.Position{} = cmd}, state) do
@@ -489,69 +493,72 @@ defmodule BB.Actuator do
   # ----------------------------------------------------------------------------
 
   @doc """
-  Send a position command via pubsub.
+  Send a position command and wait for the actuator to accept or refuse it.
 
-  The command is published to `[:actuator | path]` where subscribers can
-  receive it via `handle_info({:bb, path, message}, state)`.
+  The command is published to `[:actuator | path]` for whoever is watching the
+  topic, and delivered to the actuator itself by a call, so the caller learns
+  whether the joint is actually moving. An actuator refuses a command it
+  doesn't accept, or any command at all while the robot is disarmed.
+
+  The publication records that a command was issued; the return value says
+  whether it was accepted. A refused command still appears on the topic.
+
+  Runs in the caller's process, so a driver must not call this from inside its
+  own `c:handle_command/2` - it would be waiting on itself.
 
   ## Options
 
   - `:velocity` - Velocity hint (rad/s or m/s)
   - `:duration` - Duration hint (milliseconds)
   - `:command_id` - Correlation ID for feedback tracking
-
-  ## Examples
-
-      BB.Actuator.set_position(MyRobot, [:base_link, :shoulder, :servo], 1.57)
-      BB.Actuator.set_position(MyRobot, [:shoulder, :servo], 1.57, velocity: 0.5)
-  """
-  @spec set_position(module(), target(), number(), keyword()) :: :ok
-  def set_position(robot, target, position, opts \\ []) do
-    path = actuator_path!(robot, target)
-    message = build_position_message(path, position, opts)
-    BB.publish(robot, [:actuator | path], message)
-  end
-
-  @doc """
-  Send a position command directly to an actuator (bypasses pubsub).
-
-  Uses `BB.Process.cast` for fire-and-forget delivery. The actuator receives
-  the command via `handle_cast({:command, message}, state)`.
-
-  ## Options
-
-  Same as `set_position/4`.
-  """
-  @spec set_position!(module(), target(), number(), keyword()) :: :ok
-  def set_position!(robot, target, position, opts \\ []) do
-    actuator_name = actuator_name!(robot, target)
-    message = build_position_message(actuator_name, position, opts)
-    BB.cast(robot, actuator_name, {:command, message})
-  end
-
-  @doc """
-  Send a position command and wait for acknowledgement.
-
-  Uses `BB.Process.call` for synchronous delivery. Returns the actuator's
-  response or raises on timeout.
-
-  ## Options
-
-  Same as `set_position/4`, plus:
-  - Fifth argument is timeout in milliseconds (default 5000)
+  - `:timeout` - How long to wait for the actuator, in milliseconds (default 5000)
 
   ## Returns
 
-  - `{:ok, :accepted}` - Command accepted
-  - `{:ok, :accepted, map()}` - Command accepted with additional info
-  - `{:error, reason}` - Command rejected
+  - `:ok` - Command accepted
+  - `{:error, reason}` - Command refused, `reason` being a `BB.Error` struct
+
+  Exits if the actuator isn't running or doesn't answer within `:timeout`,
+  like any other `GenServer.call/3`.
+
+  ## Examples
+
+      :ok = BB.Actuator.set_position(MyRobot, [:base_link, :shoulder, :servo], 1.57)
+
+      case BB.Actuator.set_position(MyRobot, :servo, 1.57, velocity: 0.5) do
+        :ok -> :moving
+        {:error, error} -> Logger.error(Exception.message(error))
+      end
   """
-  @spec set_position_sync(module(), target(), number(), keyword(), timeout()) ::
-          {:ok, :accepted | {:accepted, map()}} | {:error, term()}
-  def set_position_sync(robot, target, position, opts \\ [], timeout \\ 5000) do
+  @spec set_position(module(), target(), number(), keyword()) :: :ok | {:error, term()}
+  def set_position(robot, target, position, opts \\ []) do
+    path = actuator_path!(robot, target)
+    message = build_position_message(path, position, opts)
+    send_command(robot, path, message, opts)
+  end
+
+  @doc """
+  Send a position command without waiting for an answer.
+
+  Uses `BB.Process.cast` for fire-and-forget delivery, for control paths where
+  the round trip of `set_position/4` costs more than knowing the outcome is
+  worth. Nothing is published to the actuator's topic, so orchestration and
+  logging don't see the command either.
+
+  A refusal can't be returned to a caller that isn't waiting: it shows up as a
+  warning in the log and a `[:bb, :actuator, :rejected]` telemetry event, and
+  nowhere else. Reach for `set_position/4` unless you have measured that you
+  can't afford it.
+
+  ## Options
+
+  Same as `set_position/4`, except `:timeout`, which has nothing to wait for.
+  """
+  @spec set_position_async(module(), target(), number(), keyword()) :: :ok
+  def set_position_async(robot, target, position, opts \\ []) do
     actuator_name = actuator_name!(robot, target)
     message = build_position_message(actuator_name, position, opts)
-    BB.call(robot, actuator_name, {:command, message}, timeout)
+    BB.cast(robot, actuator_name, {:command, message})
   end
 
   defp build_position_message(frame_id, position, opts) do
@@ -832,6 +839,34 @@ defmodule BB.Actuator do
     frame_id = if is_list(frame_id), do: List.last(frame_id), else: frame_id
     Message.new!(Command.Hold, frame_id, command_id: opts[:command_id])
   end
+
+  # ----------------------------------------------------------------------------
+  # Delivery
+  # ----------------------------------------------------------------------------
+
+  @default_timeout 5000
+
+  # The actuator is excluded from the publication because it is about to be
+  # handed the same command directly: it subscribes to its own command topic,
+  # and would otherwise drive the hardware twice for one call.
+  @spec send_command(module(), [atom()], Message.t(), keyword()) :: :ok | {:error, term()}
+  defp send_command(robot, path, message, opts) do
+    actuator_name = List.last(path)
+
+    BB.publish(robot, [:actuator | path], message,
+      except: [BB.Process.whereis(robot, actuator_name)]
+    )
+
+    robot
+    |> BB.call(actuator_name, {:command, message}, Keyword.get(opts, :timeout, @default_timeout))
+    |> command_result()
+  end
+
+  # A driver may answer `c:handle_command/2` with anything it likes; only a
+  # refusal changes what the caller should do next.
+  @spec command_result(term()) :: :ok | {:error, term()}
+  defp command_result({:error, reason}), do: {:error, reason}
+  defp command_result(_accepted), do: :ok
 
   # ----------------------------------------------------------------------------
   # Addressing

--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -30,7 +30,7 @@ defmodule BB.Actuator do
 
   ### Optional Callbacks
 
-  - `capabilities/0` - Declare that the driver reads position, velocity or
+  - `capabilities/1` - Declare that the driver reads position, velocity or
     effort back from the hardware. Without it the framework assumes it doesn't,
     and warns that the joint needs a sensor
   - `handle_options/2` - React to parameter changes at runtime
@@ -365,7 +365,7 @@ defmodule BB.Actuator do
   `BB.Message.Sensor.JointState` on its joint's sensor topic:
 
       @impl BB.Actuator
-      def capabilities, do: [:position_feedback, :velocity_feedback]
+      def capabilities(_opts), do: [:position_feedback, :velocity_feedback]
 
   Declaring `:position_feedback` tells the framework this actuator is its own
   position sensor, so no warning is issued for the joint it drives. Declare it
@@ -374,13 +374,37 @@ defmodule BB.Actuator do
   else, so a joint nobody reports on never moves as far as the rest of the
   framework is concerned.
 
-  Answered without options or state, because it describes the driver rather
-  than any one instance of it, and the DSL asks at compile time.
+  ## Options
+
+  `opts` lets a driver answer for how it was wired up, rather than for the
+  hardware in general - an encoder input that may or may not be connected:
+
+      @impl BB.Actuator
+      def capabilities(opts) do
+        if opts[:feedback_pin], do: [:position_feedback], else: []
+      end
+
+  > #### These are not the options `init/1` receives {: .warning}
+  >
+  > This is asked at compile time, by a DSL verifier, so `opts` is what the
+  > robot's author wrote in the DSL, checked against `c:options_schema/0` and
+  > with its defaults applied. Two things follow:
+  >
+  > - There is no `:bb` key, and no `:motor_profile`. The robot doesn't exist
+  >   yet.
+  > - A `param()` reference can't be resolved before the robot is running, so a
+  >   parameterised option arrives holding its schema default instead of the
+  >   value the robot will run with. A capability that genuinely depends on one
+  >   can't be answered here; say what is true of the common case, and prefer
+  >   claiming a capability you sometimes lack over disclaiming one you usually
+  >   have - a spurious warning teaches people to ignore warnings.
+  >
+  > Keep it pure for the same reason: no hardware, no processes, no `Mix`.
   """
-  @callback capabilities() :: [capability()]
+  @callback capabilities(opts :: keyword()) :: [capability()]
 
   @optional_callbacks [
-    capabilities: 0,
+    capabilities: 1,
     command_payloads: 1,
     handle_options: 2,
     handle_call: 3,
@@ -420,7 +444,7 @@ defmodule BB.Actuator do
 
       # Default implementations - all overridable
       @impl BB.Actuator
-      def capabilities, do: []
+      def capabilities(_opts), do: []
 
       @impl BB.Actuator
       def command_payloads(_opts), do: BB.Actuator.default_command_payloads()
@@ -443,7 +467,7 @@ defmodule BB.Actuator do
       @impl BB.Actuator
       def terminate(_reason, _state), do: :ok
 
-      defoverridable capabilities: 0,
+      defoverridable capabilities: 1,
                      command_payloads: 1,
                      handle_options: 2,
                      handle_call: 3,

--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -108,26 +108,25 @@ defmodule BB.Actuator do
 
   ### Delivery Methods
 
-  - **Acknowledged** (`set_position/4`) - The command is published to
-    `[:actuator | path]` so orchestration and logging can observe it, and
-    delivered to the actuator by a call. Returns `:ok` or `{:error, reason}`,
-    so a caller finds out that a joint isn't moving rather than assuming it is.
+  `set_position/4` takes a `:delivery` option, the same one `BB.Motion` takes:
 
-  - **Fire-and-forget** (`set_position_async/4`, `set_velocity!/4`, etc.) -
-    Commands sent via `BB.Process.cast`. Lower latency for time-critical
-    control, at the price of a refusal that only the log and telemetry ever
-    see.
+  - **`:pubsub`** (default) - The command is published to `[:actuator | path]`
+    so orchestration and logging can observe it, and delivered to the actuator
+    by a call. Returns `:ok` or `{:error, reason}`, so a caller finds out that
+    a joint isn't moving rather than assuming it is.
 
-  - **Synchronous** (`set_velocity_sync/5`, etc.) - Commands sent via
-    `BB.Process.call`, without publishing. Returns acknowledgement or error.
+  - **`:direct`** - Sent via `BB.Process.cast`, publishing nothing. Lower
+    latency for time-critical control, at the price of a refusal that only the
+    log and telemetry ever see. It always returns `:ok`.
+
+  The other payloads still offer the older trio - a pubsub function, a `!` cast
+  and a `_sync` call (`set_velocity/4`, `set_velocity!/4`,
+  `set_velocity_sync/5`) - in which the pubsub form cannot report a refusal at
+  all.
 
   All of them converge on `c:handle_command/2`. Which transport a caller chose
   is not something a driver has to know about, and choosing one cannot skip
   the checks `BB.Actuator.Server` applies on the way in.
-
-  Only the position commands have been through this treatment so far; the other
-  payloads still offer the older pubsub/`!`/`_sync` trio, in which the pubsub
-  form cannot report a refusal.
 
   ### Addressing
 
@@ -147,7 +146,7 @@ defmodule BB.Actuator do
       :ok = BB.Actuator.set_position(MyRobot, :shoulder_servo, 1.57)
 
       # Fire-and-forget (for time-critical control)
-      BB.Actuator.set_position_async(MyRobot, :shoulder_servo, 1.57)
+      BB.Actuator.set_position(MyRobot, :shoulder_servo, 1.57, delivery: :direct)
   """
 
   # ----------------------------------------------------------------------------
@@ -493,12 +492,13 @@ defmodule BB.Actuator do
   # ----------------------------------------------------------------------------
 
   @doc """
-  Send a position command and wait for the actuator to accept or refuse it.
+  Send a position command.
 
-  The command is published to `[:actuator | path]` for whoever is watching the
-  topic, and delivered to the actuator itself by a call, so the caller learns
-  whether the joint is actually moving. An actuator refuses a command it
-  doesn't accept, or any command at all while the robot is disarmed.
+  Under the default `delivery: :pubsub` the command is published to
+  `[:actuator | path]` for whoever is watching the topic, and delivered to the
+  actuator itself by a call, so the caller learns whether the joint is actually
+  moving. An actuator refuses a command it doesn't accept, or any command at
+  all while the robot is disarmed.
 
   The publication records that a command was issued; the return value says
   whether it was accepted. A refused command still appears on the topic.
@@ -508,18 +508,31 @@ defmodule BB.Actuator do
 
   ## Options
 
+  - `:delivery` - `:pubsub` (default) publishes the command and waits for the
+    actuator to accept it; `:direct` casts to the actuator and returns at once,
+    publishing nothing. Use `:direct` for control paths where the round trip
+    costs more than knowing the outcome is worth
   - `:velocity` - Velocity hint (rad/s or m/s)
   - `:duration` - Duration hint (milliseconds)
   - `:command_id` - Correlation ID for feedback tracking
-  - `:timeout` - How long to wait for the actuator, in milliseconds (default 5000)
+  - `:timeout` - How long to wait for the actuator, in milliseconds (default
+    5000). Unused under `:direct`, which waits for nothing
 
   ## Returns
 
   - `:ok` - Command accepted
   - `{:error, reason}` - Command refused, `reason` being a `BB.Error` struct
 
-  Exits if the actuator isn't running or doesn't answer within `:timeout`,
-  like any other `GenServer.call/3`.
+  Under `delivery: :pubsub`, exits if the actuator isn't running or doesn't
+  answer within `:timeout`, like any other `GenServer.call/3`.
+
+  > #### `delivery: :direct` always returns `:ok` {: .warning}
+  >
+  > A cast has nowhere to put an answer, so `:direct` returns `:ok` whether the
+  > actuator accepted the command or refused it. The refusal reaches the log
+  > and a `[:bb, :actuator, :rejected]` telemetry event, and nowhere else —
+  > matching on `{:error, reason}` there is a branch that can never run.
+  >
 
   ## Commanding several joints
 
@@ -555,30 +568,16 @@ defmodule BB.Actuator do
   """
   @spec set_position(module(), target(), number(), keyword()) :: :ok | {:error, term()}
   def set_position(robot, target, position, opts \\ []) do
+    deliver_position(Keyword.get(opts, :delivery, :pubsub), robot, target, position, opts)
+  end
+
+  defp deliver_position(:pubsub, robot, target, position, opts) do
     path = actuator_path!(robot, target)
     message = build_position_message(path, position, opts)
     send_command(robot, path, message, opts)
   end
 
-  @doc """
-  Send a position command without waiting for an answer.
-
-  Uses `BB.Process.cast` for fire-and-forget delivery, for control paths where
-  the round trip of `set_position/4` costs more than knowing the outcome is
-  worth. Nothing is published to the actuator's topic, so orchestration and
-  logging don't see the command either.
-
-  A refusal can't be returned to a caller that isn't waiting: it shows up as a
-  warning in the log and a `[:bb, :actuator, :rejected]` telemetry event, and
-  nowhere else. Reach for `set_position/4` unless you have measured that you
-  can't afford it.
-
-  ## Options
-
-  Same as `set_position/4`, except `:timeout`, which has nothing to wait for.
-  """
-  @spec set_position_async(module(), target(), number(), keyword()) :: :ok
-  def set_position_async(robot, target, position, opts \\ []) do
+  defp deliver_position(:direct, robot, target, position, opts) do
     actuator_name = actuator_name!(robot, target)
     message = build_position_message(actuator_name, position, opts)
     BB.cast(robot, actuator_name, {:command, message})

--- a/lib/bb/actuator.ex
+++ b/lib/bb/actuator.ex
@@ -521,6 +521,29 @@ defmodule BB.Actuator do
   Exits if the actuator isn't running or doesn't answer within `:timeout`,
   like any other `GenServer.call/3`.
 
+  ## Commanding several joints
+
+  This is an ordinary blocking call, so several joints cost several round
+  trips and how they overlap is yours to choose:
+
+      [shoulder: 1.57, elbow: 0.5]
+      |> Enum.map(fn {joint, position} ->
+        Task.async(fn -> BB.Actuator.set_position(MyRobot, joint, position) end)
+      end)
+      |> Task.await_many()
+
+  Three things to know before reaching for that:
+
+  - `Task.async/1` **links**. From a long-lived process - a controller loop -
+    use `Task.Supervisor.async_nolink/3` instead, or an actuator that has died
+    takes the caller down with it.
+  - `Task.await_many/2` applies one deadline to the whole set and kills the
+    stragglers when it expires. It isn't "collect as they land".
+  - Each command publishes from inside its own task, so observers see the
+    commands interleaved rather than in the order you listed them.
+
+  `BB.Motion.send_positions/3` already does this for the joints of one motion.
+
   ## Examples
 
       :ok = BB.Actuator.set_position(MyRobot, [:base_link, :shoulder, :servo], 1.57)

--- a/lib/bb/actuator/server.ex
+++ b/lib/bb/actuator/server.ex
@@ -38,6 +38,8 @@ defmodule BB.Actuator.Server do
 
   use GenServer
 
+  require Logger
+
   alias BB.Actuator.MotorProfile
   alias BB.Component.OptionsSchema
   alias BB.Error.State.NotArmed
@@ -356,6 +358,12 @@ defmodule BB.Actuator.Server do
   end
 
   defp refuse(message, reason, error, transport, state) do
+    Logger.warning(
+      "Actuator #{inspect(state.actuator_name)} on #{inspect(state.bb.robot)} refused " <>
+        "#{inspect(message.payload.__struct__)} delivered by #{transport}: " <>
+        Exception.message(error)
+    )
+
     :telemetry.execute(
       [:bb, :actuator, :rejected],
       %{count: 1},

--- a/lib/bb/command/move_to.ex
+++ b/lib/bb/command/move_to.ex
@@ -92,7 +92,6 @@ defmodule BB.Command.MoveTo do
   use BB.Command
 
   alias BB.Error.Invalid.Command, as: InvalidCommand
-  alias BB.Error.Kinematics.MultiFailed
   alias BB.Math.Vec3
   alias BB.Message.Geometry.Point3D
   alias BB.Motion
@@ -130,13 +129,7 @@ defmodule BB.Command.MoveTo do
       opts = build_opts(goal, source_link, solver)
       target = normalize_target(target)
 
-      case Motion.move_to(context, target_link, target, opts) do
-        {:ok, meta} ->
-          {:ok, meta}
-
-        {:error, error} ->
-          {:error, error}
-      end
+      Motion.move_to(context, target_link, target, opts)
     end
   end
 
@@ -146,18 +139,7 @@ defmodule BB.Command.MoveTo do
          {:ok, source_link} <- fetch_required(goal, :source_link) do
       opts = build_opts(goal, source_link, solver)
 
-      case Motion.move_to_multi(context, targets, opts) do
-        {:ok, results} ->
-          {:ok, results}
-
-        {:error, failed_link, error, results} ->
-          {:error,
-           MultiFailed.exception(
-             failed_link: failed_link,
-             error: error,
-             partial_results: results
-           )}
-      end
+      Motion.move_to_multi(context, targets, opts)
     end
   end
 

--- a/lib/bb/command/move_to.ex
+++ b/lib/bb/command/move_to.ex
@@ -35,6 +35,10 @@ defmodule BB.Command.MoveTo do
   - `respect_limits` - Whether to clamp to joint limits (default: true)
   - `delivery` - Actuator command delivery: `:pubsub` (default) waits for each
     actuator to accept its command, `:direct` doesn't wait
+  - `velocity` - Velocity hint for actuators (rad/s or m/s)
+  - `duration` - Duration hint for actuators (milliseconds)
+  - `timeout` - How long to wait for each actuator to accept its command, in
+    milliseconds (default: 5000). Unused under `delivery: :direct`
 
   ## Usage
 
@@ -174,7 +178,10 @@ defmodule BB.Command.MoveTo do
       max_iterations: Map.get(goal, :max_iterations),
       tolerance: Map.get(goal, :tolerance),
       respect_limits: Map.get(goal, :respect_limits),
-      delivery: Map.get(goal, :delivery)
+      delivery: Map.get(goal, :delivery),
+      velocity: Map.get(goal, :velocity),
+      duration: Map.get(goal, :duration),
+      timeout: Map.get(goal, :timeout)
     ]
     |> Keyword.reject(fn {_k, v} -> is_nil(v) end)
   end

--- a/lib/bb/command/move_to.ex
+++ b/lib/bb/command/move_to.ex
@@ -33,7 +33,8 @@ defmodule BB.Command.MoveTo do
   - `max_iterations` - Maximum solver iterations (default: 50)
   - `tolerance` - Convergence tolerance in metres (default: 1.0e-4)
   - `respect_limits` - Whether to clamp to joint limits (default: true)
-  - `delivery` - Actuator command delivery: `:pubsub` (default), `:direct`, or `:sync`
+  - `delivery` - Actuator command delivery: `:pubsub` (default) waits for each
+    actuator to accept its command, `:direct` doesn't wait
 
   ## Usage
 

--- a/lib/bb/dsl.ex
+++ b/lib/bb/dsl.ex
@@ -476,6 +476,17 @@ defmodule BB.Dsl do
         required: true,
         doc:
           "The child specification for the actuator process. Either a module or `{module, keyword_list}`"
+      ],
+      sensor: [
+        type: :boolean,
+        required: false,
+        default: true,
+        doc: """
+        Whether this actuator needs a separate sensor to report where its joint
+        actually is. Set it to `false` for hardware that reports its own
+        position - a smart servo answering position queries on its bus - to say
+        that the missing position sensor is deliberate.
+        """
       ]
     ]
   }
@@ -1279,6 +1290,7 @@ defmodule BB.Dsl do
       __MODULE__.Verifiers.ValidateChildSpecs,
       __MODULE__.Verifiers.ValidateEstimators,
       __MODULE__.Verifiers.ValidateParamRefs,
+      __MODULE__.Verifiers.ValidatePositionFeedback,
       __MODULE__.Verifiers.ValidateStateRefs,
       __MODULE__.Verifiers.ValidateCategoryRefs
     ]

--- a/lib/bb/dsl.ex
+++ b/lib/bb/dsl.ex
@@ -476,17 +476,6 @@ defmodule BB.Dsl do
         required: true,
         doc:
           "The child specification for the actuator process. Either a module or `{module, keyword_list}`"
-      ],
-      sensor: [
-        type: :boolean,
-        required: false,
-        default: true,
-        doc: """
-        Whether this actuator needs a separate sensor to report where its joint
-        actually is. Set it to `false` for hardware that reports its own
-        position - a smart servo answering position queries on its bus - to say
-        that the missing position sensor is deliberate.
-        """
       ]
     ]
   }

--- a/lib/bb/dsl/actuator.ex
+++ b/lib/bb/dsl/actuator.ex
@@ -9,6 +9,7 @@ defmodule BB.Dsl.Actuator do
             __spark_metadata__: nil,
             name: nil,
             child_spec: nil,
+            sensor: true,
             transmission: nil
 
   alias BB.Dsl.Transmission
@@ -21,6 +22,7 @@ defmodule BB.Dsl.Actuator do
           __spark_metadata__: Entity.spark_meta(),
           name: atom,
           child_spec: child_spec,
+          sensor: boolean,
           transmission: nil | Transmission.t()
         }
 end

--- a/lib/bb/dsl/actuator.ex
+++ b/lib/bb/dsl/actuator.ex
@@ -9,7 +9,6 @@ defmodule BB.Dsl.Actuator do
             __spark_metadata__: nil,
             name: nil,
             child_spec: nil,
-            sensor: true,
             transmission: nil
 
   alias BB.Dsl.Transmission
@@ -22,7 +21,6 @@ defmodule BB.Dsl.Actuator do
           __spark_metadata__: Entity.spark_meta(),
           name: atom,
           child_spec: child_spec,
-          sensor: boolean,
           transmission: nil | Transmission.t()
         }
 end

--- a/lib/bb/dsl/child_spec_options.ex
+++ b/lib/bb/dsl/child_spec_options.ex
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Dsl.ChildSpecOptions do
+  @moduledoc """
+  A child spec's options, resolved as far as compile time allows.
+
+  Used by the verifiers that need to ask a component module about itself before
+  the robot exists - what options it accepts, what its driver can do - so they
+  all take the same view of a `param()` reference.
+
+  Which is that they can't see one. A parameter isn't resolved until the robot
+  is running and its store has been populated, so a parameterised option is
+  dropped here and its key is not required, leaving the schema's default in its
+  place. Anything reading these options has to answer for the default rather
+  than for the value the robot will actually run with.
+  """
+
+  alias BB.Dsl.ParamRef
+
+  @doc """
+  Split a child spec into its module and options.
+  """
+  @spec module_and_options(module() | {module(), keyword()}) :: {module(), keyword()}
+  def module_and_options(module) when is_atom(module), do: {module, []}
+  def module_and_options({module, opts}) when is_atom(module), do: {module, opts}
+
+  @doc """
+  Validate options against the module's `options_schema/0`, applying defaults.
+
+  Parameterised options are dropped and their keys made optional, so a spec
+  that is only valid once its parameters resolve still validates here.
+  """
+  @spec validate(module(), keyword()) ::
+          {:ok, keyword()} | {:error, Spark.Options.ValidationError.t()}
+  def validate(module, opts) do
+    schema = mark_optional(module.options_schema(), param_ref_keys(opts))
+
+    opts
+    |> Enum.reject(&param_ref?/1)
+    |> Spark.Options.validate(schema)
+  end
+
+  defp param_ref_keys(opts) do
+    opts
+    |> Enum.filter(&param_ref?/1)
+    |> Keyword.keys()
+  end
+
+  defp param_ref?({_key, value}), do: is_struct(value, ParamRef)
+
+  defp mark_optional(%Spark.Options{schema: schema} = spark_opts, keys) do
+    %{spark_opts | schema: mark_optional(schema, keys)}
+  end
+
+  defp mark_optional(schema, keys) when is_list(schema) do
+    Enum.map(schema, fn {key, opts} ->
+      if key in keys do
+        {key, Keyword.put(opts, :required, false)}
+      else
+        {key, opts}
+      end
+    end)
+  end
+end

--- a/lib/bb/dsl/verifiers/validate_child_specs.ex
+++ b/lib/bb/dsl/verifiers/validate_child_specs.ex
@@ -17,7 +17,7 @@ defmodule BB.Dsl.Verifiers.ValidateChildSpecs do
 
   use Spark.Dsl.Verifier
 
-  alias BB.Dsl.{Actuator, Bridge, Controller, Estimator, Joint, Link, ParamRef, Sensor}
+  alias BB.Dsl.{Actuator, Bridge, ChildSpecOptions, Controller, Estimator, Joint, Link, Sensor}
   alias Spark.Dsl.Verifier
   alias Spark.Error.DslError
 
@@ -177,20 +177,14 @@ defmodule BB.Dsl.Verifiers.ValidateChildSpecs do
   end
 
   defp validate_child_spec(child_spec, path, robot_module) do
-    {module, opts} = normalize_child_spec(child_spec)
+    {module, opts} = ChildSpecOptions.module_and_options(child_spec)
     validate_options(module, opts, path, robot_module)
   end
 
-  defp normalize_child_spec(module) when is_atom(module), do: {module, []}
-  defp normalize_child_spec({module, opts}) when is_atom(module), do: {module, opts}
-
   defp validate_options(module, opts, path, robot_module) do
     schema = module.options_schema()
-    param_ref_keys = get_param_ref_keys(opts)
-    schema_for_validation = mark_keys_as_optional(schema, param_ref_keys)
-    opts_without_param_refs = filter_param_refs(opts)
 
-    case Spark.Options.validate(opts_without_param_refs, schema_for_validation) do
+    case ChildSpecOptions.validate(module, opts) do
       {:ok, _validated} ->
         :ok
 
@@ -209,30 +203,6 @@ defmodule BB.Dsl.Verifiers.ValidateChildSpecs do
            """
          )}
     end
-  end
-
-  defp filter_param_refs(opts) do
-    Enum.reject(opts, fn {_key, value} -> is_struct(value, ParamRef) end)
-  end
-
-  defp get_param_ref_keys(opts) do
-    opts
-    |> Enum.filter(fn {_key, value} -> is_struct(value, ParamRef) end)
-    |> Keyword.keys()
-  end
-
-  defp mark_keys_as_optional(%Spark.Options{schema: schema} = spark_opts, keys) do
-    %{spark_opts | schema: mark_keys_as_optional(schema, keys)}
-  end
-
-  defp mark_keys_as_optional(schema, keys) when is_list(schema) do
-    Enum.map(schema, fn {key, opts} ->
-      if key in keys do
-        {key, Keyword.put(opts, :required, false)}
-      else
-        {key, opts}
-      end
-    end)
   end
 
   defp format_schema(%Spark.Options{schema: schema}) do

--- a/lib/bb/dsl/verifiers/validate_position_feedback.ex
+++ b/lib/bb/dsl/verifiers/validate_position_feedback.ex
@@ -57,7 +57,11 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedback do
 
   defp unsensed_joints_in(%Link{} = link), do: unsensed_joints(link.joints)
 
-  defp unsensed_joints_in(%Joint{type: :fixed}), do: []
+  # A fixed joint has nowhere to go. A continuous one rotates without limit - a
+  # wheel, a spinner - so it has no position to hold, nothing solves toward it,
+  # and the estimator this warning recommends can't help: it interpolates
+  # position moves, which a velocity- or effort-driven wheel never issues.
+  defp unsensed_joints_in(%Joint{type: type}) when type in [:fixed, :continuous], do: []
 
   defp unsensed_joints_in(%Joint{sensors: [_ | _]} = joint), do: nested_joints(joint)
 

--- a/lib/bb/dsl/verifiers/validate_position_feedback.ex
+++ b/lib/bb/dsl/verifiers/validate_position_feedback.ex
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Dsl.Verifiers.ValidatePositionFeedback do
+  @moduledoc """
+  Warns about joints that are driven but never measured.
+
+  `BB.Robot.State` is written from `BB.Message.Sensor.JointState` messages and
+  from nothing else - commanding a joint doesn't move it in state, because a
+  commanded position isn't a measured one. A joint with an actuator and no
+  sensor therefore stays at its initial configuration forever, which quietly
+  ruins anything reading it: forward kinematics, the URDF-driven visualisers,
+  and inverse kinematics, which seeds each solve from the current
+  configuration.
+
+  Hardware without position feedback is served by
+  `BB.Sensor.OpenLoopPositionEstimator`, which interpolates from the actuator's
+  `BeginMotion` messages. Simulation adds one to every unsensed actuator
+  automatically; hardware doesn't, since only the author knows whether the real
+  device reports its own position.
+
+  Which is the case this can't see: a smart servo that answers position queries
+  on its bus is its own sensor, and the driver may publish `JointState` without
+  anything appearing in the topology. `sensor false` on the actuator says so
+  and silences the warning.
+
+  This warns rather than failing the build. A robot that is only ever driven
+  open-loop, never asked where it is, is unusual but not wrong.
+  """
+
+  use Spark.Dsl.Verifier
+
+  alias BB.Dsl.Joint
+  alias BB.Dsl.Link
+  alias Spark.Dsl.Verifier
+
+  @impl true
+  def verify(dsl_state) do
+    robot = Verifier.get_persisted(dsl_state, :module)
+    file = Verifier.get_persisted(dsl_state, :file)
+
+    dsl_state
+    |> Verifier.get_entities([:topology])
+    |> unsensed_joints()
+    |> Enum.each(&warn(&1, robot, file))
+
+    :ok
+  end
+
+  defp unsensed_joints(entities) do
+    Enum.flat_map(entities, &unsensed_joints_in/1)
+  end
+
+  defp unsensed_joints_in(%Link{} = link) do
+    unsensed_joints(link.joints)
+  end
+
+  defp unsensed_joints_in(%Joint{type: :fixed}), do: []
+
+  defp unsensed_joints_in(%Joint{sensors: [_ | _]} = joint), do: nested_joints(joint)
+
+  defp unsensed_joints_in(%Joint{} = joint) do
+    case Enum.filter(joint.actuators, & &1.sensor) do
+      [] -> nested_joints(joint)
+      actuators -> [{joint, actuators} | nested_joints(joint)]
+    end
+  end
+
+  defp unsensed_joints_in(_entity), do: []
+
+  defp nested_joints(%Joint{link: nil}), do: []
+  defp nested_joints(%Joint{link: link}), do: unsensed_joints_in(link)
+
+  defp warn({joint, actuators}, robot, file) do
+    names = Enum.map_join(actuators, ", ", &inspect(&1.name))
+    example = actuators |> List.first() |> Map.fetch!(:name)
+
+    IO.warn(
+      """
+      #{inspect(robot)}: joint #{inspect(joint.name)} is driven by #{names} but has no sensor, \
+      so nothing ever reports where it is. Its configuration in `BB.Robot.State` will stay at \
+      its initial value, and inverse kinematics will keep solving from there.
+
+      If the hardware has no position feedback, estimate it from the commands:
+
+          sensor :#{example}_position, {BB.Sensor.OpenLoopPositionEstimator, actuator: :#{example}}
+
+      If the actuator reports its own position, say so:
+
+          actuator :#{example}, ..., sensor: false
+      """,
+      file: file,
+      line: 1
+    )
+  end
+end

--- a/lib/bb/dsl/verifiers/validate_position_feedback.ex
+++ b/lib/bb/dsl/verifiers/validate_position_feedback.ex
@@ -17,7 +17,7 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedback do
   an encoder, or `BB.Sensor.OpenLoopPositionEstimator` interpolating from the
   actuator's `BeginMotion` messages for hardware with no feedback at all. Or
   the actuator itself, if it reads position back from the hardware and says so
-  through `c:BB.Actuator.capabilities/0`. A joint with neither gets a warning
+  through `c:BB.Actuator.capabilities/1`. A joint with neither gets a warning
   naming both fixes.
 
   The driver is asked directly rather than the robot's author being made to
@@ -33,6 +33,7 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedback do
 
   use Spark.Dsl.Verifier
 
+  alias BB.Dsl.ChildSpecOptions
   alias BB.Dsl.Joint
   alias BB.Dsl.Link
   alias Spark.Dsl.Verifier
@@ -76,24 +77,25 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedback do
   # break the cross-package builds `ValidateChildSpecBehavioursTransformer`
   # already goes out of its way to allow. Say nothing rather than guess.
   defp senses_position?(actuator) do
-    module = module_for(actuator.child_spec)
+    {module, opts} = ChildSpecOptions.module_and_options(actuator.child_spec)
 
     case Code.ensure_compiled(module) do
-      {:module, _} -> :position_feedback in capabilities(module)
+      {:module, _} -> :position_feedback in capabilities(module, opts)
       {:error, _reason} -> true
     end
   end
 
-  defp capabilities(module) do
-    if function_exported?(module, :capabilities, 0) do
-      module.capabilities()
+  # Options the driver couldn't have asked for are worse than none: invalid ones
+  # are `ValidateChildSpecs`' to report, and this verifier would only turn its
+  # error into a crash.
+  defp capabilities(module, opts) do
+    with true <- function_exported?(module, :capabilities, 1),
+         {:ok, opts} <- ChildSpecOptions.validate(module, opts) do
+      module.capabilities(opts)
     else
-      []
+      _ -> []
     end
   end
-
-  defp module_for(module) when is_atom(module), do: module
-  defp module_for({module, _opts}) when is_atom(module), do: module
 
   # Sorted because the DSL hands entities back in whatever order it holds them,
   # and a warning that reorders itself between builds is a warning people learn
@@ -116,7 +118,7 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedback do
       `BB.Message.Sensor.JointState`:
 
           @impl BB.Actuator
-          def capabilities, do: [:position_feedback]
+          def capabilities(_opts), do: [:position_feedback]
       """,
       file: file,
       line: 1

--- a/lib/bb/dsl/verifiers/validate_position_feedback.ex
+++ b/lib/bb/dsl/verifiers/validate_position_feedback.ex
@@ -8,24 +8,26 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedback do
 
   `BB.Robot.State` is written from `BB.Message.Sensor.JointState` messages and
   from nothing else - commanding a joint doesn't move it in state, because a
-  commanded position isn't a measured one. A joint with an actuator and no
-  sensor therefore stays at its initial configuration forever, which quietly
-  ruins anything reading it: forward kinematics, the URDF-driven visualisers,
-  and inverse kinematics, which seeds each solve from the current
-  configuration.
+  commanded position isn't a measured one. A joint that nothing reports on
+  therefore stays at its initial configuration forever, which quietly ruins
+  anything reading it: forward kinematics, the URDF-driven visualisers, and
+  inverse kinematics, which seeds each solve from the current configuration.
 
-  Hardware without position feedback is served by
-  `BB.Sensor.OpenLoopPositionEstimator`, which interpolates from the actuator's
-  `BeginMotion` messages. Simulation adds one to every unsensed actuator
-  automatically; hardware doesn't, since only the author knows whether the real
-  device reports its own position.
+  Two things can report on a joint. A sensor declared alongside the actuator -
+  an encoder, or `BB.Sensor.OpenLoopPositionEstimator` interpolating from the
+  actuator's `BeginMotion` messages for hardware with no feedback at all. Or
+  the actuator itself, if it reads position back from the hardware and says so
+  through `c:BB.Actuator.capabilities/0`. A joint with neither gets a warning
+  naming both fixes.
 
-  Which is the case this can't see: a smart servo that answers position queries
-  on its bus is its own sensor, and the driver may publish `JointState` without
-  anything appearing in the topology. `sensor false` on the actuator says so
-  and silences the warning.
+  The driver is asked directly rather than the robot's author being made to
+  declare it, because whether a smart servo answers position queries is a
+  property of the driver, not of the robot it's wired into.
 
-  This warns rather than failing the build. A robot that is only ever driven
+  Simulation adds an estimator to every actuator without a declared position
+  sensor; hardware doesn't, which is why this check exists.
+
+  It warns rather than failing the build. A robot that is only ever driven
   open-loop, never asked where it is, is unusual but not wrong.
   """
 
@@ -52,16 +54,14 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedback do
     Enum.flat_map(entities, &unsensed_joints_in/1)
   end
 
-  defp unsensed_joints_in(%Link{} = link) do
-    unsensed_joints(link.joints)
-  end
+  defp unsensed_joints_in(%Link{} = link), do: unsensed_joints(link.joints)
 
   defp unsensed_joints_in(%Joint{type: :fixed}), do: []
 
   defp unsensed_joints_in(%Joint{sensors: [_ | _]} = joint), do: nested_joints(joint)
 
   defp unsensed_joints_in(%Joint{} = joint) do
-    case Enum.filter(joint.actuators, & &1.sensor) do
+    case Enum.reject(joint.actuators, &senses_position?/1) do
       [] -> nested_joints(joint)
       actuators -> [{joint, actuators} | nested_joints(joint)]
     end
@@ -72,23 +72,51 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedback do
   defp nested_joints(%Joint{link: nil}), do: []
   defp nested_joints(%Joint{link: link}), do: unsensed_joints_in(link)
 
+  # A driver BB can't load can't be asked, and refusing to compile over it would
+  # break the cross-package builds `ValidateChildSpecBehavioursTransformer`
+  # already goes out of its way to allow. Say nothing rather than guess.
+  defp senses_position?(actuator) do
+    module = module_for(actuator.child_spec)
+
+    case Code.ensure_compiled(module) do
+      {:module, _} -> :position_feedback in capabilities(module)
+      {:error, _reason} -> true
+    end
+  end
+
+  defp capabilities(module) do
+    if function_exported?(module, :capabilities, 0) do
+      module.capabilities()
+    else
+      []
+    end
+  end
+
+  defp module_for(module) when is_atom(module), do: module
+  defp module_for({module, _opts}) when is_atom(module), do: module
+
+  # Sorted because the DSL hands entities back in whatever order it holds them,
+  # and a warning that reorders itself between builds is a warning people learn
+  # to distrust.
   defp warn({joint, actuators}, robot, file) do
-    names = Enum.map_join(actuators, ", ", &inspect(&1.name))
-    example = actuators |> List.first() |> Map.fetch!(:name)
+    [example | _] = sorted = actuators |> Enum.map(& &1.name) |> Enum.sort()
+    names = Enum.map_join(sorted, ", ", &inspect/1)
 
     IO.warn(
       """
-      #{inspect(robot)}: joint #{inspect(joint.name)} is driven by #{names} but has no sensor, \
-      so nothing ever reports where it is. Its configuration in `BB.Robot.State` will stay at \
-      its initial value, and inverse kinematics will keep solving from there.
+      #{inspect(robot)}: joint #{inspect(joint.name)} is driven by #{names} but nothing reports \
+      where it is, so its configuration in `BB.Robot.State` will stay at its initial value and \
+      inverse kinematics will keep solving from there.
 
       If the hardware has no position feedback, estimate it from the commands:
 
           sensor :#{example}_position, {BB.Sensor.OpenLoopPositionEstimator, actuator: :#{example}}
 
-      If the actuator reports its own position, say so:
+      If the driver does read position back from the hardware, it should say so and publish it as \
+      `BB.Message.Sensor.JointState`:
 
-          actuator :#{example}, ..., sensor: false
+          @impl BB.Actuator
+          def capabilities, do: [:position_feedback]
       """,
       file: file,
       line: 1

--- a/lib/bb/error/kinematics/multi_failed.ex
+++ b/lib/bb/error/kinematics/multi_failed.ex
@@ -25,7 +25,9 @@ defmodule BB.Error.Kinematics.MultiFailed do
   end
 
   def message(%{failed_link: link, error: error, partial_results: results}) do
-    successful_count = map_size(results)
+    # `partial_results` carries the failed target's own error alongside the
+    # solved ones, so the successes have to be counted rather than assumed.
+    successful_count = Enum.count(results, &match?({_link, {:ok, _positions, _meta}}, &1))
 
     "Multi-target IK failed for #{inspect(link)}: #{format_error(error)}. " <>
       "#{successful_count} target(s) solved before failure."

--- a/lib/bb/motion.ex
+++ b/lib/bb/motion.ex
@@ -81,7 +81,7 @@ defmodule BB.Motion do
   @type meta :: Solver.meta()
   @type kinematics_error :: Solver.kinematics_error()
   @type robot_or_context :: module() | Context.t()
-  @type delivery :: :pubsub | :direct | :sync
+  @type delivery :: :pubsub | :direct
   @type targets :: %{atom() => target()}
   @type multi_results ::
           %{atom() => {:ok, positions(), meta()} | {:error, kinematics_error()}}
@@ -108,7 +108,9 @@ defmodule BB.Motion do
     pass `BB.Robot.root_link(robot)` when you do mean the whole tree
 
   Optional:
-  - `:delivery` - How to send actuator commands: `:pubsub` (default), `:direct`, or `:sync`
+  - `:delivery` - How to send actuator commands. `:pubsub` (default) publishes
+    each command and waits for the actuator to accept it, raising the actuator's
+    error if one refuses; `:direct` casts to each actuator without waiting
   - `:max_iterations` - Maximum solver iterations (passed to solver)
   - `:tolerance` - Convergence tolerance in metres (passed to solver)
   - `:respect_limits` - Whether to clamp to joint limits (passed to solver)
@@ -245,7 +247,9 @@ defmodule BB.Motion do
     pass `BB.Robot.root_link(robot)` when you do mean the whole tree
 
   Optional:
-  - `:delivery` - How to send actuator commands: `:pubsub` (default), `:direct`, or `:sync`
+  - `:delivery` - How to send actuator commands. `:pubsub` (default) publishes
+    each command and waits for the actuator to accept it, raising the actuator's
+    error if one refuses; `:direct` casts to each actuator without waiting
   - `:max_iterations` - Maximum solver iterations (passed to solver)
   - `:tolerance` - Convergence tolerance in metres (passed to solver)
   - `:respect_limits` - Whether to clamp to joint limits (passed to solver)
@@ -358,7 +362,9 @@ defmodule BB.Motion do
 
   ## Options
 
-  - `:delivery` - How to send actuator commands: `:pubsub` (default), `:direct`, or `:sync`
+  - `:delivery` - How to send actuator commands. `:pubsub` (default) publishes
+    each command and waits for the actuator to accept it, raising the actuator's
+    error if one refuses; `:direct` casts to each actuator without waiting
   - `:velocity` - Velocity hint for actuators (rad/s or m/s)
   - `:duration` - Duration hint for actuators (milliseconds)
 
@@ -435,17 +441,14 @@ defmodule BB.Motion do
   defp send_position_to_actuator(robot_module, robot, actuator_name, position, :pubsub, opts) do
     # The name came from the joint's own actuator list, so the lookup cannot miss.
     {:ok, path} = BB.Robot.actuator_path(robot, actuator_name)
-    Actuator.set_position(robot_module, path, position, opts)
+
+    case Actuator.set_position(robot_module, path, position, opts) do
+      :ok -> :ok
+      {:error, error} -> raise error
+    end
   end
 
   defp send_position_to_actuator(robot_module, _robot, actuator_name, position, :direct, opts) do
-    Actuator.set_position!(robot_module, actuator_name, position, opts)
-  end
-
-  defp send_position_to_actuator(robot_module, _robot, actuator_name, position, :sync, opts) do
-    case Actuator.set_position_sync(robot_module, actuator_name, position, opts) do
-      {:ok, _} -> :ok
-      {:error, reason} -> raise "Actuator #{actuator_name} rejected position: #{inspect(reason)}"
-    end
+    Actuator.set_position_async(robot_module, actuator_name, position, opts)
   end
 end

--- a/lib/bb/motion.ex
+++ b/lib/bb/motion.ex
@@ -419,36 +419,42 @@ defmodule BB.Motion do
   end
 
   defp send_positions_to_actuators(robot_module, robot, positions, delivery, opts \\ []) do
-    Enum.each(positions, fn {joint_name, position} ->
-      send_joint_position(robot_module, robot, joint_name, position, delivery, opts)
-    end)
-
-    :ok
+    positions
+    |> Enum.flat_map(&actuators_for_joint(robot, &1))
+    |> send_to_actuators(robot_module, robot, delivery, opts)
   end
 
-  defp send_joint_position(robot_module, robot, joint_name, position, delivery, opts) do
+  defp actuators_for_joint(robot, {joint_name, position}) do
     case Map.get(robot.joints, joint_name) do
-      nil ->
-        :ok
-
-      joint ->
-        Enum.each(joint.actuators, fn actuator_name ->
-          send_position_to_actuator(robot_module, robot, actuator_name, position, delivery, opts)
-        end)
+      nil -> []
+      joint -> Enum.map(joint.actuators, &{&1, position})
     end
   end
 
-  defp send_position_to_actuator(robot_module, robot, actuator_name, position, :pubsub, opts) do
-    # The name came from the joint's own actuator list, so the lookup cannot miss.
-    {:ok, path} = BB.Robot.actuator_path(robot, actuator_name)
+  # The joints of one motion are meant to move together, so they are commanded
+  # together: waiting on each in turn would cost a round trip per joint, and
+  # nothing downstream is ordered by the order they were sent in.
+  defp send_to_actuators(commands, robot_module, robot, :pubsub, opts) do
+    commands
+    |> Enum.map(fn {actuator_name, position} ->
+      # The name came from the joint's own actuator list, so the lookup cannot miss.
+      {:ok, path} = BB.Robot.actuator_path(robot, actuator_name)
+      Task.async(fn -> Actuator.set_position(robot_module, path, position, opts) end)
+    end)
+    |> Task.await_many(:infinity)
+    |> raise_refusal()
+  end
 
-    case Actuator.set_position(robot_module, path, position, opts) do
-      :ok -> :ok
+  defp send_to_actuators(commands, robot_module, _robot, :direct, opts) do
+    Enum.each(commands, fn {actuator_name, position} ->
+      Actuator.set_position_async(robot_module, actuator_name, position, opts)
+    end)
+  end
+
+  defp raise_refusal(results) do
+    case Enum.find(results, &match?({:error, _}, &1)) do
+      nil -> :ok
       {:error, error} -> raise error
     end
-  end
-
-  defp send_position_to_actuator(robot_module, _robot, actuator_name, position, :direct, opts) do
-    Actuator.set_position_async(robot_module, actuator_name, position, opts)
   end
 end

--- a/lib/bb/motion.ex
+++ b/lib/bb/motion.ex
@@ -38,7 +38,7 @@ defmodule BB.Motion do
       case BB.Motion.move_to(MyRobot, :gripper, {0.3, 0.2, 0.1},
              source_link: :base_link, solver: BB.IK.FABRIK) do
         {:ok, meta} -> IO.puts("Reached target in \#{meta.iterations} iterations")
-        {:error, %{class: :kinematics} = error} -> IO.puts("Failed: \#{BB.Error.message(error)}")
+        {:error, %{class: :kinematics} = error} -> IO.puts("Failed: \#{Exception.message(error)}")
       end
 
       # Multiple targets (for gait, coordinated motion)
@@ -46,7 +46,7 @@ defmodule BB.Motion do
       case BB.Motion.move_to_multi(MyRobot, targets,
              source_link: :body, solver: BB.IK.FABRIK) do
         {:ok, results} -> IO.puts("All targets reached")
-        {:error, error} -> IO.puts("Failed: \#{BB.Error.message(error)}")
+        {:error, error} -> IO.puts("Failed: \#{Exception.message(error)}")
       end
 
       # In a custom command handler
@@ -305,10 +305,10 @@ defmodule BB.Motion do
           IO.puts("All targets reached")
 
         {:error, %MultiFailed{failed_link: link} = error} ->
-          IO.puts("Failed to reach \#{link}: \#{BB.Error.message(error)}")
+          IO.puts("Failed to reach \#{link}: \#{Exception.message(error)}")
 
         {:error, error} ->
-          IO.puts("An actuator refused: \#{BB.Error.message(error)}")
+          IO.puts("An actuator refused: \#{Exception.message(error)}")
       end
   """
   @spec move_to_multi(robot_or_context(), targets(), keyword()) :: multi_motion_result()
@@ -367,7 +367,7 @@ defmodule BB.Motion do
           end)
 
         {:error, %MultiFailed{failed_link: link} = error} ->
-          IO.puts("\#{link} is unreachable: \#{BB.Error.message(error)}")
+          IO.puts("\#{link} is unreachable: \#{Exception.message(error)}")
       end
   """
   @spec solve_only_multi(robot_or_context(), targets(), keyword()) :: multi_solve_result()

--- a/lib/bb/motion.ex
+++ b/lib/bb/motion.ex
@@ -86,10 +86,16 @@ defmodule BB.Motion do
   @type multi_results ::
           %{atom() => {:ok, positions(), meta()} | {:error, kinematics_error()}}
 
-  @type motion_result :: {:ok, meta()} | {:error, kinematics_error()}
+  @typedoc """
+  Why a motion stopped: either the solver couldn't reach the target, or an
+  actuator refused the command it was sent.
+  """
+  @type motion_error :: kinematics_error() | BB.Error.t()
+
+  @type motion_result :: {:ok, meta()} | {:error, motion_error()}
   @type solve_result :: {:ok, positions(), meta()} | {:error, kinematics_error()}
   @type multi_motion_result ::
-          {:ok, multi_results()} | {:error, atom(), kinematics_error(), multi_results()}
+          {:ok, multi_results()} | {:error, atom() | nil, motion_error(), multi_results()}
   @type multi_solve_result ::
           {:ok, multi_results()} | {:error, atom(), kinematics_error(), multi_results()}
 
@@ -109,13 +115,14 @@ defmodule BB.Motion do
 
   Optional:
   - `:delivery` - How to send actuator commands. `:pubsub` (default) publishes
-    each command and waits for the actuator to accept it, raising the actuator's
-    error if one refuses; `:direct` casts to each actuator without waiting
+    each command and waits for the actuator to accept it, reporting the first
+    refusal; `:direct` casts to each actuator and waits for nothing, so a
+    refusal is never reported
   - `:velocity` - Velocity hint (passed to actuators)
   - `:duration` - Duration hint in milliseconds (passed to actuators)
   - `:command_id` - Correlation ID for feedback tracking (passed to actuators)
   - `:timeout` - How long to wait for each actuator to accept its command, in
-    milliseconds (default 5000). Ignored under `:direct`, which waits for
+    milliseconds (default 5000). Unused under `:direct`, which waits for
     nothing. A timeout exits the caller, as `GenServer.call/3` does — a loop
     that would rather skip a late step than die wants `:direct`
   - `:max_iterations` - Maximum solver iterations (passed to solver)
@@ -125,7 +132,10 @@ defmodule BB.Motion do
   ## Returns
 
   - `{:ok, meta}` - Successfully moved; meta contains solver info (iterations, residual, etc.)
-  - `{:error, error}` - Failed; error is a struct from `BB.Error.Kinematics`
+  - `{:error, error}` - Failed; either a struct from `BB.Error.Kinematics` if
+    the target couldn't be solved, or the actuator's own error if one refused
+    the command it was sent. The robot state is updated either way: the
+    positions were computed, and some joints may have taken them
 
   ## Examples
 
@@ -155,25 +165,26 @@ defmodule BB.Motion do
       [:bb, :motion, :move_to],
       %{robot: robot.name, target_link: target_link, solver: solver},
       fn ->
-        case solver.solve(robot, robot_state, source_link, target_link, target, solver_opts) do
-          {:ok, positions, meta} ->
-            RobotState.set_configurations(robot_state, positions)
-            send_positions_to_actuators(robot_module, robot, positions, delivery, actuator_opts)
+        with {:ok, positions, meta} <-
+               solver.solve(robot, robot_state, source_link, target_link, target, solver_opts),
+             RobotState.set_configurations(robot_state, positions),
+             :ok <-
+               send_positions_to_actuators(
+                 robot_module,
+                 robot,
+                 positions,
+                 delivery,
+                 actuator_opts
+               ) do
+          extra_meta = %{
+            iterations: meta.iterations,
+            residual: meta.residual,
+            reached: meta.reached
+          }
 
-            result = {:ok, meta}
-
-            extra_meta = %{
-              iterations: meta.iterations,
-              residual: meta.residual,
-              reached: meta.reached
-            }
-
-            {result, extra_meta}
-
-          {:error, error} ->
-            result = {:error, error}
-            extra_meta = %{error: error.__struct__}
-            {result, extra_meta}
+          {{:ok, meta}, extra_meta}
+        else
+          {:error, error} -> {{:error, error}, %{error: error.__struct__}}
         end
       end
     )
@@ -256,13 +267,14 @@ defmodule BB.Motion do
 
   Optional:
   - `:delivery` - How to send actuator commands. `:pubsub` (default) publishes
-    each command and waits for the actuator to accept it, raising the actuator's
-    error if one refuses; `:direct` casts to each actuator without waiting
+    each command and waits for the actuator to accept it, reporting the first
+    refusal; `:direct` casts to each actuator and waits for nothing, so a
+    refusal is never reported
   - `:velocity` - Velocity hint (passed to actuators)
   - `:duration` - Duration hint in milliseconds (passed to actuators)
   - `:command_id` - Correlation ID for feedback tracking (passed to actuators)
   - `:timeout` - How long to wait for each actuator to accept its command, in
-    milliseconds (default 5000). Ignored under `:direct`, which waits for
+    milliseconds (default 5000). Unused under `:direct`, which waits for
     nothing. A timeout exits the caller, as `GenServer.call/3` does — a loop
     that would rather skip a late step than die wants `:direct`
   - `:max_iterations` - Maximum solver iterations (passed to solver)
@@ -273,6 +285,9 @@ defmodule BB.Motion do
 
   - `{:ok, results}` - All targets solved; results is a map of link → `{:ok, positions, meta}`
   - `{:error, failed_link, error, results}` - A target failed; error is from `BB.Error.Kinematics`
+  - `{:error, nil, error, results}` - Every target solved, but an actuator
+    refused the command it was sent. The failed link is `nil` because a refusal
+    belongs to an actuator rather than to one of the targets
 
   ## Examples
 
@@ -292,20 +307,29 @@ defmodule BB.Motion do
   """
   @spec move_to_multi(robot_or_context(), targets(), keyword()) :: multi_motion_result()
   def move_to_multi(robot_or_context, targets, opts) do
-    case solve_only_multi(robot_or_context, targets, opts) do
-      {:ok, results} ->
-        delivery = Keyword.get(opts, :delivery, :pubsub)
-        actuator_opts = extract_actuator_opts(opts)
-        {robot_module, robot, robot_state} = extract_context(robot_or_context)
+    with {:ok, results} <- solve_only_multi(robot_or_context, targets, opts) do
+      delivery = Keyword.get(opts, :delivery, :pubsub)
+      actuator_opts = extract_actuator_opts(opts)
+      {robot_module, robot, robot_state} = extract_context(robot_or_context)
 
-        all_positions = merge_all_positions(results)
-        RobotState.set_configurations(robot_state, all_positions)
-        send_positions_to_actuators(robot_module, robot, all_positions, delivery, actuator_opts)
+      all_positions = merge_all_positions(results)
+      RobotState.set_configurations(robot_state, all_positions)
 
-        {:ok, results}
+      case send_positions_to_actuators(
+             robot_module,
+             robot,
+             all_positions,
+             delivery,
+             actuator_opts
+           ) do
+        :ok ->
+          {:ok, results}
 
-      {:error, failed_link, error, results} ->
-        {:error, failed_link, error, results}
+        # A refusal belongs to an actuator rather than to one of the targets:
+        # every target solved, and the command was refused on the way out.
+        {:error, error} ->
+          {:error, nil, error, results}
+      end
     end
   end
 
@@ -379,15 +403,22 @@ defmodule BB.Motion do
   ## Options
 
   - `:delivery` - How to send actuator commands. `:pubsub` (default) publishes
-    each command and waits for the actuator to accept it, raising the actuator's
-    error if one refuses; `:direct` casts to each actuator without waiting
+    each command and waits for the actuator to accept it, reporting the first
+    refusal; `:direct` casts to each actuator and waits for nothing, so a
+    refusal is never reported
   - `:velocity` - Velocity hint for actuators (rad/s or m/s)
   - `:duration` - Duration hint for actuators (milliseconds)
   - `:command_id` - Correlation ID for feedback tracking
   - `:timeout` - How long to wait for each actuator to accept its command, in
-    milliseconds (default 5000). Ignored under `:direct`, which waits for
+    milliseconds (default 5000). Unused under `:direct`, which waits for
     nothing. A timeout exits the caller, as `GenServer.call/3` does — a loop
     that would rather skip a late step than die wants `:direct`
+
+  ## Returns
+
+  - `:ok` - Every actuator accepted its command
+  - `{:error, error}` - One refused; the rest were still sent, and the robot
+    state was updated regardless
 
   ## Examples
 
@@ -397,7 +428,8 @@ defmodule BB.Motion do
       # With direct delivery for lower latency
       :ok = BB.Motion.send_positions(MyRobot, positions, delivery: :direct)
   """
-  @spec send_positions(robot_or_context(), positions(), keyword()) :: :ok
+  @spec send_positions(robot_or_context(), positions(), keyword()) ::
+          :ok | {:error, motion_error()}
   def send_positions(robot_or_context, positions, opts \\ []) do
     delivery = Keyword.get(opts, :delivery, :pubsub)
     actuator_opts = extract_actuator_opts(opts)
@@ -409,12 +441,13 @@ defmodule BB.Motion do
       %{robot: robot.name, joint_count: map_size(positions), delivery: delivery},
       fn ->
         RobotState.set_configurations(robot_state, positions)
-        send_positions_to_actuators(robot_module, robot, positions, delivery, actuator_opts)
-        {:ok, %{}}
+
+        result =
+          send_positions_to_actuators(robot_module, robot, positions, delivery, actuator_opts)
+
+        {result, %{}}
       end
     )
-
-    :ok
   end
 
   defp extract_context(%Context{} = context) do
@@ -427,11 +460,11 @@ defmodule BB.Motion do
     {robot_module, robot, robot_state}
   end
 
-  @actuator_opts [:velocity, :duration, :command_id, :timeout]
+  @actuator_opts [:delivery, :velocity, :duration, :command_id, :timeout]
 
   defp extract_solver_opts(opts) do
     opts
-    |> Keyword.drop([:solver, :source_link, :delivery | @actuator_opts])
+    |> Keyword.drop([:solver, :source_link | @actuator_opts])
     |> Keyword.reject(fn {_k, v} -> is_nil(v) end)
   end
 
@@ -465,19 +498,19 @@ defmodule BB.Motion do
       Task.async(fn -> Actuator.set_position(robot_module, path, position, opts) end)
     end)
     |> Task.await_many(:infinity)
-    |> raise_refusal()
+    |> first_refusal()
   end
 
   defp send_to_actuators(commands, robot_module, _robot, :direct, opts) do
     Enum.each(commands, fn {actuator_name, position} ->
-      Actuator.set_position_async(robot_module, actuator_name, position, opts)
+      Actuator.set_position(robot_module, actuator_name, position, opts)
     end)
   end
 
-  defp raise_refusal(results) do
+  defp first_refusal(results) do
     case Enum.find(results, &match?({:error, _}, &1)) do
       nil -> :ok
-      {:error, error} -> raise error
+      {:error, error} -> {:error, error}
     end
   end
 end

--- a/lib/bb/motion.ex
+++ b/lib/bb/motion.ex
@@ -111,6 +111,13 @@ defmodule BB.Motion do
   - `:delivery` - How to send actuator commands. `:pubsub` (default) publishes
     each command and waits for the actuator to accept it, raising the actuator's
     error if one refuses; `:direct` casts to each actuator without waiting
+  - `:velocity` - Velocity hint (passed to actuators)
+  - `:duration` - Duration hint in milliseconds (passed to actuators)
+  - `:command_id` - Correlation ID for feedback tracking (passed to actuators)
+  - `:timeout` - How long to wait for each actuator to accept its command, in
+    milliseconds (default 5000). Ignored under `:direct`, which waits for
+    nothing. A timeout exits the caller, as `GenServer.call/3` does — a loop
+    that would rather skip a late step than die wants `:direct`
   - `:max_iterations` - Maximum solver iterations (passed to solver)
   - `:tolerance` - Convergence tolerance in metres (passed to solver)
   - `:respect_limits` - Whether to clamp to joint limits (passed to solver)
@@ -140,6 +147,7 @@ defmodule BB.Motion do
     source_link = Keyword.fetch!(opts, :source_link)
     delivery = Keyword.get(opts, :delivery, :pubsub)
     solver_opts = extract_solver_opts(opts)
+    actuator_opts = extract_actuator_opts(opts)
 
     {robot_module, robot, robot_state} = extract_context(robot_or_context)
 
@@ -150,7 +158,7 @@ defmodule BB.Motion do
         case solver.solve(robot, robot_state, source_link, target_link, target, solver_opts) do
           {:ok, positions, meta} ->
             RobotState.set_configurations(robot_state, positions)
-            send_positions_to_actuators(robot_module, robot, positions, delivery)
+            send_positions_to_actuators(robot_module, robot, positions, delivery, actuator_opts)
 
             result = {:ok, meta}
 
@@ -250,6 +258,13 @@ defmodule BB.Motion do
   - `:delivery` - How to send actuator commands. `:pubsub` (default) publishes
     each command and waits for the actuator to accept it, raising the actuator's
     error if one refuses; `:direct` casts to each actuator without waiting
+  - `:velocity` - Velocity hint (passed to actuators)
+  - `:duration` - Duration hint in milliseconds (passed to actuators)
+  - `:command_id` - Correlation ID for feedback tracking (passed to actuators)
+  - `:timeout` - How long to wait for each actuator to accept its command, in
+    milliseconds (default 5000). Ignored under `:direct`, which waits for
+    nothing. A timeout exits the caller, as `GenServer.call/3` does — a loop
+    that would rather skip a late step than die wants `:direct`
   - `:max_iterations` - Maximum solver iterations (passed to solver)
   - `:tolerance` - Convergence tolerance in metres (passed to solver)
   - `:respect_limits` - Whether to clamp to joint limits (passed to solver)
@@ -280,11 +295,12 @@ defmodule BB.Motion do
     case solve_only_multi(robot_or_context, targets, opts) do
       {:ok, results} ->
         delivery = Keyword.get(opts, :delivery, :pubsub)
+        actuator_opts = extract_actuator_opts(opts)
         {robot_module, robot, robot_state} = extract_context(robot_or_context)
 
         all_positions = merge_all_positions(results)
         RobotState.set_configurations(robot_state, all_positions)
-        send_positions_to_actuators(robot_module, robot, all_positions, delivery)
+        send_positions_to_actuators(robot_module, robot, all_positions, delivery, actuator_opts)
 
         {:ok, results}
 
@@ -367,6 +383,11 @@ defmodule BB.Motion do
     error if one refuses; `:direct` casts to each actuator without waiting
   - `:velocity` - Velocity hint for actuators (rad/s or m/s)
   - `:duration` - Duration hint for actuators (milliseconds)
+  - `:command_id` - Correlation ID for feedback tracking
+  - `:timeout` - How long to wait for each actuator to accept its command, in
+    milliseconds (default 5000). Ignored under `:direct`, which waits for
+    nothing. A timeout exits the caller, as `GenServer.call/3` does — a loop
+    that would rather skip a late step than die wants `:direct`
 
   ## Examples
 
@@ -406,19 +427,21 @@ defmodule BB.Motion do
     {robot_module, robot, robot_state}
   end
 
+  @actuator_opts [:velocity, :duration, :command_id, :timeout]
+
   defp extract_solver_opts(opts) do
     opts
-    |> Keyword.drop([:solver, :source_link, :delivery, :velocity, :duration, :command_id])
+    |> Keyword.drop([:solver, :source_link, :delivery | @actuator_opts])
     |> Keyword.reject(fn {_k, v} -> is_nil(v) end)
   end
 
   defp extract_actuator_opts(opts) do
     opts
-    |> Keyword.take([:velocity, :duration, :command_id])
+    |> Keyword.take(@actuator_opts)
     |> Keyword.reject(fn {_k, v} -> is_nil(v) end)
   end
 
-  defp send_positions_to_actuators(robot_module, robot, positions, delivery, opts \\ []) do
+  defp send_positions_to_actuators(robot_module, robot, positions, delivery, opts) do
     positions
     |> Enum.flat_map(&actuators_for_joint(robot, &1))
     |> send_to_actuators(robot_module, robot, delivery, opts)

--- a/lib/bb/motion.ex
+++ b/lib/bb/motion.ex
@@ -46,7 +46,7 @@ defmodule BB.Motion do
       case BB.Motion.move_to_multi(MyRobot, targets,
              source_link: :body, solver: BB.IK.FABRIK) do
         {:ok, results} -> IO.puts("All targets reached")
-        {:error, failed_link, error, _results} -> IO.puts("Failed: \#{failed_link}")
+        {:error, error} -> IO.puts("Failed: \#{BB.Error.message(error)}")
       end
 
       # In a custom command handler
@@ -72,6 +72,7 @@ defmodule BB.Motion do
 
   alias BB.Actuator
   alias BB.Command.Context
+  alias BB.Error.Kinematics.MultiFailed
   alias BB.IK.Solver
   alias BB.Robot.Runtime
   alias BB.Robot.State, as: RobotState
@@ -94,10 +95,8 @@ defmodule BB.Motion do
 
   @type motion_result :: {:ok, meta()} | {:error, motion_error()}
   @type solve_result :: {:ok, positions(), meta()} | {:error, kinematics_error()}
-  @type multi_motion_result ::
-          {:ok, multi_results()} | {:error, atom() | nil, motion_error(), multi_results()}
-  @type multi_solve_result ::
-          {:ok, multi_results()} | {:error, atom(), kinematics_error(), multi_results()}
+  @type multi_motion_result :: {:ok, multi_results()} | {:error, motion_error()}
+  @type multi_solve_result :: {:ok, multi_results()} | {:error, MultiFailed.t()}
 
   @doc """
   Move an end-effector to a target position.
@@ -284,10 +283,12 @@ defmodule BB.Motion do
   ## Returns
 
   - `{:ok, results}` - All targets solved; results is a map of link → `{:ok, positions, meta}`
-  - `{:error, failed_link, error, results}` - A target failed; error is from `BB.Error.Kinematics`
-  - `{:error, nil, error, results}` - Every target solved, but an actuator
-    refused the command it was sent. The failed link is `nil` because a refusal
-    belongs to an actuator rather than to one of the targets
+  - `{:error, %BB.Error.Kinematics.MultiFailed{}}` - A target failed to solve.
+    The error names the link that failed, carries the underlying kinematics
+    error, and keeps the results of the targets solved before it
+  - `{:error, error}` - Every target solved, but an actuator refused the command
+    it was sent. That failure isn't kinematic, so it arrives as the actuator's
+    own error rather than wrapped in `MultiFailed`
 
   ## Examples
 
@@ -301,8 +302,11 @@ defmodule BB.Motion do
         {:ok, results} ->
           IO.puts("All targets reached")
 
-        {:error, failed_link, error, _results} ->
-          IO.puts("Failed to reach \#{failed_link}: \#{BB.Error.message(error)}")
+        {:error, %MultiFailed{failed_link: link} = error} ->
+          IO.puts("Failed to reach \#{link}: \#{BB.Error.message(error)}")
+
+        {:error, error} ->
+          IO.puts("An actuator refused: \#{BB.Error.message(error)}")
       end
   """
   @spec move_to_multi(robot_or_context(), targets(), keyword()) :: multi_motion_result()
@@ -325,10 +329,10 @@ defmodule BB.Motion do
         :ok ->
           {:ok, results}
 
-        # A refusal belongs to an actuator rather than to one of the targets:
-        # every target solved, and the command was refused on the way out.
+        # Not wrapped in `MultiFailed`: every target solved, and the command was
+        # refused on the way out, so nothing about this failure is kinematic.
         {:error, error} ->
-          {:error, nil, error, results}
+          {:error, error}
       end
     end
   end
@@ -346,7 +350,9 @@ defmodule BB.Motion do
   ## Returns
 
   - `{:ok, results}` - All targets solved; results is a map of link → `{:ok, positions, meta}`
-  - `{:error, failed_link, error, results}` - A target failed; error is from `BB.Error.Kinematics`
+  - `{:error, %BB.Error.Kinematics.MultiFailed{}}` - A target failed. The error
+    names the link that failed, carries the underlying kinematics error, and
+    keeps the results of the targets solved before it
 
   ## Examples
 
@@ -359,8 +365,8 @@ defmodule BB.Motion do
             IO.puts("\#{link}: residual=\#{meta.residual}")
           end)
 
-        {:error, failed_link, error, _results} ->
-          IO.puts("\#{failed_link} is unreachable: \#{BB.Error.message(error)}")
+        {:error, %MultiFailed{failed_link: link} = error} ->
+          IO.puts("\#{link} is unreachable: \#{BB.Error.message(error)}")
       end
   """
   @spec solve_only_multi(robot_or_context(), targets(), keyword()) :: multi_solve_result()
@@ -381,7 +387,13 @@ defmodule BB.Motion do
         {:cont, {:ok, Map.put(results, link, result)}}
 
       {:ok, {link, {:error, error} = result}}, {:ok, results} ->
-        {:halt, {:error, link, error, Map.put(results, link, result)}}
+        {:halt,
+         {:error,
+          MultiFailed.exception(
+            failed_link: link,
+            error: error,
+            partial_results: Map.put(results, link, result)
+          )}}
     end)
   end
 

--- a/lib/bb/motion.ex
+++ b/lib/bb/motion.ex
@@ -8,12 +8,12 @@ defmodule BB.Motion do
 
   This module provides functions for moving robot end-effectors to target
   positions using pluggable IK solvers. It handles the full workflow:
-  solving IK, updating robot state, and sending commands to actuators.
+  solving IK and sending the resulting positions to actuators.
 
   ## Usage
 
   Single-target functions:
-  - `move_to/4` - Solve IK for one target, update state, send actuator commands
+  - `move_to/4` - Solve IK for one target and send the actuator commands
   - `solve_only/4` - Solve IK without sending commands (for planning/validation)
 
   Multi-target functions (for coordinated motion like gait):
@@ -75,7 +75,6 @@ defmodule BB.Motion do
   alias BB.Error.Kinematics.MultiFailed
   alias BB.IK.Solver
   alias BB.Robot.Runtime
-  alias BB.Robot.State, as: RobotState
 
   @type target :: Solver.target()
   @type positions :: Solver.positions()
@@ -101,8 +100,13 @@ defmodule BB.Motion do
   @doc """
   Move an end-effector to a target position.
 
-  Solves inverse kinematics for the given target, updates the robot state,
-  and sends position commands to all actuators controlling the affected joints.
+  Solves inverse kinematics for the given target and sends position commands
+  to all actuators controlling the affected joints.
+
+  Where the joints actually end up is reported by their sensors, so this does
+  not write the solved positions into `BB.Robot.State` - a commanded position
+  is not a measured one. A joint whose actuator has no position feedback wants
+  a `BB.Sensor.OpenLoopPositionEstimator`.
 
   ## Options
 
@@ -133,8 +137,7 @@ defmodule BB.Motion do
   - `{:ok, meta}` - Successfully moved; meta contains solver info (iterations, residual, etc.)
   - `{:error, error}` - Failed; either a struct from `BB.Error.Kinematics` if
     the target couldn't be solved, or the actuator's own error if one refused
-    the command it was sent. The robot state is updated either way: the
-    positions were computed, and some joints may have taken them
+    the command it was sent
 
   ## Examples
 
@@ -166,7 +169,6 @@ defmodule BB.Motion do
       fn ->
         with {:ok, positions, meta} <-
                solver.solve(robot, robot_state, source_link, target_link, target, solver_opts),
-             RobotState.set_configurations(robot_state, positions),
              :ok <-
                send_positions_to_actuators(
                  robot_module,
@@ -314,10 +316,9 @@ defmodule BB.Motion do
     with {:ok, results} <- solve_only_multi(robot_or_context, targets, opts) do
       delivery = Keyword.get(opts, :delivery, :pubsub)
       actuator_opts = extract_actuator_opts(opts)
-      {robot_module, robot, robot_state} = extract_context(robot_or_context)
+      {robot_module, robot, _robot_state} = extract_context(robot_or_context)
 
       all_positions = merge_all_positions(results)
-      RobotState.set_configurations(robot_state, all_positions)
 
       case send_positions_to_actuators(
              robot_module,
@@ -409,8 +410,8 @@ defmodule BB.Motion do
   Bypasses IK solving entirely - useful when you've already computed
   positions through other means (e.g., trajectory planning, manual input).
 
-  Updates the robot state and sends commands to all actuators controlling
-  the specified joints.
+  Sends commands to all actuators controlling the specified joints. As with
+  `move_to/4`, the robot's own state is left to its sensors.
 
   ## Options
 
@@ -429,8 +430,7 @@ defmodule BB.Motion do
   ## Returns
 
   - `:ok` - Every actuator accepted its command
-  - `{:error, error}` - One refused; the rest were still sent, and the robot
-    state was updated regardless
+  - `{:error, error}` - One refused; the rest were still sent
 
   ## Examples
 
@@ -446,14 +446,12 @@ defmodule BB.Motion do
     delivery = Keyword.get(opts, :delivery, :pubsub)
     actuator_opts = extract_actuator_opts(opts)
 
-    {robot_module, robot, robot_state} = extract_context(robot_or_context)
+    {robot_module, robot, _robot_state} = extract_context(robot_or_context)
 
     :telemetry.span(
       [:bb, :motion, :send_positions],
       %{robot: robot.name, joint_count: map_size(positions), delivery: delivery},
       fn ->
-        RobotState.set_configurations(robot_state, positions)
-
         result =
           send_positions_to_actuators(robot_module, robot, positions, delivery, actuator_opts)
 

--- a/lib/bb/pub_sub.ex
+++ b/lib/bb/pub_sub.ex
@@ -102,20 +102,30 @@ defmodule BB.PubSub do
   ancestor paths. At each level, subscribers are filtered by their registered
   `message_types` (if any).
 
+  ## Options
+
+    * `:except` - Processes to skip. Use it to put a message on a topic for the
+      benefit of its observers when one subscriber is being handed the same
+      message by another route and would otherwise act on it twice.
+
   ## Examples
 
       # From a sensor process
       path = [:sensor | state.bb.path]
       publish(state.bb.robot, path, message)
+
+      # Everyone watching the topic except the process being called directly
+      publish(robot, path, message, except: [pid])
   """
-  @spec publish(module, [atom], BB.Message.t()) :: :ok
-  def publish(robot, path, %BB.Message{} = message)
+  @spec publish(module, [atom], BB.Message.t(), keyword) :: :ok
+  def publish(robot, path, %BB.Message{} = message, opts \\ [])
       when is_atom(robot) and is_list(path) do
     settings = Info.settings(robot)
     registry_module = settings.registry_module
     registry = registry_name(robot)
     message = %{message | robot: robot}
     message_module = message.payload.__struct__
+    except = Keyword.get(opts, :except, [])
 
     path
     |> ancestor_paths()
@@ -123,15 +133,16 @@ defmodule BB.PubSub do
       registry_module.dispatch(
         registry,
         topic,
-        &dispatch_to_subscribers(&1, path, message, message_module)
+        &dispatch_to_subscribers(&1, path, message, message_module, except)
       )
     end)
 
     :ok
   end
 
-  defp dispatch_to_subscribers(entries, path, message, message_module) do
+  defp dispatch_to_subscribers(entries, path, message, message_module, except) do
     for {pid, msg_types} <- entries,
+        pid not in except,
         msg_types == [] or message_module in msg_types do
       send(pid, {:bb, path, message})
     end

--- a/test/bb/actuator/addressing_test.exs
+++ b/test/bb/actuator/addressing_test.exs
@@ -106,8 +106,8 @@ defmodule BB.Actuator.AddressingTest do
   end
 
   describe "addressing by path on the direct transports" do
-    test "set_position_async/4 accepts a full path" do
-      :ok = BB.Actuator.set_position_async(Robot, [:base, :shoulder, :motor], 0.5)
+    test "delivery: :direct accepts a full path" do
+      :ok = BB.Actuator.set_position(Robot, [:base, :shoulder, :motor], 0.5, delivery: :direct)
 
       assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.5}}},
                      500

--- a/test/bb/actuator/addressing_test.exs
+++ b/test/bb/actuator/addressing_test.exs
@@ -106,16 +106,15 @@ defmodule BB.Actuator.AddressingTest do
   end
 
   describe "addressing by path on the direct transports" do
-    test "set_position!/4 accepts a full path" do
-      :ok = BB.Actuator.set_position!(Robot, [:base, :shoulder, :motor], 0.5)
+    test "set_position_async/4 accepts a full path" do
+      :ok = BB.Actuator.set_position_async(Robot, [:base, :shoulder, :motor], 0.5)
 
       assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.5}}},
                      500
     end
 
-    test "set_position_sync/5 accepts a full path" do
-      assert {:ok, :accepted} =
-               BB.Actuator.set_position_sync(Robot, [:base, :shoulder, :motor], 0.5, [], 500)
+    test "set_position/4 accepts a full path with a timeout" do
+      assert :ok = BB.Actuator.set_position(Robot, [:base, :shoulder, :motor], 0.5, timeout: 500)
 
       assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.5}}},
                      500

--- a/test/bb/actuator/command_payloads_test.exs
+++ b/test/bb/actuator/command_payloads_test.exs
@@ -137,7 +137,7 @@ defmodule BB.Actuator.CommandPayloadsTest do
     end
 
     test "the built-ins still work alongside it" do
-      :ok = BB.Actuator.set_position(Robot, :wide, 0.5)
+      assert :ok = BB.Actuator.set_position(Robot, :wide, 0.5)
       assert_receive {:commanded, %Command.Position{position: 0.5}}, 500
     end
   end
@@ -148,23 +148,20 @@ defmodule BB.Actuator.CommandPayloadsTest do
       assert_receive {:commanded, %Command.Effort{}}, 500
     end
 
-    test "a published payload outside the list never arrives" do
-      :ok = BB.Actuator.set_position(Robot, :narrow, 0.5)
+    test "a payload outside the list never arrives, and the caller is told so" do
+      assert {:error, %UnsupportedCommand{actuator: :narrow, command: Command.Position}} =
+               BB.Actuator.set_position(Robot, :narrow, 0.5, timeout: 500)
+
       refute_receive {:commanded, _}, 200
     end
 
     test "narrowing holds on the direct transport, not just the published one" do
-      :ok = BB.Actuator.set_position!(Robot, :narrow, 0.5)
+      :ok = BB.Actuator.set_position_async(Robot, :narrow, 0.5)
       refute_receive {:commanded, _}, 200
     end
 
-    test "the synchronous transport gets a structured error" do
-      assert {:error, %UnsupportedCommand{actuator: :narrow, command: Command.Position}} =
-               BB.Actuator.set_position_sync(Robot, :narrow, 0.5, [], 500)
-    end
-
     test "the error names what the actuator does accept" do
-      {:error, error} = BB.Actuator.set_position_sync(Robot, :narrow, 0.5, [], 500)
+      {:error, error} = BB.Actuator.set_position(Robot, :narrow, 0.5, timeout: 500)
       assert Exception.message(error) =~ "Command.Effort"
     end
 
@@ -192,7 +189,7 @@ defmodule BB.Actuator.CommandPayloadsTest do
 
       on_exit(fn -> :telemetry.detach(handler) end)
 
-      :ok = BB.Actuator.set_position!(Robot, :narrow, 0.5)
+      :ok = BB.Actuator.set_position_async(Robot, :narrow, 0.5)
 
       assert_receive {:telemetry, %{reason: :unsupported_command, actuator: :narrow}}, 500
     end

--- a/test/bb/actuator/command_payloads_test.exs
+++ b/test/bb/actuator/command_payloads_test.exs
@@ -40,6 +40,9 @@ defmodule BB.Actuator.CommandPayloadsTest do
     def disarm(_opts), do: :ok
 
     @impl BB.Actuator
+    def capabilities, do: [:position_feedback]
+
+    @impl BB.Actuator
     def handle_command(%Message{} = message, state) do
       if state.recipient, do: send(state.recipient, {:commanded, message.payload})
       {:noreply, state}
@@ -63,6 +66,9 @@ defmodule BB.Actuator.CommandPayloadsTest do
 
     @impl BB.Actuator
     def disarm(_opts), do: :ok
+
+    @impl BB.Actuator
+    def capabilities, do: [:position_feedback]
 
     @impl BB.Actuator
     def handle_command(%Message{} = message, state) do

--- a/test/bb/actuator/command_payloads_test.exs
+++ b/test/bb/actuator/command_payloads_test.exs
@@ -156,7 +156,7 @@ defmodule BB.Actuator.CommandPayloadsTest do
     end
 
     test "narrowing holds on the direct transport, not just the published one" do
-      :ok = BB.Actuator.set_position_async(Robot, :narrow, 0.5)
+      :ok = BB.Actuator.set_position(Robot, :narrow, 0.5, delivery: :direct)
       refute_receive {:commanded, _}, 200
     end
 
@@ -189,7 +189,7 @@ defmodule BB.Actuator.CommandPayloadsTest do
 
       on_exit(fn -> :telemetry.detach(handler) end)
 
-      :ok = BB.Actuator.set_position_async(Robot, :narrow, 0.5)
+      :ok = BB.Actuator.set_position(Robot, :narrow, 0.5, delivery: :direct)
 
       assert_receive {:telemetry, %{reason: :unsupported_command, actuator: :narrow}}, 500
     end

--- a/test/bb/actuator/command_payloads_test.exs
+++ b/test/bb/actuator/command_payloads_test.exs
@@ -40,7 +40,7 @@ defmodule BB.Actuator.CommandPayloadsTest do
     def disarm(_opts), do: :ok
 
     @impl BB.Actuator
-    def capabilities, do: [:position_feedback]
+    def capabilities(_opts), do: [:position_feedback]
 
     @impl BB.Actuator
     def handle_command(%Message{} = message, state) do
@@ -68,7 +68,7 @@ defmodule BB.Actuator.CommandPayloadsTest do
     def disarm(_opts), do: :ok
 
     @impl BB.Actuator
-    def capabilities, do: [:position_feedback]
+    def capabilities(_opts), do: [:position_feedback]
 
     @impl BB.Actuator
     def handle_command(%Message{} = message, state) do

--- a/test/bb/actuator/server_command_pipeline_test.exs
+++ b/test/bb/actuator/server_command_pipeline_test.exs
@@ -54,6 +54,27 @@ defmodule BB.Actuator.ServerCommandPipelineTest do
     end
   end
 
+  defmodule SlowRobot do
+    use BB
+
+    topology do
+      link :base do
+        joint :shoulder do
+          type :revolute
+
+          limit do
+            effort(~u(10 newton_meter))
+            velocity(~u(180 degree_per_second))
+          end
+
+          actuator :motor, {BB.Test.RecordingActuator, delay_ms: 300}
+
+          link :arm
+        end
+      end
+    end
+  end
+
   defmodule SubscribingRobot do
     use BB
 
@@ -159,6 +180,23 @@ defmodule BB.Actuator.ServerCommandPipelineTest do
       :ok = BB.publish(ArmedRobot, @actuator_topic, begin_motion)
 
       refute_receive {:received, _kind, %Message{payload: %BeginMotion{}}}, 200
+    end
+  end
+
+  describe "waiting" do
+    setup do
+      start_robot(SlowRobot)
+      :ok = BB.Safety.arm(SlowRobot)
+      :ok
+    end
+
+    test ":timeout bounds how long the caller waits for a slow driver" do
+      assert {:timeout, _} =
+               catch_exit(BB.Actuator.set_position(SlowRobot, :motor, 0.5, timeout: 50))
+    end
+
+    test "and the default is long enough for one that merely takes its time" do
+      assert :ok = BB.Actuator.set_position(SlowRobot, :motor, 0.5)
     end
   end
 

--- a/test/bb/actuator/server_command_pipeline_test.exs
+++ b/test/bb/actuator/server_command_pipeline_test.exs
@@ -147,8 +147,8 @@ defmodule BB.Actuator.ServerCommandPipelineTest do
       refute_receive {:received, :command, %Message{payload: %Command.Position{}}}, 200
     end
 
-    test "set_position_async/4 reaches the driver without waiting" do
-      :ok = BB.Actuator.set_position_async(ArmedRobot, :motor, 0.25)
+    test "delivery: :direct reaches the driver without waiting" do
+      :ok = BB.Actuator.set_position(ArmedRobot, :motor, 0.25, delivery: :direct)
 
       assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.25}}},
                      500
@@ -222,7 +222,7 @@ defmodule BB.Actuator.ServerCommandPipelineTest do
     test "a refusal is logged, whichever transport delivered the command" do
       log =
         capture_log(fn ->
-          :ok = BB.Actuator.set_position_async(DisarmedRobot, :motor, 0.5)
+          :ok = BB.Actuator.set_position(DisarmedRobot, :motor, 0.5, delivery: :direct)
           refute_receive {:received, :command, _message}, 200
         end)
 

--- a/test/bb/actuator/server_command_pipeline_test.exs
+++ b/test/bb/actuator/server_command_pipeline_test.exs
@@ -5,6 +5,8 @@
 defmodule BB.Actuator.ServerCommandPipelineTest do
   use ExUnit.Case
 
+  import ExUnit.CaptureLog
+
   alias BB.Error.State.NotArmed
   alias BB.Message
   alias BB.Message.Actuator.BeginMotion
@@ -108,6 +110,29 @@ defmodule BB.Actuator.ServerCommandPipelineTest do
                      500
     end
 
+    test "set_position/4 still publishes the command for observers" do
+      BB.subscribe(ArmedRobot, @actuator_topic)
+
+      :ok = BB.Actuator.set_position(ArmedRobot, [:base, :shoulder, :motor], 0.25)
+
+      assert_receive {:bb, @actuator_topic, %Message{payload: %Command.Position{position: 0.25}}},
+                     500
+    end
+
+    test "set_position/4 drives the actuator once, not once per transport" do
+      :ok = BB.Actuator.set_position(ArmedRobot, [:base, :shoulder, :motor], 0.25)
+
+      assert_receive {:received, :command, %Message{payload: %Command.Position{}}}, 500
+      refute_receive {:received, :command, %Message{payload: %Command.Position{}}}, 200
+    end
+
+    test "set_position_async/4 reaches the driver without waiting" do
+      :ok = BB.Actuator.set_position_async(ArmedRobot, :motor, 0.25)
+
+      assert_receive {:received, :command, %Message{payload: %Command.Position{position: 0.25}}},
+                     500
+    end
+
     test "a cast command reaches the driver" do
       :ok = BB.cast(ArmedRobot, :motor, {:command, position(0.5)})
 
@@ -147,6 +172,25 @@ defmodule BB.Actuator.ServerCommandPipelineTest do
       :ok = BB.publish(DisarmedRobot, @actuator_topic, position(0.5))
 
       refute_receive {:received, :command, _message}, 200
+    end
+
+    test "set_position/4 reports the refusal rather than leaving the caller guessing" do
+      assert {:error, %NotArmed{actuator: :motor, command: Command.Position}} =
+               BB.Actuator.set_position(DisarmedRobot, :motor, 0.5, timeout: 500)
+
+      refute_receive {:received, :command, _message}, 200
+    end
+
+    test "a refusal is logged, whichever transport delivered the command" do
+      log =
+        capture_log(fn ->
+          :ok = BB.Actuator.set_position_async(DisarmedRobot, :motor, 0.5)
+          refute_receive {:received, :command, _message}, 200
+        end)
+
+      assert log =~ "refused"
+      assert log =~ "robot is not armed"
+      assert log =~ ":motor"
     end
 
     test "a cast command is dropped while disarmed" do

--- a/test/bb/command/move_to_test.exs
+++ b/test/bb/command/move_to_test.exs
@@ -130,6 +130,7 @@ defmodule BB.Command.MoveToTest do
 
     test "returns ok with metadata on success" do
       start_supervised!(MoveToTestRobot)
+      :ok = BB.Safety.arm(MoveToTestRobot)
 
       robot = MoveToTestRobot.robot()
       {:ok, robot_state} = RobotState.new(robot)
@@ -165,6 +166,7 @@ defmodule BB.Command.MoveToTest do
 
     test "returns error on solver failure" do
       start_supervised!(MoveToTestRobot)
+      :ok = BB.Safety.arm(MoveToTestRobot)
 
       robot = MoveToTestRobot.robot()
       {:ok, robot_state} = RobotState.new(robot)
@@ -195,6 +197,7 @@ defmodule BB.Command.MoveToTest do
 
     test "passes solver options through" do
       start_supervised!(MoveToTestRobot)
+      :ok = BB.Safety.arm(MoveToTestRobot)
 
       robot = MoveToTestRobot.robot()
       {:ok, robot_state} = RobotState.new(robot)
@@ -228,6 +231,7 @@ defmodule BB.Command.MoveToTest do
 
     test "handles multi-target mode" do
       start_supervised!(MoveToTestRobot)
+      :ok = BB.Safety.arm(MoveToTestRobot)
 
       robot = MoveToTestRobot.robot()
       {:ok, robot_state} = RobotState.new(robot)

--- a/test/bb/dsl/validate_position_feedback_test.exs
+++ b/test/bb/dsl/validate_position_feedback_test.exs
@@ -28,7 +28,30 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedbackTest do
     use BB.Actuator, options_schema: []
 
     @impl BB.Actuator
-    def capabilities, do: [:position_feedback]
+    def capabilities(_opts), do: [:position_feedback]
+
+    @impl BB.Actuator
+    def disarm(_opts), do: :ok
+
+    @impl BB.Actuator
+    def init(_opts), do: {:ok, %{}}
+
+    @impl BB.Actuator
+    def handle_command(_message, state), do: {:noreply, state}
+  end
+
+  defmodule OptionalEncoderActuator do
+    @moduledoc false
+    use BB.Actuator,
+      options_schema: [
+        feedback_pin: [type: :pos_integer, required: false],
+        channel: [type: :non_neg_integer, required: false, default: 0]
+      ]
+
+    @impl BB.Actuator
+    def capabilities(opts) do
+      if opts[:feedback_pin], do: [:position_feedback], else: []
+    end
 
     @impl BB.Actuator
     def disarm(_opts), do: :ok
@@ -76,13 +99,14 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedbackTest do
 
   @blind inspect(BlindActuator)
   @self_sensing inspect(SelfSensingActuator)
+  @optional_encoder inspect(OptionalEncoderActuator)
 
   test "warns when a joint is driven but nothing reports where it is" do
     warning = define(revolute_joint("actuator :motor, #{@blind}"))
 
     assert warning =~ "joint :shoulder is driven by :motor but nothing reports where it is"
     assert warning =~ "OpenLoopPositionEstimator"
-    assert warning =~ "def capabilities, do: [:position_feedback]"
+    assert warning =~ "def capabilities(_opts), do: [:position_feedback]"
   end
 
   test "stays quiet when the joint has a sensor" do
@@ -101,6 +125,35 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedbackTest do
     warning = define(revolute_joint("actuator :motor, #{@self_sensing}"))
 
     refute warning =~ "nothing reports where it is"
+  end
+
+  test "lets the driver answer for how it was configured" do
+    with_encoder =
+      define(revolute_joint("actuator :motor, {#{@optional_encoder}, feedback_pin: 27}"))
+
+    without_encoder =
+      define(revolute_joint("actuator :motor, {#{@optional_encoder}, channel: 3}"))
+
+    refute with_encoder =~ "nothing reports where it is"
+    assert without_encoder =~ "nothing reports where it is"
+  end
+
+  # The parameter's own default (27) is beside the point: it lives in a store
+  # that doesn't exist yet, so the driver answers as though the option were
+  # never given, and gets whatever its own schema says.
+  test "a parameterised option can't be seen, so the driver answers without it" do
+    warning =
+      define("""
+      parameters do
+        group :encoder do
+          param :feedback_pin, type: :integer, default: 27
+        end
+      end
+
+      #{revolute_joint("actuator :motor, {#{@optional_encoder}, feedback_pin: param([:encoder, :feedback_pin])}")}
+      """)
+
+    assert warning =~ "nothing reports where it is"
   end
 
   test "names every unsensed actuator on the joint" do

--- a/test/bb/dsl/validate_position_feedback_test.exs
+++ b/test/bb/dsl/validate_position_feedback_test.exs
@@ -9,19 +9,48 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedbackTest do
 
   import ExUnit.CaptureIO
 
-  defp define(module_body) do
+  defmodule BlindActuator do
+    @moduledoc false
+    use BB.Actuator, options_schema: []
+
+    @impl BB.Actuator
+    def disarm(_opts), do: :ok
+
+    @impl BB.Actuator
+    def init(_opts), do: {:ok, %{}}
+
+    @impl BB.Actuator
+    def handle_command(_message, state), do: {:noreply, state}
+  end
+
+  defmodule SelfSensingActuator do
+    @moduledoc false
+    use BB.Actuator, options_schema: []
+
+    @impl BB.Actuator
+    def capabilities, do: [:position_feedback]
+
+    @impl BB.Actuator
+    def disarm(_opts), do: :ok
+
+    @impl BB.Actuator
+    def init(_opts), do: {:ok, %{}}
+
+    @impl BB.Actuator
+    def handle_command(_message, state), do: {:noreply, state}
+  end
+
+  defp define(topology) do
     capture_io(:stderr, fn ->
       Code.eval_string("""
-      defmodule #{unique_module()} do
+      defmodule PositionFeedbackTest#{System.unique_integer([:positive])} do
         use BB
 
-        #{module_body}
+        #{topology}
       end
       """)
     end)
   end
-
-  defp unique_module, do: "PositionFeedbackTest#{System.unique_integer([:positive])}"
 
   defp revolute_joint(actuator, sensors \\ "") do
     """
@@ -45,36 +74,52 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedbackTest do
     """
   end
 
-  test "warns when a joint is driven but nothing reports where it is" do
-    warning = define(revolute_joint("actuator :motor, BB.Test.MockActuator"))
+  @blind inspect(BlindActuator)
+  @self_sensing inspect(SelfSensingActuator)
 
-    assert warning =~ "joint :shoulder is driven by :motor but has no sensor"
+  test "warns when a joint is driven but nothing reports where it is" do
+    warning = define(revolute_joint("actuator :motor, #{@blind}"))
+
+    assert warning =~ "joint :shoulder is driven by :motor but nothing reports where it is"
     assert warning =~ "OpenLoopPositionEstimator"
-    assert warning =~ "sensor: false"
+    assert warning =~ "def capabilities, do: [:position_feedback]"
   end
 
   test "stays quiet when the joint has a sensor" do
     warning =
       define(
         revolute_joint(
-          "actuator :motor, BB.Test.MockActuator",
+          "actuator :motor, #{@blind}",
           "sensor :position, {BB.Sensor.OpenLoopPositionEstimator, actuator: :motor}"
         )
       )
 
-    refute warning =~ "has no sensor"
+    refute warning =~ "nothing reports where it is"
   end
 
-  test "stays quiet when the actuator says it doesn't need one" do
-    warning = define(revolute_joint("actuator :motor, BB.Test.MockActuator, sensor: false"))
+  test "stays quiet when the driver reports its own position" do
+    warning = define(revolute_joint("actuator :motor, #{@self_sensing}"))
 
-    refute warning =~ "has no sensor"
+    refute warning =~ "nothing reports where it is"
+  end
+
+  test "names every unsensed actuator on the joint" do
+    warning =
+      define(
+        revolute_joint("""
+        actuator :left, #{@blind}
+        actuator :right, #{@blind}
+        actuator :sensing, #{@self_sensing}
+        """)
+      )
+
+    assert warning =~ "driven by :left, :right but nothing reports"
   end
 
   test "stays quiet about a joint with no actuator to drive it" do
     warning = define(revolute_joint(""))
 
-    refute warning =~ "has no sensor"
+    refute warning =~ "nothing reports where it is"
   end
 
   test "stays quiet about a fixed joint, which has nowhere to go" do
@@ -85,7 +130,7 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedbackTest do
           joint :mount do
             type :fixed
 
-            actuator :motor, BB.Test.MockActuator
+            actuator :motor, #{@blind}
 
             link :arm
           end
@@ -93,6 +138,6 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedbackTest do
       end
       """)
 
-    refute warning =~ "has no sensor"
+    refute warning =~ "nothing reports where it is"
   end
 end

--- a/test/bb/dsl/validate_position_feedback_test.exs
+++ b/test/bb/dsl/validate_position_feedback_test.exs
@@ -175,6 +175,30 @@ defmodule BB.Dsl.Verifiers.ValidatePositionFeedbackTest do
     refute warning =~ "nothing reports where it is"
   end
 
+  test "stays quiet about a continuous joint, which has no position to hold" do
+    warning =
+      define("""
+      topology do
+        link :base do
+          joint :wheel do
+            type :continuous
+
+            limit do
+              effort(~u(10 newton_meter))
+              velocity(~u(1 radian_per_second))
+            end
+
+            actuator :drive, #{@blind}
+
+            link :tyre
+          end
+        end
+      end
+      """)
+
+    refute warning =~ "nothing reports where it is"
+  end
+
   test "stays quiet about a fixed joint, which has nowhere to go" do
     warning =
       define("""

--- a/test/bb/dsl/validate_position_feedback_test.exs
+++ b/test/bb/dsl/validate_position_feedback_test.exs
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Dsl.Verifiers.ValidatePositionFeedbackTest do
+  # `capture_io(:stderr, …)` redirects a named process, so a robot compiled by
+  # another test running alongside would land in the captured output.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  defp define(module_body) do
+    capture_io(:stderr, fn ->
+      Code.eval_string("""
+      defmodule #{unique_module()} do
+        use BB
+
+        #{module_body}
+      end
+      """)
+    end)
+  end
+
+  defp unique_module, do: "PositionFeedbackTest#{System.unique_integer([:positive])}"
+
+  defp revolute_joint(actuator, sensors \\ "") do
+    """
+    topology do
+      link :base do
+        joint :shoulder do
+          type :revolute
+
+          limit do
+            effort(~u(10 newton_meter))
+            velocity(~u(180 degree_per_second))
+          end
+
+          #{actuator}
+          #{sensors}
+
+          link :arm
+        end
+      end
+    end
+    """
+  end
+
+  test "warns when a joint is driven but nothing reports where it is" do
+    warning = define(revolute_joint("actuator :motor, BB.Test.MockActuator"))
+
+    assert warning =~ "joint :shoulder is driven by :motor but has no sensor"
+    assert warning =~ "OpenLoopPositionEstimator"
+    assert warning =~ "sensor: false"
+  end
+
+  test "stays quiet when the joint has a sensor" do
+    warning =
+      define(
+        revolute_joint(
+          "actuator :motor, BB.Test.MockActuator",
+          "sensor :position, {BB.Sensor.OpenLoopPositionEstimator, actuator: :motor}"
+        )
+      )
+
+    refute warning =~ "has no sensor"
+  end
+
+  test "stays quiet when the actuator says it doesn't need one" do
+    warning = define(revolute_joint("actuator :motor, BB.Test.MockActuator, sensor: false"))
+
+    refute warning =~ "has no sensor"
+  end
+
+  test "stays quiet about a joint with no actuator to drive it" do
+    warning = define(revolute_joint(""))
+
+    refute warning =~ "has no sensor"
+  end
+
+  test "stays quiet about a fixed joint, which has nowhere to go" do
+    warning =
+      define("""
+      topology do
+        link :base do
+          joint :mount do
+            type :fixed
+
+            actuator :motor, BB.Test.MockActuator
+
+            link :arm
+          end
+        end
+      end
+      """)
+
+    refute warning =~ "has no sensor"
+  end
+end

--- a/test/bb/error/kinematics_test.exs
+++ b/test/bb/error/kinematics_test.exs
@@ -5,11 +5,13 @@
 defmodule BB.Error.KinematicsTest do
   use ExUnit.Case, async: true
 
+  alias BB.Error.Kinematics.MultiFailed
   alias BB.Error.Kinematics.NoParentJoint
   alias BB.Error.Kinematics.NotAnAncestor
   alias BB.Error.Kinematics.UnknownActuator
   alias BB.Error.Kinematics.UnknownJoint
   alias BB.Error.Kinematics.UnknownLink
+  alias BB.Error.Kinematics.Unreachable
 
   describe "UnknownLink" do
     test "carries link, role and robot" do
@@ -139,6 +141,38 @@ defmodule BB.Error.KinematicsTest do
 
       assert message =~ ":left_gripper is not an ancestor of :right_gripper"
       assert message =~ "nearest common ancestor is :torso"
+    end
+  end
+
+  describe "MultiFailed" do
+    # `partial_results` carries the failed target's own error alongside the ones
+    # that solved, so a count of the whole map reads one too high — and it's a
+    # user-visible number now that this error is what `move_to_multi/3` returns.
+    test "message counts the targets that solved, not the entry that failed" do
+      err =
+        MultiFailed.exception(
+          failed_link: :right_foot,
+          error: Unreachable.exception(target_link: :right_foot),
+          partial_results: %{
+            left_foot: {:ok, %{hip: 0.5}, %{iterations: 3}},
+            right_foot: {:error, Unreachable.exception(target_link: :right_foot)}
+          }
+        )
+
+      assert MultiFailed.message(err) =~ "1 target(s) solved before failure"
+    end
+
+    test "and says none when the first target it tried was the one that failed" do
+      err =
+        MultiFailed.exception(
+          failed_link: :right_foot,
+          error: Unreachable.exception(target_link: :right_foot),
+          partial_results: %{
+            right_foot: {:error, Unreachable.exception(target_link: :right_foot)}
+          }
+        )
+
+      assert MultiFailed.message(err) =~ "0 target(s) solved before failure"
     end
   end
 end

--- a/test/bb/integration/child_spec_param_ref_test.exs
+++ b/test/bb/integration/child_spec_param_ref_test.exs
@@ -43,7 +43,7 @@ defmodule BB.Integration.ChildSpecParamRefTest do
     def disarm(_opts), do: :ok
 
     @impl BB.Actuator
-    def capabilities, do: [:position_feedback]
+    def capabilities(_opts), do: [:position_feedback]
 
     @impl BB.Actuator
     def init(opts) do

--- a/test/bb/integration/child_spec_param_ref_test.exs
+++ b/test/bb/integration/child_spec_param_ref_test.exs
@@ -43,6 +43,9 @@ defmodule BB.Integration.ChildSpecParamRefTest do
     def disarm(_opts), do: :ok
 
     @impl BB.Actuator
+    def capabilities, do: [:position_feedback]
+
+    @impl BB.Actuator
     def init(opts) do
       max_effort = Keyword.get(opts, :max_effort)
       StateTracker.record({:actuator_init, max_effort})

--- a/test/bb/motion_test.exs
+++ b/test/bb/motion_test.exs
@@ -7,6 +7,7 @@ defmodule BB.MotionTest do
 
   alias BB.Command.Context
   alias BB.Error.Kinematics.Unreachable
+  alias BB.Error.State.NotArmed
   alias BB.Motion
   alias BB.Robot.State, as: RobotState
   alias BB.Test.MockSolver
@@ -302,6 +303,24 @@ defmodule BB.MotionTest do
 
       assert RobotState.get_configuration(robot_state, :shoulder_joint) == {:ok, 0.7}
       assert RobotState.get_configuration(robot_state, :elbow_joint) == {:ok, 0.4}
+    end
+
+    test "raises an actuator's refusal rather than reporting success" do
+      start_supervised!(MotionTestRobot)
+
+      robot = MotionTestRobot.robot()
+      {:ok, robot_state} = RobotState.new(robot)
+
+      context = %Context{
+        robot_module: MotionTestRobot,
+        robot: robot,
+        robot_state: robot_state,
+        execution_id: make_ref()
+      }
+
+      assert_raise NotArmed, fn ->
+        Motion.send_positions(context, %{shoulder_joint: 0.7, elbow_joint: 0.4})
+      end
     end
   end
 

--- a/test/bb/motion_test.exs
+++ b/test/bb/motion_test.exs
@@ -6,6 +6,7 @@ defmodule BB.MotionTest do
   use ExUnit.Case, async: true
 
   alias BB.Command.Context
+  alias BB.Error.Kinematics.MultiFailed
   alias BB.Error.Kinematics.Unreachable
   alias BB.Error.State.NotArmed
   alias BB.Motion
@@ -486,13 +487,13 @@ defmodule BB.MotionTest do
         end
       end
 
-      {:error, :upper_arm, %Unreachable{}, results} =
+      {:error, %MultiFailed{failed_link: :upper_arm, error: %Unreachable{}} = failure} =
         Motion.solve_only_multi(context, targets,
           source_link: :base_link,
           solver: FailOnSecondSolver
         )
 
-      assert {:error, %Unreachable{}} = results[:upper_arm]
+      assert {:error, %Unreachable{}} = failure.partial_results[:upper_arm]
     end
   end
 
@@ -525,7 +526,7 @@ defmodule BB.MotionTest do
       assert meta.reached == true
     end
 
-    test "reports an actuator's refusal with no failed link, since no target failed" do
+    test "reports an actuator's refusal unwrapped, since no target failed" do
       start_supervised!(MotionTestRobot)
 
       robot = MotionTestRobot.robot()
@@ -548,13 +549,11 @@ defmodule BB.MotionTest do
         execution_id: make_ref()
       }
 
-      assert {:error, nil, %NotArmed{}, results} =
+      assert {:error, %NotArmed{}} =
                Motion.move_to_multi(context, %{tip: {0.3, 0.2, 0.1}},
                  source_link: :base_link,
                  solver: SolvesShoulder
                )
-
-      assert {:ok, _positions, _meta} = results[:tip]
     end
   end
 end

--- a/test/bb/motion_test.exs
+++ b/test/bb/motion_test.exs
@@ -254,6 +254,36 @@ defmodule BB.MotionTest do
       assert RobotState.get_configuration(robot_state, :elbow_joint) == {:ok, 0.3}
     end
 
+    test "passes the actuator hints on rather than dropping them with the solver's" do
+      start_supervised!(MotionTestRobot)
+      :ok = BB.Safety.arm(MotionTestRobot)
+      BB.subscribe(MotionTestRobot, [:actuator])
+
+      robot = MotionTestRobot.robot()
+      {:ok, robot_state} = RobotState.new(robot)
+
+      MockSolver.set_result(
+        {:ok, %{shoulder_joint: 0.5}, %{iterations: 10, residual: 0.001, reached: true}}
+      )
+
+      context = %Context{
+        robot_module: MotionTestRobot,
+        robot: robot,
+        robot_state: robot_state,
+        execution_id: make_ref()
+      }
+
+      {:ok, _meta} =
+        Motion.move_to(context, :tip, {0.3, 0.2, 0.1},
+          source_link: :base_link,
+          solver: MockSolver,
+          velocity: 0.25,
+          duration: 400
+        )
+
+      assert_receive {:bb, _path, %{payload: %{velocity: 0.25, duration: 400}}}, 500
+    end
+
     test "does not update state on error" do
       robot = MotionTestRobot.robot()
       {:ok, robot_state} = RobotState.new(robot)
@@ -303,6 +333,30 @@ defmodule BB.MotionTest do
 
       assert RobotState.get_configuration(robot_state, :shoulder_joint) == {:ok, 0.7}
       assert RobotState.get_configuration(robot_state, :elbow_joint) == {:ok, 0.4}
+    end
+
+    test "passes the actuator hints on to the actuators" do
+      start_supervised!(MotionTestRobot)
+      :ok = BB.Safety.arm(MotionTestRobot)
+      BB.subscribe(MotionTestRobot, [:actuator])
+
+      robot = MotionTestRobot.robot()
+      {:ok, robot_state} = RobotState.new(robot)
+
+      context = %Context{
+        robot_module: MotionTestRobot,
+        robot: robot,
+        robot_state: robot_state,
+        execution_id: make_ref()
+      }
+
+      :ok =
+        Motion.send_positions(context, %{shoulder_joint: 0.7},
+          velocity: 0.25,
+          duration: 400
+        )
+
+      assert_receive {:bb, _path, %{payload: %{velocity: 0.25, duration: 400}}}, 500
     end
 
     test "raises an actuator's refusal rather than reporting success" do

--- a/test/bb/motion_test.exs
+++ b/test/bb/motion_test.exs
@@ -220,7 +220,7 @@ defmodule BB.MotionTest do
   end
 
   describe "move_to/4" do
-    test "updates robot state on success" do
+    test "commands the joints without writing the commanded positions into state" do
       start_supervised!(MotionTestRobot)
       :ok = BB.Safety.arm(MotionTestRobot)
 
@@ -251,8 +251,10 @@ defmodule BB.MotionTest do
 
       assert meta.reached == true
 
-      assert RobotState.get_configuration(robot_state, :shoulder_joint) == {:ok, 0.5}
-      assert RobotState.get_configuration(robot_state, :elbow_joint) == {:ok, 0.3}
+      # Where the joint ends up is a sensor's to report; a commanded position
+      # isn't a measured one.
+      assert RobotState.get_configuration(robot_state, :shoulder_joint) == {:ok, 0.0}
+      assert RobotState.get_configuration(robot_state, :elbow_joint) == {:ok, 0.0}
     end
 
     test "passes the actuator hints on rather than dropping them with the solver's" do
@@ -339,9 +341,10 @@ defmodule BB.MotionTest do
   end
 
   describe "send_positions/3" do
-    test "updates robot state" do
+    test "leaves robot state to the sensors" do
       start_supervised!(MotionTestRobot)
       :ok = BB.Safety.arm(MotionTestRobot)
+      BB.subscribe(MotionTestRobot, [:actuator])
 
       robot = MotionTestRobot.robot()
       {:ok, robot_state} = RobotState.new(robot)
@@ -356,8 +359,10 @@ defmodule BB.MotionTest do
       positions = %{shoulder_joint: 0.7, elbow_joint: 0.4}
       :ok = Motion.send_positions(context, positions)
 
-      assert RobotState.get_configuration(robot_state, :shoulder_joint) == {:ok, 0.7}
-      assert RobotState.get_configuration(robot_state, :elbow_joint) == {:ok, 0.4}
+      assert_receive {:bb, _path, %{payload: %{position: 0.7}}}, 500
+
+      assert RobotState.get_configuration(robot_state, :shoulder_joint) == {:ok, 0.0}
+      assert RobotState.get_configuration(robot_state, :elbow_joint) == {:ok, 0.0}
     end
 
     test "passes the actuator hints on to the actuators" do

--- a/test/bb/motion_test.exs
+++ b/test/bb/motion_test.exs
@@ -220,6 +220,7 @@ defmodule BB.MotionTest do
   describe "move_to/4" do
     test "updates robot state on success" do
       start_supervised!(MotionTestRobot)
+      :ok = BB.Safety.arm(MotionTestRobot)
 
       robot = MotionTestRobot.robot()
       {:ok, robot_state} = RobotState.new(robot)
@@ -284,6 +285,7 @@ defmodule BB.MotionTest do
   describe "send_positions/3" do
     test "updates robot state" do
       start_supervised!(MotionTestRobot)
+      :ok = BB.Safety.arm(MotionTestRobot)
 
       robot = MotionTestRobot.robot()
       {:ok, robot_state} = RobotState.new(robot)
@@ -401,6 +403,7 @@ defmodule BB.MotionTest do
   describe "move_to_multi/3" do
     test "moves to multiple targets" do
       start_supervised!(MotionTestRobot)
+      :ok = BB.Safety.arm(MotionTestRobot)
 
       robot = MotionTestRobot.robot()
       {:ok, robot_state} = RobotState.new(robot)

--- a/test/bb/motion_test.exs
+++ b/test/bb/motion_test.exs
@@ -284,6 +284,30 @@ defmodule BB.MotionTest do
       assert_receive {:bb, _path, %{payload: %{velocity: 0.25, duration: 400}}}, 500
     end
 
+    test "returns an actuator's refusal rather than the solver's metadata" do
+      start_supervised!(MotionTestRobot)
+
+      robot = MotionTestRobot.robot()
+      {:ok, robot_state} = RobotState.new(robot)
+
+      MockSolver.set_result(
+        {:ok, %{shoulder_joint: 0.5}, %{iterations: 10, residual: 0.001, reached: true}}
+      )
+
+      context = %Context{
+        robot_module: MotionTestRobot,
+        robot: robot,
+        robot_state: robot_state,
+        execution_id: make_ref()
+      }
+
+      assert {:error, %NotArmed{}} =
+               Motion.move_to(context, :tip, {0.3, 0.2, 0.1},
+                 source_link: :base_link,
+                 solver: MockSolver
+               )
+    end
+
     test "does not update state on error" do
       robot = MotionTestRobot.robot()
       {:ok, robot_state} = RobotState.new(robot)
@@ -359,7 +383,7 @@ defmodule BB.MotionTest do
       assert_receive {:bb, _path, %{payload: %{velocity: 0.25, duration: 400}}}, 500
     end
 
-    test "raises an actuator's refusal rather than reporting success" do
+    test "returns an actuator's refusal rather than reporting success" do
       start_supervised!(MotionTestRobot)
 
       robot = MotionTestRobot.robot()
@@ -372,9 +396,8 @@ defmodule BB.MotionTest do
         execution_id: make_ref()
       }
 
-      assert_raise NotArmed, fn ->
-        Motion.send_positions(context, %{shoulder_joint: 0.7, elbow_joint: 0.4})
-      end
+      assert {:error, %NotArmed{}} =
+               Motion.send_positions(context, %{shoulder_joint: 0.7, elbow_joint: 0.4})
     end
   end
 
@@ -500,6 +523,38 @@ defmodule BB.MotionTest do
 
       assert {:ok, _positions, meta} = results[:tip]
       assert meta.reached == true
+    end
+
+    test "reports an actuator's refusal with no failed link, since no target failed" do
+      start_supervised!(MotionTestRobot)
+
+      robot = MotionTestRobot.robot()
+      {:ok, robot_state} = RobotState.new(robot)
+
+      # Each target is solved in its own task, which doesn't inherit the process
+      # dictionary `MockSolver` keeps its answer in, so this one carries its own.
+      defmodule SolvesShoulder do
+        @behaviour BB.IK.Solver
+
+        def solve(_robot, _state, _source_link, _target_link, _target, _opts) do
+          {:ok, %{shoulder_joint: 0.5}, %{iterations: 10, residual: 0.001, reached: true}}
+        end
+      end
+
+      context = %Context{
+        robot_module: MotionTestRobot,
+        robot: robot,
+        robot_state: robot_state,
+        execution_id: make_ref()
+      }
+
+      assert {:error, nil, %NotArmed{}, results} =
+               Motion.move_to_multi(context, %{tip: {0.3, 0.2, 0.1}},
+                 source_link: :base_link,
+                 solver: SolvesShoulder
+               )
+
+      assert {:ok, _positions, _meta} = results[:tip]
     end
   end
 end

--- a/test/bb/sim/actuator_test.exs
+++ b/test/bb/sim/actuator_test.exs
@@ -46,7 +46,7 @@ defmodule BB.Sim.ActuatorTest do
       # Move from 0 to 1.0 rad. v=60°/s≈1.047 rad/s, a=120°/s²≈2.094 rad/s².
       # 2 * d_accel = 2 * 0.5 * a * (v/a)² = v²/a ≈ 0.524 rad.
       # 1.0 > 0.524, so trapezoid; peak_velocity should equal velocity limit.
-      BB.Actuator.set_position!(TrapRobot, :motor, 1.0)
+      :ok = BB.Actuator.set_position(TrapRobot, :motor, 1.0)
 
       assert_receive {:bb, _path,
                       %Message{
@@ -72,7 +72,7 @@ defmodule BB.Sim.ActuatorTest do
 
       # Move 0.1 rad — below the cruise threshold of ~0.524 rad. Should be
       # triangular: peak_velocity < velocity limit, peak = sqrt(d * a).
-      BB.Actuator.set_position!(TrapRobot, :motor, 0.1)
+      :ok = BB.Actuator.set_position(TrapRobot, :motor, 0.1)
 
       assert_receive {:bb, _path,
                       %Message{
@@ -124,7 +124,7 @@ defmodule BB.Sim.ActuatorTest do
       PubSub.subscribe(RectRobot, [:actuator, :base, :shoulder, :motor])
       :ok = BB.Safety.arm(RectRobot)
 
-      BB.Actuator.set_position!(RectRobot, :motor, 1.0)
+      :ok = BB.Actuator.set_position(RectRobot, :motor, 1.0)
 
       assert_receive {:bb, _path,
                       %Message{
@@ -171,7 +171,7 @@ defmodule BB.Sim.ActuatorTest do
 
       # First move: 0 → 1.0 rad. Velocity = 10°/s ≈ 0.175 rad/s, so travel
       # time ≈ 5.7s. We deliberately interrupt long before arrival.
-      BB.Actuator.set_position!(RapidRobot, :motor, 1.0)
+      :ok = BB.Actuator.set_position(RapidRobot, :motor, 1.0)
 
       assert_receive {:bb, _path, %Message{payload: %BeginMotion{}}}, 1000
 
@@ -179,7 +179,7 @@ defmodule BB.Sim.ActuatorTest do
       # Second command: should NOT report initial_position=1.0 (the previous
       # commanded target); it should report a position partway between 0 and
       # 1.0 reflecting elapsed interpolation.
-      BB.Actuator.set_position!(RapidRobot, :motor, 0.5)
+      :ok = BB.Actuator.set_position(RapidRobot, :motor, 0.5)
 
       assert_receive {:bb, _path,
                       %Message{

--- a/test/bb/sim/actuator_transmission_test.exs
+++ b/test/bb/sim/actuator_transmission_test.exs
@@ -51,7 +51,7 @@ defmodule BB.Sim.ActuatorTransmissionTest do
       :ok = BB.Safety.arm(SimTxRobot)
 
       joint_target = :math.pi() / 4 + 0.01
-      BB.Actuator.set_position!(SimTxRobot, :motor, joint_target)
+      :ok = BB.Actuator.set_position(SimTxRobot, :motor, joint_target)
 
       assert_receive {:bb, _path,
                       %Message{

--- a/test/bb/sim/simulation_test.exs
+++ b/test/bb/sim/simulation_test.exs
@@ -5,6 +5,7 @@
 defmodule BB.Sim.SimulationTest do
   use ExUnit.Case, async: false
 
+  alias BB.Error.State.NotArmed
   alias BB.Message
   alias BB.Message.Actuator.BeginMotion
   alias BB.PubSub
@@ -71,7 +72,7 @@ defmodule BB.Sim.SimulationTest do
       :ok = BB.Safety.arm(SimModeRobot)
 
       target_position = 0.5
-      BB.Actuator.set_position!(SimModeRobot, :motor, target_position)
+      :ok = BB.Actuator.set_position(SimModeRobot, :motor, target_position)
 
       assert_receive {:bb, [:actuator, :base_link, :shoulder, :motor],
                       %Message{payload: %BeginMotion{target_position: ^target_position}}},
@@ -89,7 +90,7 @@ defmodule BB.Sim.SimulationTest do
       :ok = BB.Safety.arm(SimModeRobot)
 
       over_limit = 3.0
-      BB.Actuator.set_position!(SimModeRobot, :motor, over_limit)
+      :ok = BB.Actuator.set_position(SimModeRobot, :motor, over_limit)
 
       upper_limit = :math.pi() / 2
 
@@ -102,14 +103,21 @@ defmodule BB.Sim.SimulationTest do
       Supervisor.stop(pid)
     end
 
-    test "synchronous position command returns acknowledgement" do
+    test "a position command is acknowledged once the actuator has accepted it" do
       {:ok, pid} = SimModeRobot.start_link(simulation: :kinematic)
 
       :ok = BB.Safety.arm(SimModeRobot)
 
-      result = BB.Actuator.set_position_sync(SimModeRobot, :motor, 0.5)
+      assert BB.Actuator.set_position(SimModeRobot, :motor, 0.5) == :ok
 
-      assert result == {:ok, :accepted}
+      Supervisor.stop(pid)
+    end
+
+    test "and refused while the robot is disarmed" do
+      {:ok, pid} = SimModeRobot.start_link(simulation: :kinematic)
+
+      assert {:error, %NotArmed{actuator: :motor}} =
+               BB.Actuator.set_position(SimModeRobot, :motor, 0.5)
 
       Supervisor.stop(pid)
     end
@@ -276,7 +284,7 @@ defmodule BB.Sim.SimulationTest do
       :ok = BB.Safety.arm(AutoEstimatorRobot)
 
       target_position = 0.5
-      BB.Actuator.set_position!(AutoEstimatorRobot, :motor, target_position)
+      :ok = BB.Actuator.set_position(AutoEstimatorRobot, :motor, target_position)
 
       # Should receive JointState from the auto-added estimator
       assert_receive {:bb, [:sensor, :base_link, :shoulder, :motor_position_estimator],

--- a/test/bb/supervisor_test.exs
+++ b/test/bb/supervisor_test.exs
@@ -33,7 +33,7 @@ defmodule BB.SupervisorTest do
     def disarm(_opts), do: :ok
 
     @impl BB.Actuator
-    def capabilities, do: [:position_feedback]
+    def capabilities(_opts), do: [:position_feedback]
 
     @impl BB.Actuator
     def init(opts) do

--- a/test/bb/supervisor_test.exs
+++ b/test/bb/supervisor_test.exs
@@ -33,6 +33,9 @@ defmodule BB.SupervisorTest do
     def disarm(_opts), do: :ok
 
     @impl BB.Actuator
+    def capabilities, do: [:position_feedback]
+
+    @impl BB.Actuator
     def init(opts) do
       {:ok, opts}
     end

--- a/test/support/failing_actuator.ex
+++ b/test/support/failing_actuator.ex
@@ -7,7 +7,7 @@ defmodule BB.Test.FailingActuator do
   use BB.Actuator, options_schema: [fail_mode: [type: :atom, required: false]]
 
   @impl BB.Actuator
-  def capabilities, do: [:position_feedback]
+  def capabilities(_opts), do: [:position_feedback]
 
   @impl BB.Actuator
   def disarm(opts) do

--- a/test/support/failing_actuator.ex
+++ b/test/support/failing_actuator.ex
@@ -7,6 +7,9 @@ defmodule BB.Test.FailingActuator do
   use BB.Actuator, options_schema: [fail_mode: [type: :atom, required: false]]
 
   @impl BB.Actuator
+  def capabilities, do: [:position_feedback]
+
+  @impl BB.Actuator
   def disarm(opts) do
     case opts[:fail_mode] do
       :error -> {:error, :hardware_failure}

--- a/test/support/mock_actuator.ex
+++ b/test/support/mock_actuator.ex
@@ -5,11 +5,20 @@
 defmodule BB.Test.MockActuator do
   @moduledoc """
   Minimal mock actuator for testing.
+
+  Every double in this file claims `:position_feedback`, standing in for a
+  smart servo that reads its own position back. Fixtures whose subject isn't
+  position feedback then don't trip
+  `BB.Dsl.Verifiers.ValidatePositionFeedback` for a sensor they have no use
+  for.
   """
   use BB.Actuator, options_schema: []
 
   @impl BB.Actuator
   def disarm(_opts), do: :ok
+
+  @impl BB.Actuator
+  def capabilities, do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts) do
@@ -33,6 +42,9 @@ defmodule ServoMotor do
   def disarm(_opts), do: :ok
 
   @impl BB.Actuator
+  def capabilities, do: [:position_feedback]
+
+  @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
 
   @impl BB.Actuator
@@ -45,6 +57,9 @@ defmodule MainMotor do
 
   @impl BB.Actuator
   def disarm(_opts), do: :ok
+
+  @impl BB.Actuator
+  def capabilities, do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
@@ -61,6 +76,9 @@ defmodule BrakeActuator do
   def disarm(_opts), do: :ok
 
   @impl BB.Actuator
+  def capabilities, do: [:position_feedback]
+
+  @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
 
   @impl BB.Actuator
@@ -73,6 +91,9 @@ defmodule ShoulderMotor do
 
   @impl BB.Actuator
   def disarm(_opts), do: :ok
+
+  @impl BB.Actuator
+  def capabilities, do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
@@ -89,6 +110,9 @@ defmodule ElbowMotor do
   def disarm(_opts), do: :ok
 
   @impl BB.Actuator
+  def capabilities, do: [:position_feedback]
+
+  @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
 
   @impl BB.Actuator
@@ -101,6 +125,9 @@ defmodule MyMotor do
 
   @impl BB.Actuator
   def disarm(_opts), do: :ok
+
+  @impl BB.Actuator
+  def capabilities, do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
@@ -119,6 +146,9 @@ defmodule TestActuator do
 
   @impl BB.Actuator
   def disarm(_opts), do: :ok
+
+  @impl BB.Actuator
+  def capabilities, do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}

--- a/test/support/mock_actuator.ex
+++ b/test/support/mock_actuator.ex
@@ -18,7 +18,7 @@ defmodule BB.Test.MockActuator do
   def disarm(_opts), do: :ok
 
   @impl BB.Actuator
-  def capabilities, do: [:position_feedback]
+  def capabilities(_opts), do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts) do
@@ -42,7 +42,7 @@ defmodule ServoMotor do
   def disarm(_opts), do: :ok
 
   @impl BB.Actuator
-  def capabilities, do: [:position_feedback]
+  def capabilities(_opts), do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
@@ -59,7 +59,7 @@ defmodule MainMotor do
   def disarm(_opts), do: :ok
 
   @impl BB.Actuator
-  def capabilities, do: [:position_feedback]
+  def capabilities(_opts), do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
@@ -76,7 +76,7 @@ defmodule BrakeActuator do
   def disarm(_opts), do: :ok
 
   @impl BB.Actuator
-  def capabilities, do: [:position_feedback]
+  def capabilities(_opts), do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
@@ -93,7 +93,7 @@ defmodule ShoulderMotor do
   def disarm(_opts), do: :ok
 
   @impl BB.Actuator
-  def capabilities, do: [:position_feedback]
+  def capabilities(_opts), do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
@@ -110,7 +110,7 @@ defmodule ElbowMotor do
   def disarm(_opts), do: :ok
 
   @impl BB.Actuator
-  def capabilities, do: [:position_feedback]
+  def capabilities(_opts), do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
@@ -127,7 +127,7 @@ defmodule MyMotor do
   def disarm(_opts), do: :ok
 
   @impl BB.Actuator
-  def capabilities, do: [:position_feedback]
+  def capabilities(_opts), do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}
@@ -148,7 +148,7 @@ defmodule TestActuator do
   def disarm(_opts), do: :ok
 
   @impl BB.Actuator
-  def capabilities, do: [:position_feedback]
+  def capabilities(_opts), do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts), do: {:ok, %{bb: Keyword.fetch!(opts, :bb)}}

--- a/test/support/recording_actuator.ex
+++ b/test/support/recording_actuator.ex
@@ -44,7 +44,7 @@ defmodule BB.Test.RecordingActuator do
   def disarm(_opts), do: :ok
 
   @impl BB.Actuator
-  def capabilities, do: [:position_feedback]
+  def capabilities(_opts), do: [:position_feedback]
 
   @impl BB.Actuator
   def init(opts) do

--- a/test/support/recording_actuator.ex
+++ b/test/support/recording_actuator.ex
@@ -21,6 +21,9 @@ defmodule BB.Test.RecordingActuator do
   Pass `subscribe_to:` to have it subscribe to some other topic. Messages
   arriving there are forwarded as `{:received, :info, message}`, which is how
   the tests check that the server leaves a driver's own subscriptions alone.
+
+  Pass `delay_ms:` to have it block for that long before answering a command,
+  standing in for a driver that waits on slow hardware.
   """
   use BB.Actuator,
     options_schema: [
@@ -28,6 +31,12 @@ defmodule BB.Test.RecordingActuator do
         type: {:list, :atom},
         required: false,
         doc: "An additional pubsub topic for the actuator to subscribe to itself"
+      ],
+      delay_ms: [
+        type: :non_neg_integer,
+        required: false,
+        default: 0,
+        doc: "How long to block before answering a command"
       ]
     ]
 
@@ -44,11 +53,12 @@ defmodule BB.Test.RecordingActuator do
       topic -> BB.subscribe(bb.robot, topic)
     end
 
-    {:ok, %{recipient: recipient}}
+    {:ok, %{recipient: recipient, delay_ms: Keyword.fetch!(opts, :delay_ms)}}
   end
 
   @impl BB.Actuator
   def handle_command(%BB.Message{} = message, state) do
+    Process.sleep(state.delay_ms)
     forward(state.recipient, :command, message)
     {:noreply, state}
   end

--- a/test/support/recording_actuator.ex
+++ b/test/support/recording_actuator.ex
@@ -44,6 +44,9 @@ defmodule BB.Test.RecordingActuator do
   def disarm(_opts), do: :ok
 
   @impl BB.Actuator
+  def capabilities, do: [:position_feedback]
+
+  @impl BB.Actuator
   def init(opts) do
     bb = Keyword.fetch!(opts, :bb)
     recipient = :persistent_term.get({__MODULE__, bb.robot}, nil)

--- a/usage-rules/actuators.md
+++ b/usage-rules/actuators.md
@@ -72,6 +72,19 @@ Return `{:reply, reply, state}` to answer a caller that is waiting —
 `set_position/4`, `set_velocity_sync/5` and friends; `{:noreply, state}`
 replies `{:ok, :accepted}` for you. The reply is discarded for cast delivery.
 
+If your driver reads position back from the hardware — a smart servo answering
+position queries on its bus — say so, and publish what you read as
+`BB.Message.Sensor.JointState`:
+
+```elixir
+@impl BB.Actuator
+def capabilities, do: [:position_feedback]
+```
+
+`BB.Robot.State` is written from `JointState` messages and nothing else, so a
+joint with neither a sensor nor a self-reporting driver never moves as far as
+kinematics is concerned. The DSL warns at compile time when it finds one.
+
 Don't check `BB.Safety.armed?/1` in a driver — `BB.Actuator.Server` refuses
 commands to a disarmed robot before they reach you.
 

--- a/usage-rules/actuators.md
+++ b/usage-rules/actuators.md
@@ -8,17 +8,17 @@ SPDX-License-Identifier: Apache-2.0
 
 Send an actuator a target with `BB.Actuator`. The robot must be **armed**
 first (see `bb:safety-and-commands`) — commands to a disarmed robot are
-ignored.
+refused.
 
 ```elixir
 # By the actuator's unique name, value in radians:
-BB.Actuator.set_position(MyRobot.Robot, :servo, 0.785)
+:ok = BB.Actuator.set_position(MyRobot.Robot, :servo, 0.785)
 
 # Or by its full path through the topology ([link, joint, actuator]):
-BB.Actuator.set_position(MyRobot.Robot, [:base_link, :pan_joint, :servo], 0.785)
+:ok = BB.Actuator.set_position(MyRobot.Robot, [:base_link, :pan_joint, :servo], 0.785)
 
-# Bypassing pubsub, for time-critical control:
-BB.Actuator.set_position!(MyRobot.Robot, :servo, 0.785)
+# Without waiting for an answer, for time-critical control:
+BB.Actuator.set_position_async(MyRobot.Robot, :servo, 0.785)
 ```
 
 The DSL takes `~u` sigil values; the runtime command functions take plain
@@ -29,12 +29,16 @@ numbers in SI base units (radians here).
   actuator the robot doesn't have raises rather than publishing to a topic
   nothing listens on. A full path must be complete: every link and joint from
   the root, not just the joint.
-- `set_position/4` publishes via pubsub; `set_position!/4` bypasses it for
-  lower latency. `set_velocity` and `set_effort` follow the same pair.
+- `set_position/4` publishes the command for observers and waits for the
+  actuator to accept it, returning `:ok` or `{:error, reason}`. Match on it:
+  a refusal means the joint is not moving.
+- `set_position_async/4` casts without waiting, for control paths that can't
+  afford the round trip. A refusal then reaches the log and telemetry only.
+- `set_velocity`, `set_effort`, `follow_trajectory`, `stop` and `hold` still
+  use the older pubsub/`!`/`_sync` trio, in which the pubsub form can't report
+  a refusal. Use their `_sync` variants where the outcome matters.
 - Positions are in **radians**, velocities in rad/s — SI base units, the same
   units the compiled robot struct uses.
-- Use `set_position_sync/5` when you need to wait for acknowledgement rather
-  than fire-and-forget.
 
 ## Joint-space in, motor-space handled for you
 
@@ -48,7 +52,7 @@ in motor-space — the driver does no joint-to-motor maths.
 
 `use BB.Actuator`, define `init/1`, the **required** `handle_command/2`, and
 the **required** `disarm/1`. Every command arrives at `handle_command/2`
-whichever of the three functions above sent it — a driver can't tell, and
+whichever of the functions above sent it — a driver can't tell, and
 doesn't need to:
 
 ```elixir
@@ -62,9 +66,9 @@ end
 def disarm(opts), do: cut_power(opts)   # must work without GenServer state
 ```
 
-Return `{:reply, reply, state}` to answer a `set_position_sync/5` caller;
-`{:noreply, state}` replies `{:ok, :accepted}` for you. The reply is discarded
-for the other two transports.
+Return `{:reply, reply, state}` to answer a caller that is waiting —
+`set_position/4`, `set_velocity_sync/5` and friends; `{:noreply, state}`
+replies `{:ok, :accepted}` for you. The reply is discarded for cast delivery.
 
 Don't check `BB.Safety.armed?/1` in a driver — `BB.Actuator.Server` refuses
 commands to a disarmed robot before they reach you.

--- a/usage-rules/actuators.md
+++ b/usage-rules/actuators.md
@@ -18,7 +18,7 @@ refused.
 :ok = BB.Actuator.set_position(MyRobot.Robot, [:base_link, :pan_joint, :servo], 0.785)
 
 # Without waiting for an answer, for time-critical control:
-BB.Actuator.set_position_async(MyRobot.Robot, :servo, 0.785)
+BB.Actuator.set_position(MyRobot.Robot, :servo, 0.785, delivery: :direct)
 ```
 
 The DSL takes `~u` sigil values; the runtime command functions take plain
@@ -32,11 +32,13 @@ numbers in SI base units (radians here).
 - `set_position/4` publishes the command for observers and waits for the
   actuator to accept it, returning `:ok` or `{:error, reason}`. Match on it:
   a refusal means the joint is not moving.
-- `set_position_async/4` casts without waiting, for control paths that can't
-  afford the round trip. A refusal then reaches the log and telemetry only.
+- `delivery: :direct` casts instead, for control paths that can't afford the
+  round trip. It **always returns `:ok`** — a refusal then reaches the log and
+  telemetry only, so don't write an error branch that can never run.
 - `set_velocity`, `set_effort`, `follow_trajectory`, `stop` and `hold` still
-  use the older pubsub/`!`/`_sync` trio, in which the pubsub form can't report
-  a refusal. Use their `_sync` variants where the outcome matters.
+  use the older trio — a pubsub function, a `!` cast and a `_sync` call — in
+  which the pubsub form can't report a refusal. Use their `_sync` variants
+  where the outcome matters.
 - Positions are in **radians**, velocities in rad/s — SI base units, the same
   units the compiled robot struct uses.
 

--- a/usage-rules/actuators.md
+++ b/usage-rules/actuators.md
@@ -78,7 +78,7 @@ position queries on its bus — say so, and publish what you read as
 
 ```elixir
 @impl BB.Actuator
-def capabilities, do: [:position_feedback]
+def capabilities(_opts), do: [:position_feedback]
 ```
 
 `BB.Robot.State` is written from `JointState` messages and nothing else, so a

--- a/usage-rules/anti-patterns.md
+++ b/usage-rules/anti-patterns.md
@@ -11,13 +11,13 @@ matching sub-rule.
 
 ### Don't command a disarmed robot
 
-A new robot is `:disarmed` and ignores motion. Arm it first through the command
+A new robot is `:disarmed` and refuses motion. Arm it first through the command
 system:
 
 ```elixir
 {:ok, cmd} = MyRobot.Robot.arm()
 {:ok, :armed, _} = BB.Command.await(cmd)
-BB.Actuator.set_position!(MyRobot.Robot, :servo, 0.5)
+:ok = BB.Actuator.set_position(MyRobot.Robot, :servo, 0.5)
 ```
 
 ### Don't manipulate the safety system directly

--- a/usage-rules/kinematics.md
+++ b/usage-rules/kinematics.md
@@ -61,8 +61,8 @@ IK solvers are **pluggable** and ship in satellite packages (`bb_ik_dls`,
   actuator has no position feedback needs a
   `BB.Sensor.OpenLoopPositionEstimator`, or its configuration never changes and
   every solve starts from the same place. The DSL warns at compile time when a
-  driven joint has no sensor; `actuator :servo, Driver, sensor: false` says the
-  actuator reports its own position.
+  driven joint has nothing reporting on it — a driver that reads position back
+  from its hardware says so with `c:BB.Actuator.capabilities/0` instead.
 - Solver options (`:max_iterations`, `:tolerance`, `:respect_limits`) are
   passed through untyped; defaults differ between solvers, so set them
   explicitly when it matters.

--- a/usage-rules/kinematics.md
+++ b/usage-rules/kinematics.md
@@ -37,7 +37,7 @@ matrices; angles are radians throughout.
 
 IK solvers are **pluggable** and ship in satellite packages (`bb_ik_dls`,
 `bb_ik_fabrik`) implementing the `BB.IK.Solver` behaviour. Drive them through
-`BB.Motion`, which solves, updates state, and commands the actuators:
+`BB.Motion`, which solves and commands the actuators:
 
 ```elixir
 {:ok, meta} =
@@ -55,6 +55,14 @@ IK solvers are **pluggable** and ship in satellite packages (`bb_ik_dls`,
   `BB.Robot.root_link(robot)` when you do mean the whole tree.
 - Targets are `{x, y, z}` in metres.
 - Use `BB.Motion.solve_only/4` to compute angles without moving.
+- **Commanding a joint doesn't move it in `BB.Robot.State`.** That table is
+  written from `JointState` sensor messages only, because a commanded position
+  isn't a measured one — and IK seeds each solve from it. A joint whose
+  actuator has no position feedback needs a
+  `BB.Sensor.OpenLoopPositionEstimator`, or its configuration never changes and
+  every solve starts from the same place. The DSL warns at compile time when a
+  driven joint has no sensor; `actuator :servo, Driver, sensor: false` says the
+  actuator reports its own position.
 - Solver options (`:max_iterations`, `:tolerance`, `:respect_limits`) are
   passed through untyped; defaults differ between solvers, so set them
   explicitly when it matters.


### PR DESCRIPTION
Closes #225.

## What was wrong

`BB.Actuator.Server` refuses a command when the actuator doesn't declare the payload, and refuses every command while the robot is disarmed (and will refuse out-of-limit rate or duration once limit validation lands). `refuse/5` emitted `[:bb, :actuator, :rejected]` telemetry and then called `command_reply/4`, which only replies on the `:call` transport — so `set_position/4` (pubsub) and `set_position!/4` (cast) dropped the error and the caller carried on believing the joint was moving.

## What changed

**`set_position/4` is synchronous.** It publishes the command to `[:actuator | path]` *and* delivers it to the actuator by a call, returning `:ok | {:error, reason}`. The publication stays — that delivery exists so orchestration and logging can observe commands, and adding a reply shouldn't remove the observation. The actuator itself is excluded from the publication (`BB.PubSub.publish/4` grew an `:except` list), because it is about to be handed the same command directly and would otherwise drive the hardware twice for one call.

The publication records that a command was *issued*; the return value says whether it was *accepted*. A refused command still appears on the topic, exactly as it does today.

**`set_position_sync/5` is gone.** Once `set_position/4` is synchronous, `_sync` was the same function minus the observation. Its fifth argument is now a `:timeout` option (default 5000, unchanged).

**`set_position!/4` is now `set_position_async/4`.** The bang was never Elixir's bang: it meant "cast", not "raises". A bang function that can't see the error it would raise on is the contradiction the issue names, so the cast keeps its capability under an honest name. It remains the low-latency path for control loops that can't afford the round trip, and its docs say plainly that a refusal reaches the log and telemetry and nowhere else.

**`refuse/5` logs a warning**, whichever transport delivered the command — worth doing regardless of the above, as the issue says.

**`BB.Motion`'s `delivery: :sync` is dropped.** With `:pubsub` synchronous, `:sync` was a duplicate; the delivery modes are now `:pubsub` (default; waits, raises the actuator's error if one refuses) and `:direct` (cast). `:sync` previously raised on refusal, so nothing loses error reporting — the default gains it. `BB.Command.MoveTo` passes `delivery` straight through and follows.

## Breaking changes for callers

| Before | After |
|---|---|
| `set_position(...)` → `:ok` | `set_position(...)` → `:ok \| {:error, reason}`, blocks until the actuator answers |
| `set_position!(r, t, p, opts)` | `set_position_async(r, t, p, opts)` |
| `set_position_sync(r, t, p, opts, timeout)` → `{:ok, :accepted}` | `set_position(r, t, p, opts ++ [timeout: timeout])` → `:ok` |
| `delivery: :sync` | `delivery: :pubsub` |

Two behavioural notes beyond the signatures:

- `set_position/4` now exits if the actuator process isn't running or doesn't answer in time — `GenServer.call/3` semantics, the same as `set_position_sync/5` had.
- `BB.Motion.move_to/4` and friends raise an actuator's refusal instead of continuing silently. bb's own tests caught this: several commanded a robot they had never armed and passed only because the refusal was invisible. They now arm.

Downstream in the workspace, `bb_liveview` and `bb_kino` call `set_position!/4` from UI event handlers and will need renaming to `set_position_async/4` (or moving to `set_position/4`, which would let them show the refusal instead of dropping it). `bb_servo_feetech`'s README/AGENTS docs quote the old trio.

## Siblings with the identical flaw — not touched here

Every other command entry point still has the reported bug: its pubsub form cannot report a refusal.

- `set_velocity/4` + `set_velocity!/4` + `set_velocity_sync/5`
- `set_effort/4` + `set_effort!/4` + `set_effort_sync/5`
- `follow_trajectory/4` + `follow_trajectory!/4` + `follow_trajectory_sync/5`
- `stop/3` + `stop!/3` + `stop_sync/4`
- `hold/3` + `hold!/3` + `hold_sync/4`

They're left alone deliberately — the ask was `set_position` — which does mean `BB.Actuator` is temporarily inconsistent: `!` means "cast" for the siblings and no longer exists for position. The moduledoc says so. Sweeping them is a one-shape-fits-all follow-up whenever you want it.

## Risks considered

- **Deadlock**: `set_position/4` runs in the caller's process. Nothing in bb or the workspace satellites commands an actuator from inside an actuator or from a controller an actuator calls into, so there's no cycle today. The docs warn a driver not to call it from its own `handle_command/2`.
- **Latency**: a control loop now blocks on each actuator instead of queueing casts. That's the trade the issue accepted, and for a slow bus it's backpressure rather than a growing mailbox of stale targets. `set_position_async/4` is there when it isn't.

## Verification

`mix check --no-retry` passes: compiler, credo, dialyzer, ex_doc, formatter, mix_audit, reuse, spark cheat sheets/formatter, unused deps. ExUnit has the same 3 pre-existing failures as `main` (`Mix.Tasks.Bb.AddNxBackendTest`, `Rewrite.Error: no source found for "mix.exs"`), and 1319/1322 pass.

New tests cover the acknowledged path, the refusal reaching the caller, the surviving publication, that the driver is commanded once rather than once per transport, and that a refusal is logged.

---

## Follow-up commits

Two additions after review discussion, both separable if you'd rather they didn't ride along:

**`docs: show how to overlap set_position/4 calls across joints`** — no code. `set_position/4` blocks, so how several joints overlap is the caller's choice, and `Task.async` + `Task.await_many` is that choice; no framework wrapper is needed for it. The doc note records the three things that bite: `Task.async/1` links (use `Task.Supervisor.async_nolink/3` from a control loop, or a dead actuator takes the loop down), `Task.await_many/2` applies one deadline to the whole set rather than collecting as they land, and each task publishes from its own process so observers see commands interleaved rather than in the order listed.

**`improvement: command a motion's joints together rather than one at a time`** — `BB.Motion` waited on each actuator in turn, which is where the cost of a synchronous `set_position/4` actually lands: a six-joint move is six sequential round trips, ~18 ms against a serial-bus driver. It now issues them together and collects afterwards. No public API change.

I used `Task.async`/`await_many` internally rather than `:gen_server.send_request` + a reqid collection. The OTP primitive spawns nothing and would keep publications in joint order, but it needs ~50 lines of plumbing plus translating `receive_response`'s error and timeout returns back into `GenServer.call` exit semantics, and it would have wanted a request-id API on `BB.Actuator` that nothing else asked for. Tasks reuse the public `set_position/4` unchanged and get the exit semantics right for free, at one process per actuator per call. Say the word and I'll swap it.

One behavioural note: every joint is now commanded even when an earlier one refuses — before, the first refusal stopped the rest being sent. The refusal still raises. The common refusal (disarmed robot) applies to every actuator equally, so stopping early only left a motion half-issued in cases that were failing anyway.

`mix check --no-retry` still passes, with the same 3 pre-existing `Mix.Tasks.Bb.AddNxBackendTest` failures as `main`.


**`improvement: let the caller set how long a motion waits for its actuators`** — `:timeout` is now an actuator option on `BB.Motion` alongside `:velocity`/`:duration`, so a caller issuing steps at rate isn't stuck with a 5 s deadline per actuator.

One deadline, not two: `Task.await_many/2` still waits forever and each call's own timeout bounds it. A shorter deadline on the collection would kill tasks whose calls are in flight, and killing a task cancels nothing — the actuator already has the request and will act on it, so the caller would be told a step failed that actually ran.

Threading it through turned up a pre-existing bug: `move_to/4` and `move_to_multi/3` passed *no* actuator options at all. `:velocity`, `:duration` and `:command_id` were stripped out of the solver's options (`extract_solver_opts`) and then never handed to the actuators, so only `send_positions/3` honoured them. Fixed in the same commit, with tests, and `BB.Command.MoveTo` can now name them in its goal.

A timeout still exits the caller, as `GenServer.call/3` does — I didn't change that. A loop that would rather skip a late step than die wants `delivery: :direct`, which waits for nothing and spawns nothing; the task fan-out lives only in the `:pubsub` branch. If we later want a late step to come back as `{:error, :timeout}` instead of an exit, that's a deliberate change to `set_position/4`'s contract and worth its own issue.


**`improvement!: fold the position transports into set_position/4's :delivery option`** — `set_position/4` and `set_position_async/4` collapse into one function taking `:delivery`, the same option `BB.Motion` already takes, so a caller says the same thing at both levels. `set_position_async(r, t, p, opts)` becomes `set_position(r, t, p, opts ++ [delivery: :direct])`.

The cost of an option over a name is that the return type no longer follows from the call: `:direct` has nowhere to put an answer, so it returns `:ok` whether the actuator accepted or refused. There's a warning admonition on the function saying so, because an `{:error, reason}` branch under `:direct` is one that can never run.

**`improvement!: return an actuator's refusal from BB.Motion rather than raising it`** — a refused command is an ordinary outcome, and every other failure in that module was already a value.

- `send_positions/3` → `:ok | {:error, error}`
- `move_to/4` → the actuator's error through the existing `{:error, error}`, alongside the solver's
- `move_to_multi/3` → `{:error, error}` (see the `MultiFailed` commit below, which replaced the interim `{:error, nil, error, results}` shape)

The robot state is still set before commands go out, so a refusal leaves it describing where the robot was asked to go rather than where it is. That was equally true when this raised.

## Updated caller migration

| Before | After |
|---|---|
| `set_position(...)` → `:ok` | `set_position(...)` → `:ok \| {:error, reason}`, blocks until the actuator answers |
| `set_position!(r, t, p, opts)` | `set_position(r, t, p, opts ++ [delivery: :direct])` |
| `set_position_sync(r, t, p, opts, timeout)` → `{:ok, :accepted}` | `set_position(r, t, p, opts ++ [timeout: timeout])` → `:ok` |
| `delivery: :sync` | `delivery: :pubsub` |
| `BB.Motion.send_positions(...)` → `:ok` | `:ok \| {:error, error}` |
| `BB.Motion.move_to_multi(...)` errors | may now be `{:error, nil, error, results}` |


**`improvement!: return MultiFailed from the multi-target motion functions`** — `move_to_multi/3` and `solve_only_multi/3` answered failure with `{:error, failed_link, error, results}`, which callers had to destructure by hand and which had nowhere to put a failure not attributable to one target. `BB.Error.Kinematics.MultiFailed` already carried those exact three fields — `BB.Command.MoveTo` was building one from the tuple — so it's now what they return.

Both are `{:ok, results} | {:error, error}`, the same shape as `move_to/4` and everything else fallible in the module:

- a target that won't solve gives `%MultiFailed{}` — the link, the kinematics error, and the results solved before it
- an actuator refusing gives that actuator's own error, unwrapped, since every target solved and nothing about that failure is kinematic

`BB.Command.MoveTo` loses its hand-rolled wrapping, and with it two `case` statements that mapped values onto themselves.

While documenting it I found the `MultiFailed` entry in `documentation/reference/error-types.md` listed fields the struct has never had (`attempts`, `errors`). Corrected — it's a public return type now, not an internal wrapper.

| Before | After |
|---|---|
| `{:error, failed_link, error, results}` | `{:error, %MultiFailed{failed_link:, error:, partial_results:}}` |
| (no shape for it) | `{:error, actuator_error}` when a joint refused |


**`improvement!: leave BB.Robot.State to the sensors, and warn when a joint has none`** — `BB.Motion` wrote the positions it had just solved into `BB.Robot.State` before the commands went out. `BB.Robot.Runtime` also writes that table from `JointState` sensor messages, and there's one configuration per joint, so the two fought: `move_to` set the target, then the estimator walked the joint from its start position up to that target — anything sampling the state saw the joint arrive, reverse, then arrive again.

A refusal was worse: state said "we're there", the actuator refused, no `BeginMotion` was published, so no correction ever arrived and the configuration stayed a lie until something else moved that joint. The commit before this one documented that as a caveat on `move_to/4`; deleting the writes removes it instead.

Both solvers seed from this table (`State.get_all_configurations/1`), so the writes also fed each solve from where we asked to be rather than where we are.

What fills the gap is what was always meant to — a sensor, or `BB.Sensor.OpenLoopPositionEstimator` for hardware with no feedback. Simulation auto-adds one per unsensed actuator (`joint_supervisor.ex`); hardware doesn't, because only the author knows whether the device reports its own position. So a new verifier, `BB.Dsl.Verifiers.ValidatePositionFeedback`, warns at compile time when a driven joint has no sensor, naming the estimator and showing the fix. It warns rather than failing the build — a robot driven open-loop and never asked where it is, is unusual but not wrong. Fixed joints and joints with no actuator are skipped.

Smart servos (robotis, feetech) are their own sensor and publish `JointState` without anything appearing in the topology. They declare that themselves — see the next commit.

Callers relying on `move_to/4`, `move_to_multi/3` or `send_positions/3` to advance robot state need a position sensor (or estimator) on those joints — the warning names them.


**`improvement: ask the driver whether it senses position, rather than the robot's author`** — the warning needed a way to say "this actuator is its own sensor". A DSL flag put that question to the wrong person: whether a smart servo answers position queries on its bus is a property of the driver, not of the robot it's wired into, so every robotis and feetech user would have written it at every actuator and got it wrong wherever they didn't.

`c:BB.Actuator.capabilities/0` is that declaration, made once by the driver:

```elixir
@impl BB.Actuator
def capabilities(_opts), do: [:position_feedback]
```

It returns what the driver reads back from its hardware — `:position_feedback`, `:velocity_feedback`, `:effort_feedback`, matching the `BB.Message.Sensor.JointState` fields it would publish — and defaults to `[]`, the honest answer for a PWM servo or step/direction driver. The verifier asks the module via `Code.ensure_compiled/1`, the same approach `ValidateChildSpecBehavioursTransformer` uses, and stays quiet about a driver it can't load rather than failing a cross-package build.

**Follow-up for the satellites:** `bb_servo_robotis` and `bb_servo_feetech` read position back and should declare it, or their users get a warning naming a sensor they don't need. `bb_servo_pigpio` and `bb_servo_pca9685` genuinely can't, so their examples and docs will start warning until they declare an estimator — which is the warning working.


**`improvement: hand the child spec's options to c:BB.Actuator.capabilities/1`** — capabilities aren't always a property of the driver alone: an encoder input that may or may not be wired, a stepper that runs open or closed loop by option. Nothing implements the callback yet, so this was the cheapest moment to add the argument; after robotis and feetech adopt it, changing the arity breaks them.

```elixir
@impl BB.Actuator
def capabilities(opts) do
  if opts[:feedback_pin], do: [:position_feedback], else: []
end
```

What arrives is the child spec's options as written in the DSL, checked against `options_schema/0` with defaults applied — **not** the options `init/1` receives. No `:bb`, no `:motor_profile` (the robot doesn't exist yet), and a `param()` reference can't be resolved before the store is populated, so a parameterised option arrives holding its schema default. A capability that genuinely turns on one of those can't be answered at compile time; the docs say so, and advise claiming a capability you sometimes lack over disclaiming one you usually have, because spurious warnings are how warnings come to be ignored. There's a test pinning that behaviour.

Both verifiers now take the same view of a `param()` reference through a new `BB.Dsl.ChildSpecOptions`, rather than the new one growing its own copy of rules `ValidateChildSpecs` already had.


---

## Version skew: bumping your `bb` floor is not optional if you adopt `delivery:`

Found while porting downstream packages, and worth stating plainly because it bites silently.

`set_position/4` **already exists** in bb 0.28 and 0.29, where it publishes and ignores options it doesn't recognise. So a downstream package that ports `set_position!(robot, joint, pos)` to `set_position(robot, joint, pos, delivery: :direct)` will **compile clean against an older bb and quietly take the wrong transport** — publishing where the code means to cast, returning `:ok` either way, with nothing warning about it.

That is the cost of expressing the transport as an option value rather than in the function name: a removed function fails loudly at compile time, an ignored option fails silently at runtime. `set_position!/4` and `set_position_sync/5` being *gone* is the safe half of this change; `:delivery` being *new* is the unsafe half.

So anyone adopting `:delivery` must raise their `bb` floor to the release that ships it, in the same commit. `~> 0.29` won't do it — the pin has to exclude every version where the option is ignored. The downstream PRs in this epic deliberately leave the floor alone for now, since the release doesn't exist yet, and each says so in its body; they need a one-line pin bump at release time.

The same applies to `:timeout`, and to `BB.Motion`'s `delivery: :pubsub` now meaning "wait for the actuator" — an older bb reads it as "publish and don't wait".
