### PR TITLE
fix: render units without CLDR in compile-time error messages

### DIFF
--- a/lib/bb/dsl/topology_transformer.ex
+++ b/lib/bb/dsl/topology_transformer.ex
@@ -309,7 +309,7 @@ defmodule BB.Dsl.TopologyTransformer do
          module: Transformer.get_persisted(dsl, :module),
          path: to_error_path(path),
          message: """
-         Expected unit `#{Unit.to_string!(unit)}` to be compatible with #{readable_unit_name}
+         Expected unit `#{Unit.describe(unit)}` to be compatible with #{readable_unit_name}
          """
        )}
     end

--- a/lib/bb/parameter/type.ex
+++ b/lib/bb/parameter/type.ex
@@ -212,8 +212,7 @@ defmodule BB.Parameter.Type do
     if Unit.compatible?(bound, unit_type) do
       :ok
     else
-      {:error,
-       "`#{key}` must be compatible with `#{unit_type}`, got: #{Unit.to_string!(bound, style: :narrow)}"}
+      {:error, "`#{key}` must be compatible with `#{unit_type}`, got: #{Unit.describe(bound)}"}
     end
   end
 
@@ -238,7 +237,7 @@ defmodule BB.Parameter.Type do
       :ok
     else
       {:error,
-       "`min` must not be greater than `max`, got: #{Unit.to_string!(min, style: :narrow)} and #{Unit.to_string!(max, style: :narrow)}"}
+       "`min` must not be greater than `max`, got: #{Unit.describe(min)} and #{Unit.describe(max)}"}
     end
   end
 end

--- a/lib/bb/unit.ex
+++ b/lib/bb/unit.ex
@@ -112,6 +112,21 @@ defmodule BB.Unit do
           :lt | :eq | :gt | {:error, Exception.t()}
   defdelegate compare(a, b), to: Localize.Unit
 
+  @doc """
+  Render a unit for a developer-facing error message.
+
+  `to_string!/2` needs CLDR locale data, which is loaded by a process in
+  `Localize`'s supervision tree. DSL validators run while the host robot is
+  being compiled, and `mix compile` doesn't start dependency applications, so
+  that process isn't there. This renders the magnitude and canonical unit name
+  directly instead.
+
+      iex> BB.Unit.describe(Localize.Unit.new!(-30, "degree"))
+      "-30 degree"
+  """
+  @spec describe(Localize.Unit.t()) :: String.t()
+  def describe(%Localize.Unit{name: name, value: value}), do: "#{value} #{name}"
+
   @doc "Delegates to `Localize.Unit.to_string!/2`."
   @spec to_string!(Localize.Unit.t() | [Localize.Unit.t()], keyword) :: String.t()
   defdelegate to_string!(unit, options \\ []), to: Localize.Unit

--- a/lib/bb/unit/option.ex
+++ b/lib/bb/unit/option.ex
@@ -114,15 +114,24 @@ defmodule BB.Unit.Option do
       iex> BB.Unit.Option.validate(Localize.Unit.new!(5, "meter"), min: Localize.Unit.new!(1, "meter"))
       {:ok, Localize.Unit.new!(5, "meter")}
 
+      iex> BB.Unit.Option.validate(Localize.Unit.new!(-45, "degree"), min: Localize.Unit.new!(-30, "degree"))
+      {:error, "Expected -45 degree to be greater than or equal to -30 degree"}
+
   Max constraint - value must be <= max:
 
       iex> BB.Unit.Option.validate(Localize.Unit.new!(5, "meter"), max: Localize.Unit.new!(10, "meter"))
       {:ok, Localize.Unit.new!(5, "meter")}
 
+      iex> BB.Unit.Option.validate(Localize.Unit.new!(45, "degree"), max: Localize.Unit.new!(30, "degree"))
+      {:error, "Expected 45 degree to be less than or equal to 30 degree"}
+
   Eq constraint - value must equal exactly:
 
       iex> BB.Unit.Option.validate(Localize.Unit.new!(5, "meter"), eq: Localize.Unit.new!(5, "meter"))
       {:ok, Localize.Unit.new!(5, "meter")}
+
+      iex> BB.Unit.Option.validate(Localize.Unit.new!(5, "meter"), eq: Localize.Unit.new!(6, "meter"))
+      {:error, "Expected 5 meter to equal 6 meter"}
 
   ParamRef values are accepted and annotated with expected unit type:
 
