### PR TITLE
fix!: convert a unit-typed parameter into the unit it declares

### DIFF
--- a/documentation/tutorials/07-parameters.md
+++ b/documentation/tutorials/07-parameters.md
@@ -74,6 +74,10 @@ end
 Bounds on a non-numeric type, a `min` above its `max`, or a `default` outside
 its own bounds are compile errors rather than surprises at runtime.
 
+A bound need only be *compatible* with the parameter's unit, not identical to
+it, and is checked against the value as written - so a `max` of `~u(1.2 meter)`
+still rejects `~u(200 centimeter)`.
+
 ## Organising Parameters with Groups
 
 Use `group` to organise related parameters:
@@ -394,16 +398,29 @@ parameters do
 end
 ```
 
-Unit parameters are validated and can be converted:
+A unit parameter accepts any value compatible with its declared unit, and
+converts it into that unit before storing it. Whatever a writer uses, every
+reader sees the unit the parameter declares:
 
 ```elixir
-iex> BB.Parameter.set(MyRobot.Robot, [:motion, :max_speed], ~u(2.0 m/s))
+iex> BB.Parameter.set(MyRobot.Robot, [:motion, :max_speed], ~u(2.0 meter_per_second))
 :ok
 
-# Units are converted to SI base for storage
 iex> BB.Parameter.get(MyRobot.Robot, [:motion, :max_speed])
