### PR TITLE
improvement: re-check the subproject PLT outside `mix check`'s parallel section

### DIFF
--- a/.github/workflows/test-subprojects.yml
+++ b/.github/workflows/test-subprojects.yml
@@ -130,7 +130,7 @@ jobs:
         working-directory: ${{ matrix.project.name }}
         run: mix deps.get
 
-      - name: Force a PLT re-check
+      - name: Re-check the PLT against bb's current source
         # Dialyxir decides a cached PLT is current by hashing the subproject's
         # mix.lock plus its app list. `BB_VERSION=local` makes bb a path dep, so
         # bb's source moves on every PR while that lock sits still — the hash
@@ -138,8 +138,15 @@ jobs:
         # predates bb's newest exports, reporting `call_to_missing` for them.
         # Dropping the hash forces the check, which is incremental (seconds)
         # rather than a full rebuild.
+        #
+        # Run the check here rather than leaving it to `mix check`. It spends
+        # twenty seconds or so reading every beam in the build directory, and
+        # `mix check` runs its tools in parallel — a tool that recompiles that
+        # directory meanwhile can empty it under dialyzer's feet.
         working-directory: ${{ matrix.project.name }}
-        run: rm -f _build/*/*.plt.hash
+        run: |
+          rm -f _build/*/*.plt.hash
+          mix dialyzer --plt
 
       - name: mix check --no-retry
         working-directory: ${{ matrix.project.name }}

--- a/documentation/dsls/DSL-BB.md
+++ b/documentation/dsls/DSL-BB.md
@@ -373,7 +373,7 @@ The material of the visual element
 ### topology.link.visual.material.color
 
 
-The color of the meterial
+The color of the material
 
 
 

--- a/lib/bb/dsl.ex
+++ b/lib/bb/dsl.ex
@@ -660,7 +660,7 @@ defmodule BB.Dsl do
   @color %Entity{
     name: :color,
     describe: """
-    The color of the meterial
+    The color of the material
     """,
     target: BB.Dsl.Color,
     identifier: {:auto, :unique_integer},


### PR DESCRIPTION
Fixes #245 together with beam-bots/bb_example_wx200#97 and
beam-bots/bb_example_so101#91.

## Root cause

Not the cache key, and not a stale PLT. `mix gettext.extract --check-up-to-date`
re-expands the gettext macros by force-recompiling the project
(`mix compile --force-elixir` + `mix compile.elixir --force`), and a forced
recompile empties `_build/dev/lib/<app>/ebin` and `.../consolidated` before
refilling them. Polled every 50 ms in `bb_example_wx200`, that window is about
two seconds:

```
40.86 ebin=21 consolidated=27
41.59 ebin=21 consolidated=0     <- consolidated/ emptied
41.70 ebin=1  consolidated=0     <- ebin emptied, .app file only
43.47 ebin=21 consolidated=0
43.76 ebin=21 consolidated=27
```

`ex_check` runs the `gettext` tool in parallel with `dialyzer`. Elixir's build
lock serialises the two *compiles* — that is what the "Waiting for lock on the
build directory" lines in the failing logs are — but not dialyzer's beam reads,
which happen after it releases the lock: first the PLT check, then the
`Path.wildcard` in `Dialyxir.Project.dialyzer_files/0` that builds its file list.
A wipe landing across both gives exactly the reported failure: the PLT check
can't read a consolidated protocol beam, and the file list comes back empty.

Only `bb_example_wx200` and `bb_example_so101` carry both `gettext` and
`dialyxir`, which is why only those two jobs fail — `bb_example_so101` failed
identically on the `v0.30.1` tag push (run 32619948357), so it was never really
PR-only either. The issue's `consolidate_protocols` lead is a red herring: those
two are Phoenix apps and don't set it, so they do consolidate in `:dev`. Setting
it would remove one of the two error lines and leave the empty file list.

## What this changes

The `Force a PLT re-check` step deleted `_build/*/*.plt.hash` and left the
re-check itself to `mix check`, where it runs alongside every other tool and
spends twenty-odd seconds reading every beam in the build directory. That is the
amplifier: with a valid hash, dialyzer's exposure is the ~0.15 s between
releasing the build lock and globing the ebin; with the hash deleted it is the
whole PLT check. This PR primes the PLT in that step instead, so the re-check
still happens — same correctness, same total work, moved out of the parallel
section.

That narrows the window; it doesn't close it. The two `.check.exs` PRs above
close it, by making the `gettext` tool depend on `dialyzer` so the forced
recompile runs when nothing else is reading `_build`. All three are needed.

The first commit is the real source touch used to make the downstream matrix
recompile `bb` (a one-character typo fix in the `color` entity's docs, plus the
regenerated cheat sheet). It's a genuine fix, so it stays rather than being
reverted.

## Verification

**Reproduced locally, byte for byte.** In `bb_example_wx200` with
`BB_VERSION=local` and `_build/*/*.plt.hash` deleted, overlapping
`mix gettext.extract --check-up-to-date` with `mix dialyzer`:

```
:dialyzer.run error: File not found:
  .../_build/dev/lib/bb_example_wx200/consolidated/Elixir.Collectable.beam
  files: [],
:dialyzer.run error: Analysis failed with error:
No .beam files to analyze (no --src specified?)
Halting VM with exit status 1
```

Same file, same empty `files: []` as the CI logs. With the `.check.exs` fix,
`mix check --no-retry` moves the forced recompile to the last three seconds of
the run, after dialyzer has finished.

**Not reproduced naturally in CI, and I can show why.** The `bb_example_wx200`
and `bb_example_so101` jobs pass on this PR — but they also pass on a scratch PR
carrying only the source touch with this workflow unchanged (#247, closed), so
that green is not evidence of a fix. Re-running the 23 Aug job that failed
(run 32674375855, job 97280389283) unchanged, today, also passes. The timings
against the same `_build` cache key have moved a long way since:

| | 23 Aug (failed) | today (passes) |
|---|---|---|
| `ex_unit` | 0:13 | 0:49 |
| `dialyzer` | 0:21 | 1:51 |

`gettext` is gated on `ex_unit`, so it now starts around 50 s in, well clear of
dialyzer's PLT check. That is consistent with a timing race rather than anything
about the branch, and it means CI cannot currently demonstrate either the break
or the fix.

**This PR's step does behave as intended** (job 98350500869): the PLT check runs
in its own step for 81 s, and `mix dialyzer` inside `mix check` then drops from
0:21–0:36 to 0:16 with no PLT-check phase at all.
