### PR TITLE
scratch: reproduce the subproject dialyzer failure (do not merge)

### DIFF
--- a/documentation/dsls/DSL-BB.md
+++ b/documentation/dsls/DSL-BB.md
@@ -373,7 +373,7 @@ The material of the visual element
 ### topology.link.visual.material.color
 
 
-The color of the meterial
+The color of the material
 
 
 

--- a/lib/bb/dsl.ex
+++ b/lib/bb/dsl.ex
@@ -660,7 +660,7 @@ defmodule BB.Dsl do
   @color %Entity{
     name: :color,
     describe: """
-    The color of the meterial
+    The color of the material
     """,
     target: BB.Dsl.Color,
     identifier: {:auto, :unique_integer},


### PR DESCRIPTION
Throwaway PR. Carries only the one-character source touch from #246, with `test-subprojects.yml` unchanged, to confirm the `bb_example_wx200` / `bb_example_so101` dialyzer failure reproduces on a pull request. Will be closed once observed.