-{:ok, 2.0}  # metres per second
+{:ok, ~u(2.0 meter_per_second)}
+
+# A compatible unit is converted rather than stored as written
+iex> BB.Parameter.set(MyRobot.Robot, [:motion, :max_speed], ~u(300 centimeter_per_second))
+:ok
+
+iex> BB.Parameter.get(MyRobot.Robot, [:motion, :max_speed])
+{:ok, ~u(3.0 meter_per_second)}
 ```
+
+Bounds are checked against the value as written, so a bound declared in one
+unit still rejects an out-of-range value given in another. Conversion happens
+on every write - `set/3`, `set_many/2`, a `params:` override at startup, a
+declared `default`, and a value replayed from a `BB.Parameter.Store`.
 
 ## Complete Example
 

--- a/lib/bb/parameter.ex
+++ b/lib/bb/parameter.ex
@@ -28,6 +28,18 @@ defmodule BB.Parameter do
         end
       end
 
+  ## Unit-Typed Parameters
+
+  A parameter declared as `{:unit, unit_type}` accepts any value compatible
+  with `unit_type` and is converted into it before being stored, so every
+  reader sees the declared unit regardless of what the writer used:
+
+      :ok = BB.Parameter.set(MyRobot, [:motion, :trim], ~u(0.26 radian))
+      {:ok, ~u(14.8969 degree)} = BB.Parameter.get(MyRobot, [:motion, :trim])
+
+  Bounds are checked against the value as written, so a `min`/`max` declared in
+  one unit still rejects an out-of-range value given in another.
+
   ## Path-Based Identification
 
   Parameters are identified by hierarchical paths that match the PubSub

--- a/lib/bb/parameter/type.ex
+++ b/lib/bb/parameter/type.ex
@@ -14,6 +14,10 @@ defmodule BB.Parameter.Type do
   `Spark.Options` type generated for the parameter so that they are enforced
   wherever a value is validated, and `describe/1` recovers them from a
   generated type for display.
+
+  A unit-typed parameter accepts any value compatible with its declared unit,
+  so `coerce/2` converts a value into that unit before it is stored. Without it
+  a parameter reports back whichever unit it happened to be written in.
   """
 
   alias BB.Unit
@@ -182,6 +186,58 @@ defmodule BB.Parameter.Type do
     do: {{:unit, options[:compatible]}, options[:min], options[:max]}
 
   def describe(type), do: {type, nil, nil}
+
+  @doc """
+  Converts a value into the unit its parameter type declares.
+
+  A unit-typed parameter accepts any value compatible with its declared unit,
+  so the value that reaches a write is not necessarily in the unit the reader
+  expects. Every parameter write converges on the declared unit by passing the
+  value through here.
+
+  Values of any other type are returned unchanged, as is a unit which cannot be
+  converted - a bound already rejects an incompatible unit wherever the value
+  was validated, and a write which skipped validation is left as it was rather
+  than reported wrong.
+
+  ## Examples
+
+      iex> BB.Parameter.Type.coerce({:unit, :degree}, Localize.Unit.new!(1, "radian"))
+      Localize.Unit.new!(57.29577951308232, "degree")
+
+  A value already in the declared unit is untouched:
+
+      iex> BB.Parameter.Type.coerce({:unit, :degree}, Localize.Unit.new!(30, "degree"))
+      Localize.Unit.new!(30, "degree")
+
+  So is anything which is not a unit:
+
+      iex> BB.Parameter.Type.coerce(:float, 1.5)
+      1.5
+
+      iex> BB.Parameter.Type.coerce(nil, :anything)
+      :anything
+
+  An incompatible unit is left alone for the caller's validation to reject:
+
+      iex> BB.Parameter.Type.coerce({:unit, :meter}, Localize.Unit.new!(90, "degree"))
+      Localize.Unit.new!(90, "degree")
+  """
+  @spec coerce(t | Spark.Options.type() | nil, term) :: term
+  def coerce({:unit, declared}, %Localize.Unit{} = value) when not is_nil(declared) do
+    target = Unit.unit_name(declared)
+
+    if value.name == target do
+      value
+    else
+      case Localize.Unit.convert(value, target) do
+        {:ok, converted} -> converted
+        {:error, _reason} -> value
+      end
+    end
+  end
+
+  def coerce(_type, value), do: value
 
   defp validate_numeric_type(:float, value) when is_float(value), do: {:ok, value}
   defp validate_numeric_type(:integer, value) when is_integer(value), do: {:ok, value}

--- a/lib/bb/robot/runtime.ex
+++ b/lib/bb/robot/runtime.ex
@@ -50,6 +50,7 @@ defmodule BB.Robot.Runtime do
   alias BB.Message.Sensor.JointState
   alias BB.Parameter.Changed, as: ParameterChanged
   alias BB.Parameter.Schema, as: ParameterSchema
+  alias BB.Parameter.Type, as: ParameterType
   alias BB.Robot.ParamResolver
   alias BB.Robot.State, as: RobotState
   alias BB.Safety.Controller, as: SafetyController
@@ -569,9 +570,9 @@ defmodule BB.Robot.Runtime do
 
   def handle_call({:set_parameter, path, value}, _from, state) do
     case validate_and_set_parameter(state, path, value) do
-      {:ok, old_value} ->
-        save_to_store(state, path, value)
-        publish_parameter_change(state.robot_module, path, old_value, value, :local)
+      {:ok, old_value, new_value} ->
+        save_to_store(state, path, new_value)
+        publish_parameter_change(state.robot_module, path, old_value, new_value, :local)
         {:reply, :ok, state}
 
       {:error, _} = error ->
@@ -581,9 +582,8 @@ defmodule BB.Robot.Runtime do
 
   def handle_call({:set_parameters, params}, _from, state) do
     case validate_all_parameters(state, params) do
-      :ok ->
-        # All valid - apply changes, save, and notify
-        Enum.each(params, fn {path, value} ->
+      {:ok, validated} ->
+        Enum.each(validated, fn {path, value} ->
           old_value = get_current_param_value(state, path)
           RobotState.set_parameter(state.robot_state, path, value)
           save_to_store(state, path, value)
@@ -1020,9 +1020,9 @@ defmodule BB.Robot.Runtime do
     old_value = get_current_param_value(state, path)
 
     case validate_parameter(state, path, value) do
-      :ok ->
-        RobotState.set_parameter(state.robot_state, path, value)
-        {:ok, old_value}
+      {:ok, new_value} ->
+        RobotState.set_parameter(state.robot_state, path, new_value)
+        {:ok, old_value, new_value}
 
       {:error, _} = error ->
         error
@@ -1030,19 +1030,30 @@ defmodule BB.Robot.Runtime do
   end
 
   defp validate_all_parameters(state, params) do
-    errors =
-      params
-      |> Enum.map(fn {path, value} ->
-        case validate_parameter(state, path, value) do
-          :ok -> nil
-          {:error, reason} -> {path, reason}
-        end
-      end)
-      |> Enum.reject(&is_nil/1)
+    results =
+      Enum.map(params, fn {path, value} -> {path, validate_parameter(state, path, value)} end)
 
-    case errors do
-      [] -> :ok
-      errors -> {:error, errors}
+    case Enum.filter(results, &match?({_path, {:error, _reason}}, &1)) do
+      [] ->
+        {:ok, Enum.map(results, fn {path, {:ok, value}} -> {path, value} end)}
+
+      errors ->
+        {:error, Enum.map(errors, fn {path, {:error, reason}} -> {path, reason} end)}
+    end
+  end
+
+  defp coerce_to_declared_unit(state, path, value),
+    do: ParameterType.coerce(declared_type(state, path), value)
+
+  defp declared_type(state, path) do
+    with {:ok, schema_path, %Spark.Options{schema: schema_opts}} <-
+           RobotState.find_schema_for_parameter(state.robot_state, path),
+         param_name = path |> Enum.drop(length(schema_path)) |> List.first(),
+         {:ok, param_opts} <- Keyword.fetch(schema_opts, param_name) do
+      {type, _min, _max} = ParameterType.describe(Keyword.get(param_opts, :type))
+      type
+    else
+      _ -> nil
     end
   end
 
@@ -1069,8 +1080,12 @@ defmodule BB.Robot.Runtime do
         mini_schema = Spark.Options.new!([{param_name, param_opts}])
 
         case Spark.Options.validate([{param_name, value}], mini_schema) do
-          {:ok, _} -> :ok
-          {:error, error} -> {:error, error}
+          {:ok, validated} ->
+            {type, _min, _max} = ParameterType.describe(Keyword.get(param_opts, :type))
+            {:ok, ParameterType.coerce(type, Keyword.fetch!(validated, param_name))}
+
+          {:error, error} ->
+            {:error, error}
         end
 
       :error ->
@@ -1104,8 +1119,10 @@ defmodule BB.Robot.Runtime do
       case Keyword.fetch(param_opts, :default) do
         {:ok, default} ->
           full_path = base_path ++ [param_name]
-          RobotState.set_parameter(state.robot_state, full_path, default)
-          publish_parameter_change(state.robot_module, full_path, nil, default, :init)
+          {type, _min, _max} = ParameterType.describe(Keyword.get(param_opts, :type))
+          value = ParameterType.coerce(type, default)
+          RobotState.set_parameter(state.robot_state, full_path, value)
+          publish_parameter_change(state.robot_module, full_path, nil, value, :init)
 
         :error ->
           :ok
@@ -1176,6 +1193,7 @@ defmodule BB.Robot.Runtime do
   defp apply_persisted_value(state, {path, value}) do
     case RobotState.get_parameter(state.robot_state, path) do
       {:ok, _current} ->
+        value = coerce_to_declared_unit(state, path, value)
         RobotState.set_parameter(state.robot_state, path, value)
         publish_parameter_change(state.robot_module, path, nil, value, :persisted)
 
@@ -1226,6 +1244,7 @@ defmodule BB.Robot.Runtime do
   end
 
   defp apply_default_value(state, {path, value}) do
+    value = coerce_to_declared_unit(state, path, value)
     RobotState.set_parameter(state.robot_state, path, value)
     publish_parameter_change(state.robot_module, path, nil, value, :init)
   end
@@ -1258,6 +1277,7 @@ defmodule BB.Robot.Runtime do
     validated
     |> ParameterSchema.flatten_params()
     |> Enum.each(fn {path, value} ->
+      value = coerce_to_declared_unit(state, path, value)
       RobotState.set_parameter(state.robot_state, path, value)
       publish_parameter_change(state.robot_module, path, nil, value, :startup)
     end)

--- a/test/bb/parameter/unit_coercion_test.exs
+++ b/test/bb/parameter/unit_coercion_test.exs
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: 2026 James Harton
+#
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule BB.Parameter.UnitCoercionTest do
+  @moduledoc """
+  A unit-typed parameter accepts any value compatible with its declared unit.
+  Every path which writes one has to converge on the declared unit, or the
+  parameter reports back whichever unit it happened to be written in.
+  """
+  use ExUnit.Case, async: false
+
+  import BB.Unit
+
+  alias BB.Parameter
+  alias BB.Unit.Option, as: UnitOption
+  alias Localize.Unit, as: LocalizeUnit
+
+  defmodule RadianStore do
+    @moduledoc false
+    @behaviour BB.Parameter.Store
+
+    @impl BB.Parameter.Store
+    def init(_robot_module, _opts), do: {:ok, %{}}
+
+    @impl BB.Parameter.Store
+    def load(_state), do: {:ok, [{[:motion, :trim], LocalizeUnit.new!(0.5, "radian")}]}
+
+    @impl BB.Parameter.Store
+    def save(_state, _path, _value), do: :ok
+
+    @impl BB.Parameter.Store
+    def close(_state), do: :ok
+  end
+
+  defmodule RadianDefaultController do
+    @moduledoc false
+    @behaviour BB.Parameter
+
+    @impl BB.Parameter
+    def param_schema do
+      Spark.Options.new!(
+        tilt: [
+          type: UnitOption.unit_type(compatible: :degree),
+          default: LocalizeUnit.new!(0.25, "radian")
+        ]
+      )
+    end
+  end
+
+  defmodule Robot do
+    @moduledoc false
+    use BB
+
+    parameters do
+      group :motion do
+        param(:trim,
+          type: {:unit, :degree},
+          default: ~u(0 degree),
+          min: ~u(-30 degree),
+          max: ~u(30 degree)
+        )
+
+        param(:slew, type: {:unit, :degree_per_second}, default: ~u(45 degree_per_second))
+      end
+    end
+
+    topology do
+      link :base_link do
+      end
+    end
+  end
+
+  defmodule RadianDefaultRobot do
+    @moduledoc false
+    use BB
+
+    parameters do
+      param(:reach, type: {:unit, :meter}, default: ~u(50 centimeter))
+    end
+
+    topology do
+      link :base_link do
+      end
+    end
+  end
+
+  defmodule PersistedRobot do
+    @moduledoc false
+    use BB
+
+    settings do
+      parameter_store(BB.Parameter.UnitCoercionTest.RadianStore)
+    end
+
+    parameters do
+      group :motion do
+        param(:trim, type: {:unit, :degree}, default: ~u(0 degree))
+      end
+    end
+
+    topology do
+      link :base_link do
+      end
+    end
+  end
+
+  describe "set/3" do
+    setup do
+      start_supervised!(Robot)
+      :ok
+    end
+
+    test "converts a compatible unit into the declared one" do
+      assert :ok = Parameter.set(Robot, [:motion, :trim], ~u(0.26 radian))
+
+      assert {:ok, %LocalizeUnit{name: "degree", value: degrees}} =
+               Parameter.get(Robot, [:motion, :trim])
+
+      assert_in_delta degrees, 14.8969, 0.0001
+    end
+
+    test "leaves a value already in the declared unit alone" do
+      assert :ok = Parameter.set(Robot, [:motion, :trim], ~u(12.5 degree))
+      assert Parameter.get(Robot, [:motion, :trim]) == {:ok, ~u(12.5 degree)}
+    end
+
+    test "converts a compound unit" do
+      assert :ok = Parameter.set(Robot, [:motion, :slew], ~u(1 radian_per_second))
+
+      assert {:ok, %LocalizeUnit{name: "degree-per-second", value: rate}} =
+               Parameter.get(Robot, [:motion, :slew])
+
+      assert_in_delta rate, 57.2957, 0.0001
+    end
+
+    test "still enforces bounds declared in another unit" do
+      assert {:error, _reason} = Parameter.set(Robot, [:motion, :trim], ~u(1 radian))
+      assert Parameter.get(Robot, [:motion, :trim]) == {:ok, ~u(0 degree)}
+    end
+
+    test "publishes the change in the declared unit" do
+      BB.subscribe(Robot, [:param, :motion, :trim])
+
+      :ok = Parameter.set(Robot, [:motion, :trim], ~u(0.1 radian))
+
+      assert_receive {:bb, [:param, :motion, :trim], %BB.Message{payload: payload}}
+      assert payload.new_value.name == "degree"
+    end
+  end
+
+  describe "set_many/2" do
+    setup do
+      start_supervised!(Robot)
+      :ok
+    end
+
+    test "converts every parameter it writes" do
+      assert :ok =
+               Parameter.set_many(Robot, [
+                 {[:motion, :trim], ~u(0.1 radian)},
+                 {[:motion, :slew], ~u(1 radian_per_second)}
+               ])
+
+      assert {:ok, %LocalizeUnit{name: "degree"}} = Parameter.get(Robot, [:motion, :trim])
+
+      assert {:ok, %LocalizeUnit{name: "degree-per-second"}} =
+               Parameter.get(Robot, [:motion, :slew])
+    end
+
+    test "writes nothing when one parameter is out of bounds" do
+      assert {:error, _errors} =
+               Parameter.set_many(Robot, [
+                 {[:motion, :trim], ~u(1 radian)},
+                 {[:motion, :slew], ~u(1 radian_per_second)}
+               ])
+
+      assert Parameter.get(Robot, [:motion, :trim]) == {:ok, ~u(0 degree)}
+      assert Parameter.get(Robot, [:motion, :slew]) == {:ok, ~u(45 degree_per_second)}
+    end
+  end
+
+  describe "startup values" do
+    test "a DSL default declared in another unit is converted" do
+      start_supervised!(RadianDefaultRobot)
+
+      assert Parameter.get(RadianDefaultRobot, [:reach]) == {:ok, ~u(0.5 meter)}
+    end
+
+    test "a params: override is converted" do
+      start_supervised!({Robot, params: [motion: [trim: ~u(0.1 radian)]]})
+
+      assert {:ok, %LocalizeUnit{name: "degree", value: degrees}} =
+               Parameter.get(Robot, [:motion, :trim])
+
+      assert_in_delta degrees, 5.7295, 0.0001
+    end
+
+    test "a component's schema default is converted when it registers" do
+      start_supervised!(Robot)
+
+      :ok = Parameter.register(Robot, [:controller, :tilt_ctl], RadianDefaultController)
+
+      assert {:ok, %LocalizeUnit{name: "degree", value: degrees}} =
+               Parameter.get(Robot, [:controller, :tilt_ctl, :tilt])
+
+      assert_in_delta degrees, 14.3239, 0.0001
+    end
+
+    test "a persisted value is converted when it is replayed" do
+      start_supervised!(PersistedRobot)
+
+      assert {:ok, %LocalizeUnit{name: "degree", value: degrees}} =
+               Parameter.get(PersistedRobot, [:motion, :trim])
+
+      assert_in_delta degrees, 28.6478, 0.0001
+    end
+  end
+end


### PR DESCRIPTION
## What was broken

A `{:unit, _}` parameter accepts any value compatible with its declared unit,
and nothing converted it, so the parameter reported back whichever unit it
happened to be written in:

```elixir
BB.Parameter.set(Robot, [:motion, :trim], ~u(0.26 radian))   # declared {:unit, :degree}
#=> :ok
BB.Parameter.get(Robot, [:motion, :trim])
#=> {:ok, Localize.Unit.new!(0.26, "radian")}
```

Every reader had to defend against it. Taking `.value` and pairing it with the
declared unit is simply wrong; rendering the value's own unit disagrees with
the bounds, which come from the declaration and need not share a unit with the
current value. The parameter surfaces in `bb_liveview`, `bb_kino` and `bb_mcp`
each grew their own normalisation to work around this.

## Five write paths, not one

`lib/bb/robot/runtime.ex` writes a parameter in six places. Only one was
already storing the value validation produced:

| Path | Before |
|---|---|
| `set/3` | validated, discarded the coercion, stored the raw input |
| `set_many/2` | same |
| `initialise_defaults_from_schema` (a component's `param_schema/0`) | stored the declared `default:` unvalidated |
| `apply_default_value` (a DSL `default`) | unvalidated |
| `apply_persisted_value` (a `BB.Parameter.Store` replay) | unvalidated |
| `apply_validated_startup_params` (a `params:` override) | stored the validated value, which was never converted |

So `param :trim, type: {:unit, :degree}, default: ~u(0 radian)` booted holding
radians, and a persisted radian value was replayed as radians on every restart.
Fixing only `set/3` would have left a robot that silently changes the unit it
reports the first time somebody nudges a parameter.

## What changed

- **`BB.Parameter.Type.coerce/2`** converts a value into the unit its parameter
  type declares. Anything that is not a unit passes through, as does a unit
  which cannot be converted — a bound already rejects an incompatible unit
  wherever the value was validated, and a write which skipped validation is
  left as it was rather than reported wrong.
- **All six write paths** pass through it. The two validated paths take the
  value out of `Spark.Options.validate/2`; the four unvalidated ones look the
  declared type up via `BB.Parameter.Type.describe/1`, which already recovers
  it from both DSL-generated and hand-written schemas.
- **`validate_against_schema/3` no longer throws the validated value away.**
  It previously did `{:ok, _} -> :ok` and stored the caller's raw input, so
  even a converting validator would have been overwritten. The store and the
  `BB.Parameter.Changed` message now carry the converted value too, rather than
  what the caller passed — without that, `save_to_store/3` would persist the
  un-normalised value and hand it straight back on the next boot.

## Where the conversion deliberately does not go

The obvious one-line fix is to convert inside `BB.Unit.Option.validate/2`.
That is wrong: it backs all 47 `unit_type(compatible: …)` sites in the DSL,
where preserving the unit as written is intended, documented in a doctest and
asserted by two tests.

```elixir
# lib/bb/unit/option.ex
iex> BB.Unit.Option.validate(Localize.Unit.new!(100, "centimeter"), compatible: :meter)
{:ok, Localize.Unit.new!(100, "centimeter")}