@@ -167,34 +176,25 @@ defmodule BB.Unit.Option do
 
   defp validate_min(value, min),
     do:
-      validate_cmp(
-        value,
-        min,
-        [:gt, :eq],
-        "Expected #{Unit.to_string!(value, style: :narrow)} to be greater than or equal to #{Unit.to_string!(min, style: :narrow)}"
-      )
+      validate_cmp(value, min, [:gt, :eq], fn ->
+        "Expected #{Unit.describe(value)} to be greater than or equal to #{Unit.describe(min)}"
+      end)
 
   defp validate_max(value, nil), do: {:ok, value}
 
   defp validate_max(value, max),
     do:
-      validate_cmp(
-        value,
-        max,
-        [:lt, :eq],
-        "Expected #{Unit.to_string!(value, style: :narrow)} to be less than or equal to #{Unit.to_string!(max, style: :narrow)}"
-      )
+      validate_cmp(value, max, [:lt, :eq], fn ->
+        "Expected #{Unit.describe(value)} to be less than or equal to #{Unit.describe(max)}"
+      end)
 
   defp validate_eq(value, nil), do: {:ok, value}
 
   defp validate_eq(value, eq),
     do:
-      validate_cmp(
-        value,
-        eq,
-        [:eq],
-        "Expected #{Unit.to_string!(value, style: :short)} to equal #{Unit.to_string!(eq, style: :short)}"
-      )
+      validate_cmp(value, eq, [:eq], fn ->
+        "Expected #{Unit.describe(value)} to equal #{Unit.describe(eq)}"
+      end)
 
   defp validate_cmp(value, cmp, valid, message) do
     result = Unit.compare(value, cmp)
@@ -202,7 +202,7 @@ defmodule BB.Unit.Option do
     if result in valid do
       {:ok, value}
     else
-      {:error, message}
+      {:error, message.()}
     end
   end
 


### PR DESCRIPTION
Regression in 0.30.0. Any robot with a bounded unit parameter fails to compile:

```
** (exit) exited in: GenServer.call(Localize.Locale.Loader, {:load_and_store, :"en-NZ", ...})
    ** (EXIT) no process: ... possibly because its application isn't started
    (localize 1.0.1) lib/localize/unit.ex:1481: Localize.Unit.to_string!/2
    (bb 0.30.0) lib/bb/unit/option.ex:174: BB.Unit.Option.validate_min/2
```

## Cause

`BB.Parameter.Type.option_type/3` (#234) now folds `min`/`max` into the generated Spark type, so a bounded unit parameter becomes `{:custom, BB.Unit.Option, :validate, [[compatible: :degree, min: ~u(-30 degree), max: ~u(30 degree)]]}`. Before 0.30 the bounds were dropped, `validate_min(value, nil)` short-circuited, and nothing ever formatted a unit.

Two separate defects:

1. **Eager interpolation.** `validate_min/2`, `validate_max/2` and `validate_eq/2` passed their message to `validate_cmp/4` as a plain argument, so `Localize.Unit.to_string!/2` ran on the success path too — a `~u(-3 degree)` default well inside ±30 still crashed.
2. **No CLDR at compile time.** Even lazily, a genuine violation would exit rather than report itself. `to_string!/2` needs locale data from `Localize.Locale.Loader`, a GenServer in localize's supervision tree; Spark runs the validator while compiling the robot module, and `mix compile` doesn't start dependency applications.

## Fix

`validate_cmp/4` takes a closure; the message is built in the error branch.

Adds `BB.Unit.describe/1`, a locale-free rendering (`"-30 degree"`), used for every unit interpolated into a validator error message. The same exit was reachable from `BB.Dsl.TopologyTransformer` and from the `BB.Parameter.Type` bound checks — those messages were already lazy, but they run in transformers too, so a real violation there hit `no process` as well.

Also drops the `style:` option those calls passed. `Localize.Unit.to_string/2` reads `:format`; only `display_name/2` translates `:style`, so `style: :narrow` was a no-op and the messages were rendering long form regardless.

## Verification

Under `mix run --no-start`, which reproduces `mix compile`'s unstarted-application environment:

```
OK: in-bounds default compiles with apps unstarted
** (Spark.Error.DslError) [Goatzen.OutOfBounds]
parameters -> shoulder_trim :
  invalid `default`: Expected -45 degree to be greater than or equal to -30 degree
```

Doctests pin all three failure messages, so reintroducing `to_string!/2` changes the rendering and fails. `mix check --no-retry` passes.