# test/bb/joint_test.exs
assert joint.origin.x == ~u(100 centimeter)
assert joint.origin.roll == ~u(1 radian)
```

Making that change produces exactly three new test failures, all three of them
the assertions above. A joint origin written in centimetres should stay in
centimetres; a parameter should not. The conversion belongs on the parameter
write path, which is the only thing that consults the parameter schema.

## Bounds are unaffected

Still checked against the value as written, so a `max` declared in degrees
rejects an out-of-range value given in radians:

```elixir
BB.Parameter.set(Robot, [:motion, :trim], ~u(1 radian))   # max: ~u(30 degree)
#=> {:error, %Spark.Options.ValidationError{
#     message: "... Expected 1 radian to be less than or equal to 30 degree"}}
```

## Documentation

`documentation/tutorials/07-parameters.md` already claimed this behaviour and
was wrong twice over — it said values are "converted to SI base for storage"
(they were not converted at all) and showed `get/2` returning a bare `2.0`
rather than a `Localize.Unit`. Corrected, along with a note that a bound need
only be compatible with the parameter's unit. `BB.Parameter`'s moduledoc gains
a short section on the same.

## Testing

New `test/bb/parameter/unit_coercion_test.exs` — 11 tests, one per write path
plus the guardrails:

- `set/3` converts a compatible unit, leaves a declared-unit value alone,
  handles a compound unit (`radian_per_second` → `degree-per-second`), still
  enforces a bound declared in another unit, and publishes the change in the
  declared unit
- `set_many/2` converts every parameter, and writes nothing when one is out of
  bounds
- a DSL `default` in another unit, a `params:` startup override, a component
  `param_schema/0` default, and a `BB.Parameter.Store` replay are each converted

Eight of the eleven fail without the fix; the three that pass either way are
the no-op and rejection guardrails.

## `mix check --no-retry`

`ex_unit` reports the same three pre-existing `Mix.Tasks.Bb.AddNxBackendTest`
failures as `main` (`Rewrite.Error`, unrelated) and nothing else: 1402/1405,
62/62 doctests. compiler, dialyzer, credo `--strict`, ex_doc, formatter,
mix_audit, reuse, spark_cheat_sheets, spark_formatter and unused_deps all pass.

## Compatibility

`get/2` and `list/1` now report a unit-typed parameter in its declared unit
rather than the unit it was written in, hence `fix!`.

The three satellite PRs that worked around this — beam-bots/bb_liveview#132,
beam-bots/bb_kino#127 and beam-bots/bb_mcp#52 — stay correct on top of it.
Their struct-to-magnitude rendering and magnitude-to-struct writes are still
needed; only their cross-unit conversion becomes redundant and can be dropped
once this is released.

Fixes #243
