### PR TITLE
improvement: hold the small math types as floats rather than Nx tensors

### DIFF
--- a/lib/bb/math/covariance3.ex
+++ b/lib/bb/math/covariance3.ex
@@ -13,8 +13,12 @@ defmodule BB.Math.Covariance3 do
   matrices, in particular, are legitimate "unknown variance" placeholders
   and must remain constructible).
 
-  Follows the same typed-Nx-wrapper pattern as `BB.Math.Vec3`,
-  `BB.Math.Quaternion`, and `BB.Math.Transform`.
+  Unlike `BB.Math.Vec3`, `BB.Math.Quaternion` and `BB.Math.Transform`, this is
+  still tensor-backed. Those three are read and written on every sample, so
+  their `Nx` dispatch cost dominated; a covariance is constructed from a tensor
+  and handed back as one, and no driver in the ecosystem populates it per
+  reading. Holding it as anything else would add a conversion to both ends of
+  its only path.
 
   ## Examples
 

--- a/lib/bb/math/covariance6.ex
+++ b/lib/bb/math/covariance6.ex
@@ -11,7 +11,7 @@ defmodule BB.Math.Covariance6 do
   mathematically expected to be symmetric and positive semi-definite;
   this module does not enforce those invariants on construction.
 
-  Follows the same typed-Nx-wrapper pattern as `BB.Math.Covariance3`.
+  Tensor-backed, for the reasons in `BB.Math.Covariance3`.
 
   ## Examples
 

--- a/lib/bb/math/quaternion.ex
+++ b/lib/bb/math/quaternion.ex
@@ -4,13 +4,24 @@
 
 defmodule BB.Math.Quaternion do
   @moduledoc """
-  Unit quaternion for 3D rotations, backed by an Nx tensor.
+  Unit quaternion for 3D rotations, held as four `:f64` floats.
 
-  Quaternions are stored in WXYZ order (scalar first): `[w, x, y, z]`.
-  All math operations use Nx for consistent performance and potential GPU acceleration.
+  Components are named for WXYZ order (scalar first), and every operation
+  returns a normalised unit quaternion suitable for representing a rotation.
 
-  All operations return normalised unit quaternions suitable for representing rotations.
-  The underlying tensor is always `{4}` shape with `:f64` type.
+  ## Not tensor-backed
+
+  Like `BB.Math.Vec3` and `BB.Math.Transform2D`, a single quaternion is far
+  cheaper as four BEAM floats than as an `Nx` tensor. A Hamilton product is
+  sixteen multiplies and twelve adds; dispatching those through eager `Nx` ops -
+  or through a `defn`, which retraces its expression graph per call - costs
+  orders of magnitude more than the arithmetic, and allocates every
+  intermediate. Orientation is built and read on every estimator sample, so that
+  lands squarely in the hot path. `bb_estimator_ahrs` used to carry its own
+  scalar quaternion for exactly this reason.
+
+  `tensor/1` and `from_tensor/1` convert at the boundary of code that genuinely
+  wants tensors, as do `to_rotation_matrix/1` and `from_rotation_matrix/1`.
 
   ## Examples
 
@@ -28,37 +39,23 @@ defmodule BB.Math.Quaternion do
       0.0
   """
 
-  alias BB.Math.Defn
   alias BB.Math.Vec3
 
-  defstruct [:tensor]
+  defstruct [:w, :x, :y, :z]
 
-  @type t :: %__MODULE__{tensor: Nx.Tensor.t()}
+  @type t :: %__MODULE__{w: float(), x: float(), y: float(), z: float()}
+
+  @zero_threshold 1.0e-10
+  @gimbal_threshold 0.99999
+  @slerp_linear_threshold 0.9995
+  @antiparallel_threshold -0.9999
 
   defimpl Inspect do
     import Inspect.Algebra
 
     @spec inspect(@for.t(), Inspect.Opts.t()) :: Inspect.Algebra.t()
-    def inspect(%@for{tensor: %Nx.Tensor{data: %Nx.BinaryBackend{}} = tensor}, opts) do
-      case Nx.shape(tensor) do
-        {4} ->
-          container_doc(
-            "BB.Math.Quaternion.new(",
-            Nx.to_flat_list(tensor),
-            ")",
-            opts,
-            &to_doc/2
-          )
-
-        _ ->
-          fallback(tensor, opts)
-      end
-    end
-
-    def inspect(%@for{tensor: tensor}, opts), do: fallback(tensor, opts)
-
-    defp fallback(tensor, opts) do
-      concat(["#BB.Math.Quaternion<", to_doc(tensor, opts), ">"])
+    def inspect(%@for{w: w, x: x, y: y, z: z}, opts) do
+      container_doc("BB.Math.Quaternion.new(", [w, x, y, z], ")", opts, &to_doc/2)
     end
   end
 
@@ -75,8 +72,7 @@ defmodule BB.Math.Quaternion do
   """
   @spec new(number(), number(), number(), number()) :: t()
   def new(w, x, y, z) do
-    tensor = Nx.tensor([w, x, y, z], type: :f64)
-    %__MODULE__{tensor: normalise_tensor(tensor)}
+    normalise(%__MODULE__{w: w / 1, x: x / 1, y: y / 1, z: z / 1})
   end
 
   @doc """
@@ -86,7 +82,9 @@ defmodule BB.Math.Quaternion do
   """
   @spec from_tensor(Nx.Tensor.t()) :: t()
   def from_tensor(tensor) do
-    %__MODULE__{tensor: normalise_tensor(Nx.as_type(tensor, :f64))}
+    [w, x, y, z] = tensor |> Nx.as_type(:f64) |> Nx.to_flat_list()
+
+    new(w, x, y, z)
   end
 
   @doc """
@@ -99,9 +97,7 @@ defmodule BB.Math.Quaternion do
       {1.0, 0.0, 0.0, 0.0}
   """
   @spec identity() :: t()
-  def identity do
-    %__MODULE__{tensor: Nx.tensor([1.0, 0.0, 0.0, 0.0], type: :f64)}
-  end
+  def identity, do: %__MODULE__{w: 1.0, x: 0.0, y: 0.0, z: 0.0}
 
   @doc """
   Returns an identity quaternion as a raw tensor (for batch operations).
@@ -111,32 +107,29 @@ defmodule BB.Math.Quaternion do
     Nx.tensor([1.0, 0.0, 0.0, 0.0], type: :f64)
   end
 
-  # Component accessors
-
   @doc "Returns the W (scalar) component."
   @spec w(t()) :: float()
-  def w(%__MODULE__{tensor: t}), do: Nx.to_number(t[0])
+  def w(%__MODULE__{w: w}), do: w
 
   @doc "Returns the X component."
   @spec x(t()) :: float()
-  def x(%__MODULE__{tensor: t}), do: Nx.to_number(t[1])
+  def x(%__MODULE__{x: x}), do: x
 
   @doc "Returns the Y component."
   @spec y(t()) :: float()
-  def y(%__MODULE__{tensor: t}), do: Nx.to_number(t[2])
+  def y(%__MODULE__{y: y}), do: y
 
   @doc "Returns the Z component."
   @spec z(t()) :: float()
-  def z(%__MODULE__{tensor: t}), do: Nx.to_number(t[3])
+  def z(%__MODULE__{z: z}), do: z
 
-  @doc "Returns the underlying `{4}` tensor."
+  @doc "Returns the quaternion as a `{4}` `:f64` WXYZ tensor."
   @spec tensor(t()) :: Nx.Tensor.t()
-  def tensor(%__MODULE__{tensor: t}), do: t
+  def tensor(%__MODULE__{w: w, x: x, y: y, z: z}), do: Nx.tensor([w, x, y, z], type: :f64)
 
   @doc """
   Creates a quaternion from an axis-angle representation.
 
-  The axis should be a `BB.Math.Vec3` unit vector (it will be normalised if not).
   The angle is in radians.
 
   ## Examples
@@ -146,26 +139,17 @@ defmodule BB.Math.Quaternion do
       0.707107
   """
   @spec from_axis_angle(Vec3.t(), number()) :: t()
-  def from_axis_angle(%Vec3{tensor: axis_tensor}, angle) do
-    # Normalise axis
-    axis_norm = Nx.LinAlg.norm(axis_tensor)
-    default_axis = Nx.tensor([0.0, 0.0, 1.0], type: :f64)
+  def from_axis_angle(%Vec3{} = axis, angle) do
+    {ax, ay, az} =
+      case Vec3.magnitude(axis) do
+        norm when norm > @zero_threshold -> {axis.x / norm, axis.y / norm, axis.z / norm}
+        _zero -> {0.0, 0.0, 1.0}
+      end
 
-    axis_normalised =
-      Nx.select(
-        Nx.greater(axis_norm, 1.0e-10),
-        Nx.divide(axis_tensor, axis_norm),
-        default_axis
-      )
+    half = angle / 2
+    sin_half = :math.sin(half)
 
-    half_angle = Nx.tensor(angle / 2, type: :f64)
-    sin_half = Nx.sin(half_angle)
-    cos_half = Nx.cos(half_angle)
-
-    xyz = Nx.multiply(axis_normalised, sin_half)
-    tensor = Nx.concatenate([Nx.reshape(cos_half, {1}), xyz])
-
-    %__MODULE__{tensor: tensor}
+    new(:math.cos(half), ax * sin_half, ay * sin_half, az * sin_half)
   end
 
   @doc """
@@ -190,107 +174,57 @@ defmodule BB.Math.Quaternion do
       1.0
   """
   @spec from_two_vectors(Vec3.t(), Vec3.t()) :: t()
-  def from_two_vectors(%Vec3{tensor: from_tensor}, %Vec3{tensor: to_tensor}) do
-    # Normalise both vectors
-    from_norm = Nx.LinAlg.norm(from_tensor)
-    to_norm = Nx.LinAlg.norm(to_tensor)
+  def from_two_vectors(%Vec3{} = from, %Vec3{} = to) do
+    from_unit = unit_or_x(from)
+    to_unit = unit_or_x(to)
 
-    from_unit =
-      Nx.select(
-        Nx.greater(from_norm, 1.0e-10),
-        Nx.divide(from_tensor, from_norm),
-        Nx.tensor([1.0, 0.0, 0.0], type: :f64)
-      )
+    dot = Vec3.dot(from_unit, to_unit)
 
-    to_unit =
-      Nx.select(
-        Nx.greater(to_norm, 1.0e-10),
-        Nx.divide(to_tensor, to_norm),
-        Nx.tensor([1.0, 0.0, 0.0], type: :f64)
-      )
+    if dot < @antiparallel_threshold do
+      perpendicular = perpendicular_to(from_unit)
 
-    # Dot product
-    dot = Nx.dot(from_unit, to_unit)
+      new(0.0, perpendicular.x, perpendicular.y, perpendicular.z)
+    else
+      cross = Vec3.cross(from_unit, to_unit)
 
-    # Cross product: from × to
-    f1 = from_unit[0]
-    f2 = from_unit[1]
-    f3 = from_unit[2]
-    t1 = to_unit[0]
-    t2 = to_unit[1]
-    t3 = to_unit[2]
+      new(1.0 + dot, cross.x, cross.y, cross.z)
+    end
+  end
 
-    cross =
-      Nx.stack([
-        Nx.subtract(Nx.multiply(f2, t3), Nx.multiply(f3, t2)),
-        Nx.subtract(Nx.multiply(f3, t1), Nx.multiply(f1, t3)),
-        Nx.subtract(Nx.multiply(f1, t2), Nx.multiply(f2, t1))
-      ])
+  defp unit_or_x(%Vec3{} = v) do
+    case Vec3.magnitude(v) do
+      magnitude when magnitude > @zero_threshold -> Vec3.scale(v, 1 / magnitude)
+      _zero -> Vec3.unit_x()
+    end
+  end
 
-    # Normal case: q = [1 + dot, cross] then normalise
-    # This works because (1 + dot) = 2*cos²(θ/2) and |cross| = sin(θ)
-    w_normal = Nx.add(1.0, dot)
-    q_normal = Nx.concatenate([Nx.reshape(w_normal, {1}), cross])
+  # The basis vector least aligned with `v` gives the numerically strongest
+  # perpendicular, so cross against that one rather than a fixed axis.
+  defp perpendicular_to(%Vec3{x: x, y: y, z: z} = v) do
+    {ax, ay, az} = {abs(x), abs(y), abs(z)}
 
-    # Anti-parallel case (dot ≈ -1): need to find perpendicular axis
-    # Use the axis with smallest component of from_unit to find perpendicular
-    abs_from = Nx.abs(from_unit)
+    basis =
+      cond do
+        ax <= ay and ax <= az -> Vec3.unit_x()
+        ay <= az -> Vec3.unit_y()
+        true -> Vec3.unit_z()
+      end
 
-    # Find perpendicular by crossing with least-aligned basis vector
-    perp_x =
-      Nx.stack([
-        Nx.tensor(0.0, type: :f64),
-        Nx.negate(f3),
-        f2
-      ])
+    cross = Vec3.cross(v, basis)
 
-    perp_y =
-      Nx.stack([
-        f3,
-        Nx.tensor(0.0, type: :f64),
-        Nx.negate(f1)
-      ])
-
-    perp_z =
-      Nx.stack([
-        Nx.negate(f2),
-        f1,
-        Nx.tensor(0.0, type: :f64)
-      ])
-
-    # Choose perpendicular with largest magnitude (most perpendicular to from)
-    perp =
-      Nx.select(
-        Nx.less(abs_from[0], abs_from[1]),
-        Nx.select(Nx.less(abs_from[0], abs_from[2]), perp_x, perp_z),
-        Nx.select(Nx.less(abs_from[1], abs_from[2]), perp_y, perp_z)
-      )
-
-    perp_norm = Nx.LinAlg.norm(perp)
-
-    perp_unit =
-      Nx.select(
-        Nx.greater(perp_norm, 1.0e-10),
-        Nx.divide(perp, perp_norm),
-        Nx.tensor([0.0, 1.0, 0.0], type: :f64)
-      )
-
-    # 180° rotation: w=0, xyz=perpendicular axis
-    q_antiparallel = Nx.concatenate([Nx.tensor([0.0], type: :f64), perp_unit])
-
-    # Select based on dot product
-    # Anti-parallel: dot < -0.9999
-    # Parallel: dot > 0.9999 (will normalise to identity)
-    is_antiparallel = Nx.less(dot, -0.9999)
-    result = Nx.select(is_antiparallel, q_antiparallel, q_normal)
-
-    %__MODULE__{tensor: normalise_tensor(result)}
+    if Vec3.magnitude(cross) > @zero_threshold do
+      Vec3.normalise(cross)
+    else
+      Vec3.unit_y()
+    end
   end
 
   @doc """
   Creates a quaternion from a 3x3 rotation matrix.
 
-  Uses the Shepperd method for numerical stability.
+  Accepts a `{3, 3}` tensor or a list of three three-element rows. Uses the
+  Shepperd method for numerical stability: the branch is chosen so the value
+  under the square root is largest, which keeps the division well conditioned.
 
   ## Examples
 
@@ -299,105 +233,41 @@ defmodule BB.Math.Quaternion do
       iex> BB.Math.Quaternion.w(q)
       1.0
   """
-  @spec from_rotation_matrix(Nx.Tensor.t()) :: t()
-  def from_rotation_matrix(matrix) do
-    matrix = Nx.as_type(matrix, :f64)
+  @spec from_rotation_matrix(Nx.Tensor.t() | [[number()]]) :: t()
+  def from_rotation_matrix(%Nx.Tensor{} = matrix) do
+    matrix
+    |> Nx.as_type(:f64)
+    |> Nx.to_flat_list()
+    |> from_rotation_elements()
+  end
 
-    # Extract matrix elements
-    m00 = matrix[0][0]
-    m01 = matrix[0][1]
-    m02 = matrix[0][2]
-    m10 = matrix[1][0]
-    m11 = matrix[1][1]
-    m12 = matrix[1][2]
-    m20 = matrix[2][0]
-    m21 = matrix[2][1]
-    m22 = matrix[2][2]
+  def from_rotation_matrix([[_, _, _], [_, _, _], [_, _, _]] = rows) do
+    rows
+    |> List.flatten()
+    |> Enum.map(&(&1 / 1))
+    |> from_rotation_elements()
+  end
 
-    trace = Nx.add(Nx.add(m00, m11), m22)
+  defp from_rotation_elements([m00, m01, m02, m10, m11, m12, m20, m21, m22]) do
+    trace = m00 + m11 + m22
 
-    # Compute all 4 cases and select the best one
-    # Use Nx.max to clamp values to 0 before sqrt to handle floating point errors
-    # Add epsilon to prevent division by zero in unused cases
-    eps = 1.0e-10
+    cond do
+      trace > 0 ->
+        s = :math.sqrt(trace + 1.0) * 2
+        new(s / 4, (m21 - m12) / s, (m02 - m20) / s, (m10 - m01) / s)
 
-    # Case 0: trace > 0
-    s0 = Nx.add(Nx.multiply(Nx.sqrt(Nx.max(Nx.add(trace, 1.0), 0.0)), 2.0), eps)
-    w0 = Nx.divide(s0, 4.0)
-    x0 = Nx.divide(Nx.subtract(m21, m12), s0)
-    y0 = Nx.divide(Nx.subtract(m02, m20), s0)
-    z0 = Nx.divide(Nx.subtract(m10, m01), s0)
-    q0 = Nx.stack([w0, x0, y0, z0])
+      m00 > m11 and m00 > m22 ->
+        s = :math.sqrt(1.0 + m00 - m11 - m22) * 2
+        new((m21 - m12) / s, s / 4, (m01 + m10) / s, (m02 + m20) / s)
 
-    # Case 1: m00 is largest diagonal
-    s1 =
-      Nx.add(
-        Nx.multiply(
-          Nx.sqrt(Nx.max(Nx.add(Nx.subtract(Nx.subtract(1.0, m11), m22), m00), 0.0)),
-          2.0
-        ),
-        eps
-      )
+      m11 > m22 ->
+        s = :math.sqrt(1.0 - m00 + m11 - m22) * 2
+        new((m02 - m20) / s, (m01 + m10) / s, s / 4, (m12 + m21) / s)
 
-    w1 = Nx.divide(Nx.subtract(m21, m12), s1)
-    x1 = Nx.divide(s1, 4.0)
-    y1 = Nx.divide(Nx.add(m01, m10), s1)
-    z1 = Nx.divide(Nx.add(m02, m20), s1)
-    q1 = Nx.stack([w1, x1, y1, z1])
-
-    # Case 2: m11 is largest diagonal
-    s2 =
-      Nx.add(
-        Nx.multiply(
-          Nx.sqrt(Nx.max(Nx.add(Nx.subtract(Nx.subtract(1.0, m00), m22), m11), 0.0)),
-          2.0
-        ),
-        eps
-      )
-
-    w2 = Nx.divide(Nx.subtract(m02, m20), s2)
-    x2 = Nx.divide(Nx.add(m01, m10), s2)
-    y2 = Nx.divide(s2, 4.0)
-    z2 = Nx.divide(Nx.add(m12, m21), s2)
-    q2 = Nx.stack([w2, x2, y2, z2])
-
-    # Case 3: m22 is largest diagonal
-    s3 =
-      Nx.add(
-        Nx.multiply(
-          Nx.sqrt(Nx.max(Nx.add(Nx.subtract(Nx.subtract(1.0, m00), m11), m22), 0.0)),
-          2.0
-        ),
-        eps
-      )
-
-    w3 = Nx.divide(Nx.subtract(m10, m01), s3)
-    x3 = Nx.divide(Nx.add(m02, m20), s3)
-    y3 = Nx.divide(Nx.add(m12, m21), s3)
-    z3 = Nx.divide(s3, 4.0)
-    q3 = Nx.stack([w3, x3, y3, z3])
-
-    # Select based on which case applies
-    # trace > 0 -> case 0
-    # else m00 > m11 and m00 > m22 -> case 1
-    # else m11 > m22 -> case 2
-    # else -> case 3
-    result =
-      Nx.select(
-        Nx.greater(trace, 0),
-        q0,
-        Nx.select(
-          Nx.logical_and(Nx.greater(m00, m11), Nx.greater(m00, m22)),
-          q1,
-          Nx.select(
-            Nx.greater(m11, m22),
-            q2,
-            q3
-          )
-        )
-      )
-
-    %__MODULE__{tensor: normalise_tensor(result)}
+      true ->
+        s = :math.sqrt(1.0 - m00 - m11 + m22) * 2
+        new((m10 - m01) / s, (m02 + m20) / s, (m12 + m21) / s, s / 4)
+    end
   end
 
   @doc """
@@ -415,93 +285,38 @@ defmodule BB.Math.Quaternion do
   """
   @spec from_euler(number(), number(), number(), atom()) :: t()
   def from_euler(roll, pitch, yaw, order \\ :xyz) do
-    # Half angles as tensors
-    x2 = Nx.tensor(roll / 2, type: :f64)
-    y2 = Nx.tensor(pitch / 2, type: :f64)
-    z2 = Nx.tensor(yaw / 2, type: :f64)
+    c1 = :math.cos(roll / 2)
+    c2 = :math.cos(pitch / 2)
+    c3 = :math.cos(yaw / 2)
+    s1 = :math.sin(roll / 2)
+    s2 = :math.sin(pitch / 2)
+    s3 = :math.sin(yaw / 2)
 
-    c1 = Nx.cos(x2)
-    c2 = Nx.cos(y2)
-    c3 = Nx.cos(z2)
-    s1 = Nx.sin(x2)
-    s2 = Nx.sin(y2)
-    s3 = Nx.sin(z2)
-
-    tensor = euler_to_quaternion_tensor(order, c1, c2, c3, s1, s2, s3)
-    %__MODULE__{tensor: normalise_tensor(tensor)}
+    euler_to_quaternion(order, c1, c2, c3, s1, s2, s3)
   end
 
-  defp euler_to_quaternion_tensor(:xyz, c1, c2, c3, s1, s2, s3) do
-    # x = s1 * c2 * c3 + c1 * s2 * s3
-    x =
-      Nx.add(
-        Nx.multiply(Nx.multiply(s1, c2), c3),
-        Nx.multiply(Nx.multiply(c1, s2), s3)
-      )
-
-    # y = c1 * s2 * c3 - s1 * c2 * s3
-    y =
-      Nx.subtract(
-        Nx.multiply(Nx.multiply(c1, s2), c3),
-        Nx.multiply(Nx.multiply(s1, c2), s3)
-      )
-
-    # z = c1 * c2 * s3 + s1 * s2 * c3
-    z =
-      Nx.add(
-        Nx.multiply(Nx.multiply(c1, c2), s3),
-        Nx.multiply(Nx.multiply(s1, s2), c3)
-      )
-
-    # w = c1 * c2 * c3 - s1 * s2 * s3
-    w =
-      Nx.subtract(
-        Nx.multiply(Nx.multiply(c1, c2), c3),
-        Nx.multiply(Nx.multiply(s1, s2), s3)
-      )
-
-    Nx.stack([w, x, y, z])
+  defp euler_to_quaternion(:zyx, c1, c2, c3, s1, s2, s3) do
+    new(
+      c1 * c2 * c3 + s1 * s2 * s3,
+      s1 * c2 * c3 - c1 * s2 * s3,
+      c1 * s2 * c3 + s1 * c2 * s3,
+      c1 * c2 * s3 - s1 * s2 * c3
+    )
   end
 
-  defp euler_to_quaternion_tensor(:zyx, c1, c2, c3, s1, s2, s3) do
-    # x = s1 * c2 * c3 - c1 * s2 * s3
-    x =
-      Nx.subtract(
-        Nx.multiply(Nx.multiply(s1, c2), c3),
-        Nx.multiply(Nx.multiply(c1, s2), s3)
-      )
-
-    # y = c1 * s2 * c3 + s1 * c2 * s3
-    y =
-      Nx.add(
-        Nx.multiply(Nx.multiply(c1, s2), c3),
-        Nx.multiply(Nx.multiply(s1, c2), s3)
-      )
-
-    # z = c1 * c2 * s3 - s1 * s2 * c3
-    z =
-      Nx.subtract(
-        Nx.multiply(Nx.multiply(c1, c2), s3),
-        Nx.multiply(Nx.multiply(s1, s2), c3)
-      )
-
-    # w = c1 * c2 * c3 + s1 * s2 * s3
-    w =
-      Nx.add(
-        Nx.multiply(Nx.multiply(c1, c2), c3),
-        Nx.multiply(Nx.multiply(s1, s2), s3)
-      )
-
-    Nx.stack([w, x, y, z])
-  end
-
-  # Default to xyz for unsupported orders
-  defp euler_to_quaternion_tensor(_order, c1, c2, c3, s1, s2, s3) do
-    euler_to_quaternion_tensor(:xyz, c1, c2, c3, s1, s2, s3)
+  defp euler_to_quaternion(_xyz, c1, c2, c3, s1, s2, s3) do
+    new(
+      c1 * c2 * c3 - s1 * s2 * s3,
+      s1 * c2 * c3 + c1 * s2 * s3,
+      c1 * s2 * c3 - s1 * c2 * s3,
+      c1 * c2 * s3 + s1 * s2 * c3
+    )
   end
 
   @doc """
-  Converts a quaternion to a 3x3 rotation matrix.
+  Converts a quaternion to a 3x3 rotation matrix as a `{3, 3}` `:f64` tensor.
+
+  Use `to_rotation_list/1` to avoid building a tensor.
 
   ## Examples
 
@@ -511,44 +326,35 @@ defmodule BB.Math.Quaternion do
       1.0
   """
   @spec to_rotation_matrix(t()) :: Nx.Tensor.t()
-  def to_rotation_matrix(%__MODULE__{tensor: t}) do
-    w = t[0]
-    x = t[1]
-    y = t[2]
-    z = t[3]
+  def to_rotation_matrix(%__MODULE__{} = q) do
+    Nx.tensor(to_rotation_list(q), type: :f64)
+  end
 
-    # Pre-compute products
-    xx = Nx.multiply(x, x)
-    yy = Nx.multiply(y, y)
-    zz = Nx.multiply(z, z)
-    xy = Nx.multiply(x, y)
-    xz = Nx.multiply(x, z)
-    yz = Nx.multiply(y, z)
-    wx = Nx.multiply(w, x)
-    wy = Nx.multiply(w, y)
-    wz = Nx.multiply(w, z)
+  @doc """
+  Converts a quaternion to a 3x3 rotation matrix as a list of rows.
 
-    two = Nx.tensor(2.0, type: :f64)
-    one = Nx.tensor(1.0, type: :f64)
+  ## Examples
 
-    # Build rotation matrix
-    r00 = Nx.subtract(one, Nx.multiply(two, Nx.add(yy, zz)))
-    r01 = Nx.multiply(two, Nx.subtract(xy, wz))
-    r02 = Nx.multiply(two, Nx.add(xz, wy))
+      iex> BB.Math.Quaternion.to_rotation_list(BB.Math.Quaternion.identity())
+      [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+  """
+  @spec to_rotation_list(t()) :: [[float()]]
+  def to_rotation_list(%__MODULE__{w: w, x: x, y: y, z: z}) do
+    xx = x * x
+    yy = y * y
+    zz = z * z
+    xy = x * y
+    xz = x * z
+    yz = y * z
+    wx = w * x
+    wy = w * y
+    wz = w * z
 
-    r10 = Nx.multiply(two, Nx.add(xy, wz))
-    r11 = Nx.subtract(one, Nx.multiply(two, Nx.add(xx, zz)))
-    r12 = Nx.multiply(two, Nx.subtract(yz, wx))
-
-    r20 = Nx.multiply(two, Nx.subtract(xz, wy))
-    r21 = Nx.multiply(two, Nx.add(yz, wx))
-    r22 = Nx.subtract(one, Nx.multiply(two, Nx.add(xx, yy)))
-
-    Nx.stack([
-      Nx.stack([r00, r01, r02]),
-      Nx.stack([r10, r11, r12]),
-      Nx.stack([r20, r21, r22])
-    ])
+    [
+      [1.0 - 2 * (yy + zz), 2 * (xy - wz), 2 * (xz + wy)],
+      [2 * (xy + wz), 1.0 - 2 * (xx + zz), 2 * (yz - wx)],
+      [2 * (xz - wy), 2 * (yz + wx), 1.0 - 2 * (xx + yy)]
+    ]
   end
 
   @doc """
@@ -567,28 +373,15 @@ defmodule BB.Math.Quaternion do
       1.0
   """
   @spec to_axis_angle(t()) :: {Vec3.t(), float()}
-  def to_axis_angle(%__MODULE__{tensor: t}) do
-    w = t[0]
-    xyz = Nx.slice(t, [1], [3])
+  def to_axis_angle(%__MODULE__{w: w, x: x, y: y, z: z}) do
+    angle = 2 * :math.acos(clamp(w, -1.0, 1.0))
+    sin_half = :math.sin(angle / 2)
 
-    # Clamp w to valid range for acos
-    w_clamped = Nx.clip(w, -1.0, 1.0)
-    angle = Nx.multiply(2.0, Nx.acos(w_clamped))
-    angle_float = Nx.to_number(angle)
-
-    sin_half = Nx.sin(Nx.divide(angle, 2.0))
-
-    # If sin_half is near zero, return arbitrary axis
-    default_axis = Nx.tensor([0.0, 0.0, 1.0], type: :f64)
-
-    axis_tensor =
-      Nx.select(
-        Nx.less(Nx.abs(sin_half), 1.0e-10),
-        default_axis,
-        Nx.divide(xyz, sin_half)
-      )
-
-    {Vec3.from_tensor(axis_tensor), angle_float}
+    if abs(sin_half) < @zero_threshold do
+      {Vec3.unit_z(), angle}
+    else
+      {Vec3.new(x / sin_half, y / sin_half, z / sin_half), angle}
+    end
   end
 
   @doc """
@@ -607,80 +400,25 @@ defmodule BB.Math.Quaternion do
   """
   @spec to_euler(t(), atom()) :: {float(), float(), float()}
   def to_euler(%__MODULE__{} = q, order \\ :xyz) do
-    matrix = to_rotation_matrix(q)
-    rotation_matrix_to_euler(order, matrix)
-  end
-
-  # XYZ order (roll-pitch-yaw)
-  # For intrinsic XYZ: R = Rx(roll) * Ry(pitch) * Rz(yaw)
-  defp rotation_matrix_to_euler(:xyz, matrix) do
-    m02 = matrix[0][2]
-    m12 = matrix[1][2]
-    m22 = matrix[2][2]
-    m01 = matrix[0][1]
-    m00 = matrix[0][0]
-    m10 = matrix[1][0]
-    m11 = matrix[1][1]
-
-    # Check for gimbal lock
-    gimbal_pos = Nx.greater_equal(m02, 0.99999)
-    gimbal_neg = Nx.less_equal(m02, -0.99999)
-
-    # Normal case
-    pitch_normal = Nx.asin(Nx.clip(m02, -1.0, 1.0))
-    roll_normal = Nx.atan2(Nx.negate(m12), m22)
-    yaw_normal = Nx.atan2(Nx.negate(m01), m00)
-
-    # Gimbal lock case (pitch ≈ +90°)
-    pitch_pos = Nx.tensor(:math.pi() / 2, type: :f64)
-    roll_pos = Nx.tensor(0.0, type: :f64)
-    yaw_pos = Nx.atan2(m10, m11)
-
-    # Gimbal lock case (pitch ≈ -90°)
-    pitch_neg = Nx.tensor(-:math.pi() / 2, type: :f64)
-    roll_neg = Nx.tensor(0.0, type: :f64)
-    yaw_neg = Nx.atan2(m10, m11)
-
-    roll = Nx.select(gimbal_pos, roll_pos, Nx.select(gimbal_neg, roll_neg, roll_normal))
-    pitch = Nx.select(gimbal_pos, pitch_pos, Nx.select(gimbal_neg, pitch_neg, pitch_normal))
-    yaw = Nx.select(gimbal_pos, yaw_pos, Nx.select(gimbal_neg, yaw_neg, yaw_normal))
-
-    {Nx.to_number(roll), Nx.to_number(pitch), Nx.to_number(yaw)}
+    rotation_to_euler(order, to_rotation_list(q))
   end
 
   # ZYX order (yaw-pitch-roll, common in aerospace)
-  defp rotation_matrix_to_euler(:zyx, matrix) do
-    m20 = matrix[2][0]
-    m21 = matrix[2][1]
-    m22 = matrix[2][2]
-    m10 = matrix[1][0]
-    m00 = matrix[0][0]
-
-    gimbal_pos = Nx.less_equal(m20, -0.99999)
-    gimbal_neg = Nx.greater_equal(m20, 0.99999)
-
-    pitch_normal = Nx.asin(Nx.clip(Nx.negate(m20), -1.0, 1.0))
-    roll_normal = Nx.atan2(m21, m22)
-    yaw_normal = Nx.atan2(m10, m00)
-
-    pitch_pos = Nx.tensor(:math.pi() / 2, type: :f64)
-    roll_pos = Nx.tensor(0.0, type: :f64)
-    yaw_pos = Nx.atan2(Nx.negate(m10), m00)
-
-    pitch_neg = Nx.tensor(-:math.pi() / 2, type: :f64)
-    roll_neg = Nx.tensor(0.0, type: :f64)
-    yaw_neg = Nx.atan2(Nx.negate(m10), m00)
-
-    roll = Nx.select(gimbal_pos, roll_pos, Nx.select(gimbal_neg, roll_neg, roll_normal))
-    pitch = Nx.select(gimbal_pos, pitch_pos, Nx.select(gimbal_neg, pitch_neg, pitch_normal))
-    yaw = Nx.select(gimbal_pos, yaw_pos, Nx.select(gimbal_neg, yaw_neg, yaw_normal))
-
-    {Nx.to_number(roll), Nx.to_number(pitch), Nx.to_number(yaw)}
+  defp rotation_to_euler(:zyx, [[m00, _m01, _m02], [m10, _m11, _m12], [m20, m21, m22]]) do
+    cond do
+      m20 <= -@gimbal_threshold -> {0.0, :math.pi() / 2, :math.atan2(-m10, m00)}
+      m20 >= @gimbal_threshold -> {0.0, -:math.pi() / 2, :math.atan2(-m10, m00)}
+      true -> {:math.atan2(m21, m22), :math.asin(clamp(-m20, -1.0, 1.0)), :math.atan2(m10, m00)}
+    end
   end
 
-  # Default to xyz for unsupported orders
-  defp rotation_matrix_to_euler(_order, matrix) do
-    rotation_matrix_to_euler(:xyz, matrix)
+  # XYZ order (roll-pitch-yaw). For intrinsic XYZ: R = Rx(roll) * Ry(pitch) * Rz(yaw)
+  defp rotation_to_euler(_xyz, [[m00, m01, m02], [m10, m11, m12], [_m20, _m21, m22]]) do
+    cond do
+      m02 >= @gimbal_threshold -> {0.0, :math.pi() / 2, :math.atan2(m10, m11)}
+      m02 <= -@gimbal_threshold -> {0.0, -:math.pi() / 2, :math.atan2(m10, m11)}
+      true -> {:math.atan2(-m12, m22), :math.asin(clamp(m02, -1.0, 1.0)), :math.atan2(-m01, m00)}
+    end
   end
 
   @doc """
@@ -698,8 +436,13 @@ defmodule BB.Math.Quaternion do
       3.141593
   """
   @spec multiply(t(), t()) :: t()
-  def multiply(%__MODULE__{tensor: t1}, %__MODULE__{tensor: t2}) do
-    %__MODULE__{tensor: Defn.quaternion_multiply(t1, t2)}
+  def multiply(%__MODULE__{} = a, %__MODULE__{} = b) do
+    new(
+      a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z,
+      a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
+      a.w * b.y - a.x * b.z + a.y * b.w + a.z * b.x,
+      a.w * b.z + a.x * b.y - a.y * b.x + a.z * b.w
+    )
   end
 
   @doc """
@@ -715,31 +458,32 @@ defmodule BB.Math.Quaternion do
       -0.707107
   """
   @spec conjugate(t()) :: t()
-  def conjugate(%__MODULE__{tensor: t}) do
-    # Conjugate: negate the vector part
-    w = t[0]
-    xyz = Nx.negate(Nx.slice(t, [1], [3]))
-    tensor = Nx.concatenate([Nx.reshape(w, {1}), xyz])
-
-    %__MODULE__{tensor: tensor}
+  def conjugate(%__MODULE__{w: w, x: x, y: y, z: z}) do
+    %__MODULE__{w: w, x: -x, y: -y, z: -z}
   end
 
   @doc """
   Normalises a quaternion to unit length.
 
+  Falls back to the identity quaternion when the input is near-zero, so the
+  result is always a valid unit rotation.
+
   ## Examples
 
-      iex> q = %BB.Math.Quaternion{tensor: Nx.tensor([2.0, 0.0, 0.0, 0.0])}
-      iex> qn = BB.Math.Quaternion.normalise(q)
-      iex> BB.Math.Quaternion.w(qn)
+      iex> q = BB.Math.Quaternion.normalise(%BB.Math.Quaternion{w: 2.0, x: 0.0, y: 0.0, z: 0.0})
+      iex> BB.Math.Quaternion.w(q)
       1.0
   """
   @spec normalise(t()) :: t()
-  def normalise(%__MODULE__{tensor: t}) do
-    %__MODULE__{tensor: normalise_tensor(t)}
-  end
+  def normalise(%__MODULE__{w: w, x: x, y: y, z: z}) do
+    case :math.sqrt(w * w + x * x + y * y + z * z) do
+      norm when norm > @zero_threshold ->
+        %__MODULE__{w: w / norm, x: x / norm, y: y / norm, z: z / norm}
 
-  defp normalise_tensor(tensor), do: Defn.normalise_quaternion(tensor)
+      _zero ->
+        identity()
+    end
+  end
 
   @doc """
   Returns the inverse of a quaternion.
@@ -755,9 +499,7 @@ defmodule BB.Math.Quaternion do
       1.0
   """
   @spec inverse(t()) :: t()
-  def inverse(%__MODULE__{} = q) do
-    conjugate(q)
-  end
+  def inverse(%__MODULE__{} = q), do: conjugate(q)
 
   @doc """
   Rotates a 3D vector by a quaternion.
@@ -771,49 +513,17 @@ defmodule BB.Math.Quaternion do
       {0.0, 1.0}
   """
   @spec rotate_vector(t(), Vec3.t()) :: Vec3.t()
-  def rotate_vector(%__MODULE__{tensor: t}, %Vec3{tensor: v_tensor}) do
-    w = t[0]
-    u = Nx.slice(t, [1], [3])
+  def rotate_vector(%__MODULE__{w: w, x: x, y: y, z: z}, %Vec3{} = v) do
+    # Rodrigues: v' = v + 2w(u × v) + 2(u × (u × v)), with u the vector part.
+    u = %Vec3{x: x, y: y, z: z}
+    uxv = Vec3.cross(u, v)
+    uuxv = Vec3.cross(u, uxv)
 
-    # Rodrigues rotation formula: v' = v + 2*w*(u x v) + 2*(u x (u x v))
-    # Cross product: u x v
-    u1 = u[0]
-    u2 = u[1]
-    u3 = u[2]
-    v1 = v_tensor[0]
-    v2 = v_tensor[1]
-    v3 = v_tensor[2]
-
-    # u x v
-    uxv =
-      Nx.stack([
-        Nx.subtract(Nx.multiply(u2, v3), Nx.multiply(u3, v2)),
-        Nx.subtract(Nx.multiply(u3, v1), Nx.multiply(u1, v3)),
-        Nx.subtract(Nx.multiply(u1, v2), Nx.multiply(u2, v1))
-      ])
-
-    # u x (u x v)
-    uxv1 = uxv[0]
-    uxv2 = uxv[1]
-    uxv3 = uxv[2]
-
-    uuxv =
-      Nx.stack([
-        Nx.subtract(Nx.multiply(u2, uxv3), Nx.multiply(u3, uxv2)),
-        Nx.subtract(Nx.multiply(u3, uxv1), Nx.multiply(u1, uxv3)),
-        Nx.subtract(Nx.multiply(u1, uxv2), Nx.multiply(u2, uxv1))
-      ])
-
-    # v' = v + 2*w*(u x v) + 2*(u x (u x v))
-    two = Nx.tensor(2.0, type: :f64)
-
-    result =
-      Nx.add(
-        Nx.add(v_tensor, Nx.multiply(Nx.multiply(two, w), uxv)),
-        Nx.multiply(two, uuxv)
-      )
-
-    Vec3.from_tensor(result)
+    %Vec3{
+      x: v.x + 2 * w * uxv.x + 2 * uuxv.x,
+      y: v.y + 2 * w * uxv.y + 2 * uuxv.y,
+      z: v.z + 2 * w * uxv.z + 2 * uuxv.z
+    }
   end
 
   @doc """
@@ -831,38 +541,34 @@ defmodule BB.Math.Quaternion do
       1.570796
   """
   @spec slerp(t(), t(), number()) :: t()
-  def slerp(%__MODULE__{tensor: t1}, %__MODULE__{tensor: t2}, t) when t >= 0 and t <= 1 do
-    # Compute dot product
-    dot = Nx.dot(t1, t2)
+  def slerp(%__MODULE__{} = a, %__MODULE__{} = b, t) when t >= 0 and t <= 1 do
+    dot = a.w * b.w + a.x * b.x + a.y * b.y + a.z * b.z
 
-    # If dot is negative, negate one quaternion to take shorter path
-    t2_adjusted = Nx.select(Nx.less(dot, 0), Nx.negate(t2), t2)
-    dot_adjusted = Nx.abs(dot)
+    # q and -q are the same rotation, so flip to take the shorter arc.
+    {b, dot} = if dot < 0, do: {negate(b), -dot}, else: {b, dot}
 
-    # Clamp dot to valid range for acos
-    dot_clamped = Nx.clip(dot_adjusted, 0.0, 1.0)
+    {s1, s2} =
+      case clamp(dot, 0.0, 1.0) do
+        close when close > @slerp_linear_threshold ->
+          {1 - t, t}
 
-    # Check if quaternions are very close (use linear interpolation)
-    close = Nx.greater(dot_clamped, 0.9995)
+        clamped ->
+          theta = :math.acos(clamped)
+          sin_theta = :math.sin(theta)
 
-    # Linear interpolation path
-    t_tensor = Nx.tensor(t, type: :f64)
-    one_minus_t = Nx.subtract(1.0, t_tensor)
-    lerp_result = Nx.add(Nx.multiply(t1, one_minus_t), Nx.multiply(t2_adjusted, t_tensor))
+          {:math.sin((1 - t) * theta) / sin_theta, :math.sin(t * theta) / sin_theta}
+      end
 
-    # SLERP path
-    theta = Nx.acos(dot_clamped)
-    sin_theta = Nx.sin(theta)
+    new(
+      a.w * s1 + b.w * s2,
+      a.x * s1 + b.x * s2,
+      a.y * s1 + b.y * s2,
+      a.z * s1 + b.z * s2
+    )
+  end
 
-    s1 = Nx.divide(Nx.sin(Nx.multiply(one_minus_t, theta)), sin_theta)
-    s2 = Nx.divide(Nx.sin(Nx.multiply(t_tensor, theta)), sin_theta)
-
-    slerp_result = Nx.add(Nx.multiply(t1, s1), Nx.multiply(t2_adjusted, s2))
-
-    # Select based on closeness
-    result = Nx.select(close, lerp_result, slerp_result)
-
-    %__MODULE__{tensor: normalise_tensor(result)}
+  defp negate(%__MODULE__{w: w, x: x, y: y, z: z}) do
+    %__MODULE__{w: -w, x: -x, y: -y, z: -z}
   end
 
   @doc """
@@ -878,16 +584,10 @@ defmodule BB.Math.Quaternion do
       1.570796
   """
   @spec angular_distance(t(), t()) :: float()
-  def angular_distance(%__MODULE__{tensor: t1}, %__MODULE__{tensor: t2}) do
-    # Compute absolute dot product (both q and -q represent same rotation)
-    dot = Nx.abs(Nx.dot(t1, t2))
+  def angular_distance(%__MODULE__{} = a, %__MODULE__{} = b) do
+    dot = abs(a.w * b.w + a.x * b.x + a.y * b.y + a.z * b.z)
 
-    # Clamp to valid range for acos
-    dot_clamped = Nx.clip(dot, 0.0, 1.0)
-
-    # Angular distance = 2 * acos(|dot|)
-    angle = Nx.multiply(2.0, Nx.acos(dot_clamped))
-    Nx.to_number(angle)
+    2 * :math.acos(clamp(dot, 0.0, 1.0))
   end
 
   @doc """
@@ -900,9 +600,7 @@ defmodule BB.Math.Quaternion do
       [0.0, 0.0, 0.0, 1.0]
   """
   @spec to_xyzw_list(t()) :: [float()]
-  def to_xyzw_list(%__MODULE__{tensor: t}) do
-    [Nx.to_number(t[1]), Nx.to_number(t[2]), Nx.to_number(t[3]), Nx.to_number(t[0])]
-  end
+  def to_xyzw_list(%__MODULE__{w: w, x: x, y: y, z: z}), do: [x, y, z, w]
 
   @doc """
   Creates from a list in XYZW order (for ROS/external system compatibility).
@@ -914,9 +612,7 @@ defmodule BB.Math.Quaternion do
       1.0
   """
   @spec from_xyzw_list([number()]) :: t()
-  def from_xyzw_list([x, y, z, w]) do
-    new(w, x, y, z)
-  end
+  def from_xyzw_list([x, y, z, w]), do: new(w, x, y, z)
 
   @doc """
   Converts to a list in WXYZ order.
@@ -928,9 +624,7 @@ defmodule BB.Math.Quaternion do
       [1.0, 0.0, 0.0, 0.0]
   """
   @spec to_list(t()) :: [float()]
-  def to_list(%__MODULE__{tensor: t}) do
-    Nx.to_flat_list(t)
-  end
+  def to_list(%__MODULE__{w: w, x: x, y: y, z: z}), do: [w, x, y, z]
 
   @doc """
   Creates from a list in WXYZ order.
@@ -942,7 +636,7 @@ defmodule BB.Math.Quaternion do
       1.0
   """
   @spec from_list([number()]) :: t()
-  def from_list([w, x, y, z]) do
-    new(w, x, y, z)
-  end
+  def from_list([w, x, y, z]), do: new(w, x, y, z)
+
+  defp clamp(value, min, max), do: value |> max(min) |> min(max)
 end

--- a/lib/bb/math/transform.ex
+++ b/lib/bb/math/transform.ex
@@ -4,7 +4,7 @@
 
 defmodule BB.Math.Transform do
   @moduledoc """
-  Homogeneous transformation matrices for 3D transformations, backed by an Nx tensor.
+  Homogeneous transformation matrices for 3D transformations.
 
   All transforms are represented as 4x4 matrices in row-major order:
 
@@ -17,6 +17,18 @@ defmodule BB.Math.Transform do
 
   Where the upper-left 3x3 is the rotation matrix and the rightmost column
   is the translation vector.
+
+  ## Not tensor-backed
+
+  The sixteen entries are held as a flat row-major tuple of floats rather than
+  an `Nx` tensor, for the reasons in `BB.Math.Vec3` - a 4x4 compose is 64
+  multiply-adds, and eager `Nx` dispatch costs far more than that. A tuple also
+  destructures in a single pattern match, so `compose/2` reads its 32 inputs
+  without a map lookup each.
+
+  `tensor/1` and `from_tensor/1` convert at the boundary of `BB.Robot.Kinematics`
+  and the IK solvers, where a whole chain is walked in one batched `defn` and
+  `Nx` genuinely pays for itself.
 
   ## Conventions
 
@@ -36,13 +48,19 @@ defmodule BB.Math.Transform do
       [1.0, 2.0, 3.0]
   """
 
-  alias BB.Math.Defn
   alias BB.Math.Quaternion
   alias BB.Math.Vec3
 
-  defstruct [:tensor]
+  defstruct [:m]
 
-  @type t :: %__MODULE__{tensor: Nx.Tensor.t()}
+  @typedoc "The sixteen matrix entries, row-major."
+  @type elements ::
+          {float(), float(), float(), float(), float(), float(), float(), float(), float(),
+           float(), float(), float(), float(), float(), float(), float()}
+
+  @type t :: %__MODULE__{m: elements()}
+
+  @identity {1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0}
 
   @doc """
   Create a 4x4 identity transformation matrix.
@@ -57,23 +75,31 @@ defmodule BB.Math.Transform do
        [0.0, 0.0, 0.0, 1.0]]
   """
   @spec identity() :: t()
-  def identity do
-    %__MODULE__{tensor: Nx.eye(4, type: :f64)}
-  end
+  def identity, do: %__MODULE__{m: @identity}
 
   @doc """
   Creates a transform from an existing `{4, 4}` tensor.
   """
   @spec from_tensor(Nx.Tensor.t()) :: t()
   def from_tensor(tensor) do
-    %__MODULE__{tensor: Nx.as_type(tensor, :f64)}
+    %__MODULE__{
+      m: tensor |> Nx.as_type(:f64) |> Nx.to_flat_list() |> List.to_tuple()
+    }
   end
 
   @doc """
-  Returns the underlying `{4, 4}` tensor.
+  Returns the transform as a `{4, 4}` `:f64` tensor.
   """
   @spec tensor(t()) :: Nx.Tensor.t()
-  def tensor(%__MODULE__{tensor: t}), do: t
+  def tensor(%__MODULE__{m: m}) do
+    m |> Tuple.to_list() |> Enum.chunk_every(4) |> Nx.tensor(type: :f64)
+  end
+
+  @doc """
+  Returns the sixteen matrix entries as a flat row-major list.
+  """
+  @spec to_list(t()) :: [float()]
+  def to_list(%__MODULE__{m: m}), do: Tuple.to_list(m)
 
   @doc """
   Create a transformation matrix from position and orientation.
@@ -115,22 +141,26 @@ defmodule BB.Math.Transform do
       [1.0, 2.0, 3.0]
   """
   @spec translation(Vec3.t()) :: t()
-  def translation(%Vec3{} = v) do
-    x = Vec3.x(v)
-    y = Vec3.y(v)
-    z = Vec3.z(v)
-
+  def translation(%Vec3{x: x, y: y, z: z}) do
     %__MODULE__{
-      tensor:
-        Nx.tensor(
-          [
-            [1.0, 0.0, 0.0, x],
-            [0.0, 1.0, 0.0, y],
-            [0.0, 0.0, 1.0, z],
-            [0.0, 0.0, 0.0, 1.0]
-          ],
-          type: :f64
-        )
+      m: {
+        1.0,
+        0.0,
+        0.0,
+        x,
+        0.0,
+        1.0,
+        0.0,
+        y,
+        0.0,
+        0.0,
+        1.0,
+        z,
+        0.0,
+        0.0,
+        0.0,
+        1.0
+      }
     }
   end
 
@@ -150,16 +180,24 @@ defmodule BB.Math.Transform do
     s = :math.sin(angle)
 
     %__MODULE__{
-      tensor:
-        Nx.tensor(
-          [
-            [1.0, 0.0, 0.0, 0.0],
-            [0.0, c, -s, 0.0],
-            [0.0, s, c, 0.0],
-            [0.0, 0.0, 0.0, 1.0]
-          ],
-          type: :f64
-        )
+      m: {
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        c,
+        -s,
+        0.0,
+        0.0,
+        s,
+        c,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0
+      }
     }
   end
 
@@ -172,16 +210,24 @@ defmodule BB.Math.Transform do
     s = :math.sin(angle)
 
     %__MODULE__{
-      tensor:
-        Nx.tensor(
-          [
-            [c, 0.0, s, 0.0],
-            [0.0, 1.0, 0.0, 0.0],
-            [-s, 0.0, c, 0.0],
-            [0.0, 0.0, 0.0, 1.0]
-          ],
-          type: :f64
-        )
+      m: {
+        c,
+        0.0,
+        s,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        -s,
+        0.0,
+        c,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0
+      }
     }
   end
 
@@ -194,16 +240,24 @@ defmodule BB.Math.Transform do
     s = :math.sin(angle)
 
     %__MODULE__{
-      tensor:
-        Nx.tensor(
-          [
-            [c, -s, 0.0, 0.0],
-            [s, c, 0.0, 0.0],
-            [0.0, 0.0, 1.0, 0.0],
-            [0.0, 0.0, 0.0, 1.0]
-          ],
-          type: :f64
-        )
+      m: {
+        c,
+        -s,
+        0.0,
+        0.0,
+        s,
+        c,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0
+      }
     }
   end
 
@@ -221,8 +275,34 @@ defmodule BB.Math.Transform do
       [1.0, 2.0, 0.0]
   """
   @spec compose(t(), t()) :: t()
-  def compose(%__MODULE__{tensor: a}, %__MODULE__{tensor: b}) do
-    %__MODULE__{tensor: Defn.transform_compose(a, b)}
+  def compose(
+        %__MODULE__{
+          m: {a00, a01, a02, a03, a10, a11, a12, a13, a20, a21, a22, a23, a30, a31, a32, a33}
+        },
+        %__MODULE__{
+          m: {b00, b01, b02, b03, b10, b11, b12, b13, b20, b21, b22, b23, b30, b31, b32, b33}
+        }
+      ) do
+    %__MODULE__{
+      m: {
+        a00 * b00 + a01 * b10 + a02 * b20 + a03 * b30,
+        a00 * b01 + a01 * b11 + a02 * b21 + a03 * b31,
+        a00 * b02 + a01 * b12 + a02 * b22 + a03 * b32,
+        a00 * b03 + a01 * b13 + a02 * b23 + a03 * b33,
+        a10 * b00 + a11 * b10 + a12 * b20 + a13 * b30,
+        a10 * b01 + a11 * b11 + a12 * b21 + a13 * b31,
+        a10 * b02 + a11 * b12 + a12 * b22 + a13 * b32,
+        a10 * b03 + a11 * b13 + a12 * b23 + a13 * b33,
+        a20 * b00 + a21 * b10 + a22 * b20 + a23 * b30,
+        a20 * b01 + a21 * b11 + a22 * b21 + a23 * b31,
+        a20 * b02 + a21 * b12 + a22 * b22 + a23 * b32,
+        a20 * b03 + a21 * b13 + a22 * b23 + a23 * b33,
+        a30 * b00 + a31 * b10 + a32 * b20 + a33 * b30,
+        a30 * b01 + a31 * b11 + a32 * b21 + a33 * b31,
+        a30 * b02 + a31 * b12 + a32 * b22 + a33 * b32,
+        a30 * b03 + a31 * b13 + a32 * b23 + a33 * b33
+      }
+    }
   end
 
   @doc """
@@ -248,16 +328,26 @@ defmodule BB.Math.Transform do
   Get the translation component of a transform as a Vec3.
   """
   @spec get_translation(t()) :: Vec3.t()
-  def get_translation(%__MODULE__{tensor: tensor}) do
-    Vec3.from_tensor(Nx.slice(tensor, [0, 3], [3, 1]) |> Nx.reshape({3}))
+  def get_translation(%__MODULE__{m: {_, _, _, x, _, _, _, y, _, _, _, z, _, _, _, _}}) do
+    %Vec3{x: x, y: y, z: z}
   end
 
   @doc """
   Get the rotation matrix (3x3) from a transform.
   """
   @spec get_rotation(t()) :: Nx.Tensor.t()
-  def get_rotation(%__MODULE__{tensor: tensor}) do
-    tensor[0..2][0..2]
+  def get_rotation(%__MODULE__{} = transform) do
+    Nx.tensor(get_rotation_list(transform), type: :f64)
+  end
+
+  @doc """
+  Get the rotation matrix (3x3) from a transform as a list of rows.
+  """
+  @spec get_rotation_list(t()) :: [[float()]]
+  def get_rotation_list(%__MODULE__{
+        m: {r00, r01, r02, _, r10, r11, r12, _, r20, r21, r22, _, _, _, _, _}
+      }) do
+    [[r00, r01, r02], [r10, r11, r12], [r20, r21, r22]]
   end
 
   @doc """
@@ -271,10 +361,15 @@ defmodule BB.Math.Transform do
       [1.0, 2.0, 3.0]
   """
   @spec apply_to_point(t(), Vec3.t()) :: Vec3.t()
-  def apply_to_point(%__MODULE__{tensor: tensor}, %Vec3{tensor: v}) do
-    point = Nx.concatenate([v, Nx.tensor([1.0], type: :f64)])
-    result = Nx.dot(tensor, point)
-    Vec3.from_tensor(Nx.slice(result, [0], [3]))
+  def apply_to_point(
+        %__MODULE__{m: {m00, m01, m02, m03, m10, m11, m12, m13, m20, m21, m22, m23, _, _, _, _}},
+        %Vec3{x: x, y: y, z: z}
+      ) do
+    %Vec3{
+      x: m00 * x + m01 * y + m02 * z + m03,
+      y: m10 * x + m11 * y + m12 * z + m13,
+      z: m20 * x + m21 * y + m22 * z + m23
+    }
   end
 
   @doc """
@@ -283,39 +378,30 @@ defmodule BB.Math.Transform do
   For a valid transformation matrix, this computes the inverse transform.
   """
   @spec inverse(t()) :: t()
-  def inverse(%__MODULE__{tensor: tensor}) do
-    r = get_rotation(%__MODULE__{tensor: tensor})
-    t_vec = get_translation(%__MODULE__{tensor: tensor})
-
-    r_inv = Nx.transpose(r)
-    t_inv = Vec3.negate(Vec3.from_tensor(Nx.dot(r_inv, Vec3.tensor(t_vec))))
-
+  def inverse(%__MODULE__{
+        m: {r00, r01, r02, tx, r10, r11, r12, ty, r20, r21, r22, tz, _, _, _, _}
+      }) do
+    # Rigid-body inverse: the rotation transposes, and the translation is the
+    # transposed rotation applied to the negated original.
     %__MODULE__{
-      tensor:
-        Nx.tensor(
-          [
-            [
-              Nx.to_number(r_inv[0][0]),
-              Nx.to_number(r_inv[0][1]),
-              Nx.to_number(r_inv[0][2]),
-              Vec3.x(t_inv)
-            ],
-            [
-              Nx.to_number(r_inv[1][0]),
-              Nx.to_number(r_inv[1][1]),
-              Nx.to_number(r_inv[1][2]),
-              Vec3.y(t_inv)
-            ],
-            [
-              Nx.to_number(r_inv[2][0]),
-              Nx.to_number(r_inv[2][1]),
-              Nx.to_number(r_inv[2][2]),
-              Vec3.z(t_inv)
-            ],
-            [0.0, 0.0, 0.0, 1.0]
-          ],
-          type: :f64
-        )
+      m: {
+        r00,
+        r10,
+        r20,
+        -(r00 * tx + r10 * ty + r20 * tz),
+        r01,
+        r11,
+        r21,
+        -(r01 * tx + r11 * ty + r21 * tz),
+        r02,
+        r12,
+        r22,
+        -(r02 * tx + r12 * ty + r22 * tz),
+        0.0,
+        0.0,
+        0.0,
+        1.0
+      }
     }
   end
 
@@ -338,26 +424,30 @@ defmodule BB.Math.Transform do
       {0.0, 1.0}
   """
   @spec from_axis_angle(Vec3.t(), float()) :: t()
-  def from_axis_angle(%Vec3{} = axis, angle) do
-    ax = Vec3.x(axis)
-    ay = Vec3.y(axis)
-    az = Vec3.z(axis)
-
+  def from_axis_angle(%Vec3{x: ax, y: ay, z: az}, angle) do
     c = :math.cos(angle)
     s = :math.sin(angle)
     t = 1.0 - c
 
     %__MODULE__{
-      tensor:
-        Nx.tensor(
-          [
-            [t * ax * ax + c, t * ax * ay - s * az, t * ax * az + s * ay, 0.0],
-            [t * ax * ay + s * az, t * ay * ay + c, t * ay * az - s * ax, 0.0],
-            [t * ax * az - s * ay, t * ay * az + s * ax, t * az * az + c, 0.0],
-            [0.0, 0.0, 0.0, 1.0]
-          ],
-          type: :f64
-        )
+      m: {
+        t * ax * ax + c,
+        t * ax * ay - s * az,
+        t * ax * az + s * ay,
+        0.0,
+        t * ax * ay + s * az,
+        t * ay * ay + c,
+        t * ay * az - s * ax,
+        0.0,
+        t * ax * az - s * ay,
+        t * ay * az + s * ax,
+        t * az * az + c,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0
+      }
     }
   end
 
@@ -397,14 +487,7 @@ defmodule BB.Math.Transform do
   """
   @spec from_quaternion(Quaternion.t()) :: t()
   def from_quaternion(%Quaternion{} = q) do
-    rot_3x3 = Quaternion.to_rotation_matrix(q)
-
-    row0 = Nx.concatenate([rot_3x3[0], Nx.tensor([0.0], type: :f64)])
-    row1 = Nx.concatenate([rot_3x3[1], Nx.tensor([0.0], type: :f64)])
-    row2 = Nx.concatenate([rot_3x3[2], Nx.tensor([0.0], type: :f64)])
-    row3 = Nx.tensor([0.0, 0.0, 0.0, 1.0], type: :f64)
-
-    %__MODULE__{tensor: Nx.stack([row0, row1, row2, row3])}
+    from_position_quaternion(Vec3.zero(), q)
   end
 
   @doc """
@@ -422,8 +505,7 @@ defmodule BB.Math.Transform do
   """
   @spec get_quaternion(t()) :: Quaternion.t()
   def get_quaternion(%__MODULE__{} = transform) do
-    rot_3x3 = get_rotation(transform)
-    Quaternion.from_rotation_matrix(rot_3x3)
+    transform |> get_rotation_list() |> Quaternion.from_rotation_matrix()
   end
 
   @doc """
@@ -438,16 +520,29 @@ defmodule BB.Math.Transform do
       [1.0, 2.0, 3.0]
   """
   @spec from_position_quaternion(Vec3.t(), Quaternion.t()) :: t()
-  def from_position_quaternion(%Vec3{} = pos, %Quaternion{} = q) do
-    rot_3x3 = Quaternion.to_rotation_matrix(q)
-    pos_tensor = Vec3.tensor(pos)
+  def from_position_quaternion(%Vec3{x: x, y: y, z: z}, %Quaternion{} = q) do
+    [[r00, r01, r02], [r10, r11, r12], [r20, r21, r22]] = Quaternion.to_rotation_list(q)
 
-    row0 = Nx.concatenate([rot_3x3[0], Nx.reshape(pos_tensor[0], {1})])
-    row1 = Nx.concatenate([rot_3x3[1], Nx.reshape(pos_tensor[1], {1})])
-    row2 = Nx.concatenate([rot_3x3[2], Nx.reshape(pos_tensor[2], {1})])
-    row3 = Nx.tensor([0.0, 0.0, 0.0, 1.0], type: :f64)
-
-    %__MODULE__{tensor: Nx.stack([row0, row1, row2, row3])}
+    %__MODULE__{
+      m: {
+        r00,
+        r01,
+        r02,
+        x,
+        r10,
+        r11,
+        r12,
+        y,
+        r20,
+        r21,
+        r22,
+        z,
+        0.0,
+        0.0,
+        0.0,
+        1.0
+      }
+    }
   end
 
   @doc """
@@ -464,12 +559,8 @@ defmodule BB.Math.Transform do
       [0.0, 0.0, 1.0]
   """
   @spec get_forward_vector(t()) :: Vec3.t()
-  def get_forward_vector(%__MODULE__{tensor: tensor}) do
-    Vec3.new(
-      Nx.to_number(tensor[0][2]),
-      Nx.to_number(tensor[1][2]),
-      Nx.to_number(tensor[2][2])
-    )
+  def get_forward_vector(%__MODULE__{m: {_, _, x, _, _, _, y, _, _, _, z, _, _, _, _, _}}) do
+    %Vec3{x: x, y: y, z: z}
   end
 
   @doc """
@@ -486,12 +577,8 @@ defmodule BB.Math.Transform do
       [0.0, 1.0, 0.0]
   """
   @spec get_up_vector(t()) :: Vec3.t()
-  def get_up_vector(%__MODULE__{tensor: tensor}) do
-    Vec3.new(
-      Nx.to_number(tensor[0][1]),
-      Nx.to_number(tensor[1][1]),
-      Nx.to_number(tensor[2][1])
-    )
+  def get_up_vector(%__MODULE__{m: {_, x, _, _, _, y, _, _, _, z, _, _, _, _, _, _}}) do
+    %Vec3{x: x, y: y, z: z}
   end
 
   @doc """
@@ -508,11 +595,7 @@ defmodule BB.Math.Transform do
       [1.0, 0.0, 0.0]
   """
   @spec get_right_vector(t()) :: Vec3.t()
-  def get_right_vector(%__MODULE__{tensor: tensor}) do
-    Vec3.new(
-      Nx.to_number(tensor[0][0]),
-      Nx.to_number(tensor[1][0]),
-      Nx.to_number(tensor[2][0])
-    )
+  def get_right_vector(%__MODULE__{m: {x, _, _, _, y, _, _, _, z, _, _, _, _, _, _, _}}) do
+    %Vec3{x: x, y: y, z: z}
   end
 end

--- a/lib/bb/math/transform.ex
+++ b/lib/bb/math/transform.ex
@@ -96,10 +96,20 @@ defmodule BB.Math.Transform do
   end
 
   @doc """
-  Returns the sixteen matrix entries as a flat row-major list.
+  Returns the sixteen matrix entries as a flat row-major tuple.
+
+  The inverse of `from_elements/1`. Together they are the cheapest lossless way
+  to move a transform in and out of a plain term - `BB.Robot.State` stores one
+  this way - with no arithmetic and nothing backend-specific in between.
   """
-  @spec to_list(t()) :: [float()]
-  def to_list(%__MODULE__{m: m}), do: Tuple.to_list(m)
+  @spec elements(t()) :: elements()
+  def elements(%__MODULE__{m: m}), do: m
+
+  @doc """
+  Builds a transform from sixteen row-major entries.
+  """
+  @spec from_elements(elements()) :: t()
+  def from_elements(m) when tuple_size(m) == 16, do: %__MODULE__{m: m}
 
   @doc """
   Create a transformation matrix from position and orientation.

--- a/lib/bb/math/vec3.ex
+++ b/lib/bb/math/vec3.ex
@@ -4,10 +4,20 @@
 
 defmodule BB.Math.Vec3 do
   @moduledoc """
-  3D vector backed by an Nx tensor.
+  A 3D vector, held as three `:f64` floats.
 
-  All operations are performed using Nx for consistent performance
-  and potential GPU acceleration.
+  ## Not tensor-backed
+
+  Like `BB.Math.Transform2D`, and unlike a batched computation, a single 3-vector
+  is far cheaper as three BEAM floats than as an `Nx` tensor: eager per-op
+  dispatch on three elements costs orders of magnitude more than the arithmetic
+  it performs, and allocates a tensor per intermediate. Vectors are built and
+  read on every sensor sample, so that cost lands squarely in the hot path.
+
+  `tensor/1` and `from_tensor/1` convert at the boundary of code that genuinely
+  wants tensors - batched forward kinematics, the IK solvers, `Nx.LinAlg`. Those
+  callers build one tensor for a whole computation rather than one per operation,
+  which is where `Nx` earns its keep.
 
   ## Examples
 
@@ -25,34 +35,18 @@ defmodule BB.Math.Vec3 do
       1.0
   """
 
-  defstruct [:tensor]
+  defstruct [:x, :y, :z]
 
-  @type t :: %__MODULE__{tensor: Nx.Tensor.t()}
+  @type t :: %__MODULE__{x: float(), y: float(), z: float()}
+
+  @zero_threshold 1.0e-10
 
   defimpl Inspect do
     import Inspect.Algebra
 
     @spec inspect(@for.t(), Inspect.Opts.t()) :: Inspect.Algebra.t()
-    def inspect(%@for{tensor: %Nx.Tensor{data: %Nx.BinaryBackend{}} = tensor}, opts) do
-      case Nx.shape(tensor) do
-        {3} ->
-          container_doc(
-            "BB.Math.Vec3.new(",
-            Nx.to_flat_list(tensor),
-            ")",
-            opts,
-            &to_doc/2
-          )
-
-        _ ->
-          fallback(tensor, opts)
-      end
-    end
-
-    def inspect(%@for{tensor: tensor}, opts), do: fallback(tensor, opts)
-
-    defp fallback(tensor, opts) do
-      concat(["#BB.Math.Vec3<", to_doc(tensor, opts), ">"])
+    def inspect(%@for{x: x, y: y, z: z}, opts) do
+      container_doc("BB.Math.Vec3.new(", [x, y, z], ")", opts, &to_doc/2)
     end
   end
 
@@ -67,7 +61,7 @@ defmodule BB.Math.Vec3 do
   """
   @spec new(number(), number(), number()) :: t()
   def new(x, y, z) do
-    %__MODULE__{tensor: Nx.tensor([x, y, z], type: :f64)}
+    %__MODULE__{x: x / 1, y: y / 1, z: z / 1}
   end
 
   @doc """
@@ -75,7 +69,9 @@ defmodule BB.Math.Vec3 do
   """
   @spec from_tensor(Nx.Tensor.t()) :: t()
   def from_tensor(tensor) do
-    %__MODULE__{tensor: Nx.as_type(tensor, :f64)}
+    [x, y, z] = tensor |> Nx.as_type(:f64) |> Nx.to_flat_list()
+
+    %__MODULE__{x: x, y: y, z: z}
   end
 
   @doc """
@@ -88,41 +84,39 @@ defmodule BB.Math.Vec3 do
       {0.0, 0.0, 0.0}
   """
   @spec zero() :: t()
-  def zero do
-    %__MODULE__{tensor: Nx.tensor([0.0, 0.0, 0.0], type: :f64)}
-  end
+  def zero, do: %__MODULE__{x: 0.0, y: 0.0, z: 0.0}
 
   @doc "Returns the unit X vector (1, 0, 0)."
   @spec unit_x() :: t()
-  def unit_x, do: %__MODULE__{tensor: Nx.tensor([1.0, 0.0, 0.0], type: :f64)}
+  def unit_x, do: %__MODULE__{x: 1.0, y: 0.0, z: 0.0}
 
   @doc "Returns the unit Y vector (0, 1, 0)."
   @spec unit_y() :: t()
-  def unit_y, do: %__MODULE__{tensor: Nx.tensor([0.0, 1.0, 0.0], type: :f64)}
+  def unit_y, do: %__MODULE__{x: 0.0, y: 1.0, z: 0.0}
 
   @doc "Returns the unit Z vector (0, 0, 1)."
   @spec unit_z() :: t()
-  def unit_z, do: %__MODULE__{tensor: Nx.tensor([0.0, 0.0, 1.0], type: :f64)}
+  def unit_z, do: %__MODULE__{x: 0.0, y: 0.0, z: 1.0}
 
-  @doc "Returns the underlying tensor."
+  @doc "Returns the vector as a `{3}` `:f64` tensor."
   @spec tensor(t()) :: Nx.Tensor.t()
-  def tensor(%__MODULE__{tensor: t}), do: t
+  def tensor(%__MODULE__{x: x, y: y, z: z}), do: Nx.tensor([x, y, z], type: :f64)
 
   @doc "Returns the X component."
   @spec x(t()) :: float()
-  def x(%__MODULE__{tensor: t}), do: Nx.to_number(t[0])
+  def x(%__MODULE__{x: x}), do: x
 
   @doc "Returns the Y component."
   @spec y(t()) :: float()
-  def y(%__MODULE__{tensor: t}), do: Nx.to_number(t[1])
+  def y(%__MODULE__{y: y}), do: y
 
   @doc "Returns the Z component."
   @spec z(t()) :: float()
-  def z(%__MODULE__{tensor: t}), do: Nx.to_number(t[2])
+  def z(%__MODULE__{z: z}), do: z
 
   @doc "Returns the components as a list [x, y, z]."
   @spec to_list(t()) :: [float()]
-  def to_list(%__MODULE__{tensor: t}), do: Nx.to_flat_list(t)
+  def to_list(%__MODULE__{x: x, y: y, z: z}), do: [x, y, z]
 
   @doc """
   Creates a vector from a list of three numbers.
@@ -148,8 +142,8 @@ defmodule BB.Math.Vec3 do
       [5.0, 7.0, 9.0]
   """
   @spec add(t(), t()) :: t()
-  def add(%__MODULE__{tensor: a}, %__MODULE__{tensor: b}) do
-    %__MODULE__{tensor: Nx.add(a, b)}
+  def add(%__MODULE__{} = a, %__MODULE__{} = b) do
+    %__MODULE__{x: a.x + b.x, y: a.y + b.y, z: a.z + b.z}
   end
 
   @doc """
@@ -164,8 +158,8 @@ defmodule BB.Math.Vec3 do
       [3.0, 3.0, 3.0]
   """
   @spec subtract(t(), t()) :: t()
-  def subtract(%__MODULE__{tensor: a}, %__MODULE__{tensor: b}) do
-    %__MODULE__{tensor: Nx.subtract(a, b)}
+  def subtract(%__MODULE__{} = a, %__MODULE__{} = b) do
+    %__MODULE__{x: a.x - b.x, y: a.y - b.y, z: a.z - b.z}
   end
 
   @doc """
@@ -179,8 +173,8 @@ defmodule BB.Math.Vec3 do
       [-1.0, 2.0, -3.0]
   """
   @spec negate(t()) :: t()
-  def negate(%__MODULE__{tensor: t}) do
-    %__MODULE__{tensor: Nx.negate(t)}
+  def negate(%__MODULE__{x: x, y: y, z: z}) do
+    %__MODULE__{x: -x, y: -y, z: -z}
   end
 
   @doc """
@@ -194,8 +188,8 @@ defmodule BB.Math.Vec3 do
       [2.0, 4.0, 6.0]
   """
   @spec scale(t(), number()) :: t()
-  def scale(%__MODULE__{tensor: t}, scalar) do
-    %__MODULE__{tensor: Nx.multiply(t, Nx.tensor(scalar, type: :f64))}
+  def scale(%__MODULE__{x: x, y: y, z: z}, scalar) do
+    %__MODULE__{x: x * scalar, y: y * scalar, z: z * scalar}
   end
 
   @doc """
@@ -209,8 +203,8 @@ defmodule BB.Math.Vec3 do
       32.0
   """
   @spec dot(t(), t()) :: float()
-  def dot(%__MODULE__{tensor: a}, %__MODULE__{tensor: b}) do
-    Nx.to_number(Nx.dot(a, b))
+  def dot(%__MODULE__{} = a, %__MODULE__{} = b) do
+    a.x * b.x + a.y * b.y + a.z * b.z
   end
 
   @doc """
@@ -225,23 +219,12 @@ defmodule BB.Math.Vec3 do
       [0.0, 0.0, 1.0]
   """
   @spec cross(t(), t()) :: t()
-  def cross(%__MODULE__{tensor: a}, %__MODULE__{tensor: b}) do
-    # Cross product: (a2*b3 - a3*b2, a3*b1 - a1*b3, a1*b2 - a2*b1)
-    a1 = a[0]
-    a2 = a[1]
-    a3 = a[2]
-    b1 = b[0]
-    b2 = b[1]
-    b3 = b[2]
-
-    result =
-      Nx.stack([
-        Nx.subtract(Nx.multiply(a2, b3), Nx.multiply(a3, b2)),
-        Nx.subtract(Nx.multiply(a3, b1), Nx.multiply(a1, b3)),
-        Nx.subtract(Nx.multiply(a1, b2), Nx.multiply(a2, b1))
-      ])
-
-    %__MODULE__{tensor: result}
+  def cross(%__MODULE__{} = a, %__MODULE__{} = b) do
+    %__MODULE__{
+      x: a.y * b.z - a.z * b.y,
+      y: a.z * b.x - a.x * b.z,
+      z: a.x * b.y - a.y * b.x
+    }
   end
 
   @doc """
@@ -254,8 +237,8 @@ defmodule BB.Math.Vec3 do
       5.0
   """
   @spec magnitude(t()) :: float()
-  def magnitude(%__MODULE__{tensor: t}) do
-    Nx.to_number(Nx.sqrt(Nx.dot(t, t)))
+  def magnitude(%__MODULE__{} = v) do
+    :math.sqrt(magnitude_squared(v))
   end
 
   @doc """
@@ -270,8 +253,8 @@ defmodule BB.Math.Vec3 do
       25.0
   """
   @spec magnitude_squared(t()) :: float()
-  def magnitude_squared(%__MODULE__{tensor: t}) do
-    Nx.to_number(Nx.dot(t, t))
+  def magnitude_squared(%__MODULE__{x: x, y: y, z: z}) do
+    x * x + y * y + z * z
   end
 
   @doc """
@@ -287,18 +270,11 @@ defmodule BB.Math.Vec3 do
       [1.0, 0.0, 0.0]
   """
   @spec normalise(t()) :: t()
-  def normalise(%__MODULE__{tensor: t}) do
-    mag_sq = Nx.dot(t, t)
-    mag = Nx.sqrt(mag_sq)
-
-    # Avoid division by zero - return zero vector if magnitude is zero
-    safe_mag = Nx.select(Nx.less(mag, 1.0e-10), Nx.tensor(1.0, type: :f64), mag)
-    normalised = Nx.divide(t, safe_mag)
-
-    # If original magnitude was zero, return zero vector
-    result = Nx.select(Nx.less(mag, 1.0e-10), Nx.tensor([0.0, 0.0, 0.0], type: :f64), normalised)
-
-    %__MODULE__{tensor: result}
+  def normalise(%__MODULE__{x: x, y: y, z: z} = v) do
+    case magnitude(v) do
+      magnitude when magnitude < @zero_threshold -> zero()
+      magnitude -> %__MODULE__{x: x / magnitude, y: y / magnitude, z: z / magnitude}
+    end
   end
 
   @doc """
@@ -328,16 +304,11 @@ defmodule BB.Math.Vec3 do
       [5.0, 5.0, 5.0]
   """
   @spec lerp(t(), t(), number()) :: t()
-  def lerp(%__MODULE__{tensor: a}, %__MODULE__{tensor: b}, t) do
-    # lerp(a, b, t) = a + t * (b - a) = a * (1 - t) + b * t
-    t = Nx.tensor(t, type: :f64)
-
-    result =
-      Nx.add(
-        Nx.multiply(a, Nx.subtract(1, t)),
-        Nx.multiply(b, t)
-      )
-
-    %__MODULE__{tensor: result}
+  def lerp(%__MODULE__{} = a, %__MODULE__{} = b, t) do
+    %__MODULE__{
+      x: a.x * (1 - t) + b.x * t,
+      y: a.y * (1 - t) + b.y * t,
+      z: a.z * (1 - t) + b.z * t
+    }
   end
 end

--- a/lib/bb/robot/kinematics.ex
+++ b/lib/bb/robot/kinematics.ex
@@ -113,31 +113,27 @@ defmodule BB.Robot.Kinematics do
   end
 
   def all_link_transforms(%Robot{} = robot, positions) when is_map(positions) do
-    link_order = robot.topology.link_order
-    index_of = link_order |> Enum.with_index() |> Map.new()
+    # `link_order` is root-first, so a link's parent is always already resolved
+    # by the time the link itself is reached — the same property the batched
+    # prefix-product scan in `Defn.link_transforms/9` relies on. The root has no
+    # parent joint and resolves to the identity.
+    Enum.reduce(robot.topology.link_order, %{}, fn link_name, transforms ->
+      {:ok, link} = Robot.get_link(robot, link_name)
 
-    specs =
-      Enum.map(link_order, fn link_name ->
-        {:ok, link} = Robot.get_link(robot, link_name)
-        link_joint_spec(robot, positions, index_of, link_name, link.parent_joint)
-      end)
+      Map.put(transforms, link_name, link_transform(robot, positions, transforms, link))
+    end)
+  end
 
-    result =
-      Defn.link_transforms(
-        col(specs, :position, :f64),
-        col(specs, :rpy, :f64),
-        col(specs, :xyz, :f64),
-        col(specs, :axis, :f64),
-        col(specs, :revolute, :f64),
-        col(specs, :prismatic, :f64),
-        specs |> Enum.map(& &1.stored) |> Nx.stack(),
-        Nx.broadcast(Nx.tensor(0.0, type: :f64), {length(specs), 6}),
-        col(specs, :parent_index, :s64)
-      )
+  defp link_transform(_robot, _positions, _transforms, %{parent_joint: nil}) do
+    Transform.identity()
+  end
 
-    link_order
-    |> Enum.with_index()
-    |> Map.new(fn {link_name, index} -> {link_name, Transform.from_tensor(result[index])} end)
+  defp link_transform(robot, positions, transforms, %{parent_joint: joint_name}) do
+    joint = Map.fetch!(robot.joints, joint_name)
+
+    transforms
+    |> Map.fetch!(joint.parent_link)
+    |> Transform.compose(joint_transform(positions, joint))
   end
 
   @doc """
@@ -326,17 +322,44 @@ defmodule BB.Robot.Kinematics do
   end
 
   defp compute_chain_transform(%Robot{} = robot, configurations, path) do
-    case chain_joints(robot, path) do
-      [] ->
-        Transform.identity()
-
-      joint_names ->
-        robot
-        |> chain_tensors(configurations, joint_names)
-        |> then(&apply(Defn, :fk_chain, &1))
-        |> Transform.from_tensor()
-    end
+    robot
+    |> chain_joints(path)
+    |> Enum.map(&joint_transform(configurations, Map.fetch!(robot.joints, &1)))
+    |> Transform.compose_all()
   end
+
+  # The scalar counterpart of one row of `Defn.joint_matrices/8`: the joint's
+  # origin, then its motion. `motion_transform/2` already covers both halves the
+  # `defn` keeps apart — the masked scalar motion of a single-DoF joint, and the
+  # `stored` matrix a multi-DoF one carries.
+  #
+  # Forward kinematics walks a chain of at most a few dozen links and wants a
+  # single transform back. Pushing that through the batched `defn` costs far more
+  # in trace and dispatch than the ~64 multiply-adds per link it performs, so it
+  # composes here instead. The Jacobians still go through `defn`: they are
+  # differentiated with `grad`, which has no scalar counterpart, and they
+  # genuinely benefit from the batch axis.
+  #
+  # `Defn.joint_matrices/8` also applies `augment(delta)`, which is the identity
+  # at `delta = 0`. Only the Jacobians ever pass a non-zero delta, so there is
+  # nothing to mirror here.
+  defp joint_transform(configurations, joint) do
+    joint.origin
+    |> origin_transform()
+    |> Transform.compose(motion_transform(joint, Map.get(configurations, joint.name)))
+  end
+
+  # `Rx * Ry * Rz` with the translation carried through it, matching
+  # `Defn.build_origins/2`, whose translation is `rotation * xyz` rather than a
+  # bare `xyz`.
+  defp origin_transform(%{orientation: {roll, pitch, yaw}, position: {x, y, z}}) do
+    Transform.rotation_x(roll)
+    |> Transform.compose(Transform.rotation_y(pitch))
+    |> Transform.compose(Transform.rotation_z(yaw))
+    |> Transform.compose(Transform.translation(Vec3.new(x, y, z)))
+  end
+
+  defp origin_transform(_origin), do: Transform.identity()
 
   defp chain_jacobian(robot, configurations, chain_joints, joint_names, kind) do
     case chain_joints do
@@ -475,36 +498,6 @@ defmodule BB.Robot.Kinematics do
   end
 
   defp rows(joints, fun), do: joints |> Enum.map(fun) |> Nx.tensor(type: :f64)
-
-  defp col(specs, key, type), do: specs |> Enum.map(&Map.fetch!(&1, key)) |> Nx.tensor(type: type)
-
-  defp link_joint_spec(_robot, _configurations, index_of, link_name, nil) do
-    %{
-      rpy: origin_rpy(nil),
-      xyz: origin_xyz(nil),
-      axis: axis_row(nil),
-      revolute: revolute_mask(nil),
-      prismatic: prismatic_mask(nil),
-      position: 0.0,
-      stored: Nx.eye(4, type: :f64),
-      parent_index: Map.fetch!(index_of, link_name)
-    }
-  end
-
-  defp link_joint_spec(robot, configurations, index_of, _link_name, joint_name) do
-    joint = Map.fetch!(robot.joints, joint_name)
-
-    %{
-      rpy: origin_rpy(joint.origin),
-      xyz: origin_xyz(joint.origin),
-      axis: axis_row(joint.axis),
-      revolute: revolute_mask(joint),
-      prismatic: prismatic_mask(joint),
-      position: scalar_position(configurations, joint),
-      stored: stored_motion(Map.get(configurations, joint_name), joint),
-      parent_index: Map.fetch!(index_of, joint.parent_link)
-    }
-  end
 
   defp origin_rpy(%{orientation: {roll, pitch, yaw}}), do: [roll, pitch, yaw]
   defp origin_rpy(_), do: [0.0, 0.0, 0.0]

--- a/lib/bb/robot/state.ex
+++ b/lib/bb/robot/state.ex
@@ -467,17 +467,19 @@ defmodule BB.Robot.State do
   # ----------------------------------------------------------------------------
   # Storage encoding
   #
-  # Nothing backend-specific may reach ETS. A `%Nx.Tensor{}` struct carries
-  # backend state: fine under `Nx.BinaryBackend`, but under EXLA it is a
-  # reference to accelerator memory, which is not meaningfully shareable through
-  # a table and may be invalidated out from under a reader. So tensor-backed
-  # values are stored as their raw bytes.
+  # Every value here is stored as a flat tuple of floats: plain terms, copied
+  # into the table and back with no arithmetic in either direction.
   #
-  # Those bytes are also the only lossless option. Decomposing a 4x4 to a
+  # That the encoding is arithmetic-free is the point. Decomposing a 4x4 to a
   # quaternion and translation is a `sqrt` with a branch on the trace, 16 numbers
   # to 7 is not a bijection, and the round-trip would run on *every read* — so
-  # error would accumulate rather than being a one-off. `Nx.to_binary/1` and
-  # `Nx.from_binary/2` are bit-exact and involve no arithmetic at all.
+  # error would accumulate rather than being a one-off. Storing the entries
+  # themselves is bit-exact by construction.
+  #
+  # Nothing backend-specific may reach ETS: an `%Nx.Tensor{}` carries backend
+  # state, which under EXLA is a reference to accelerator memory that is not
+  # meaningfully shareable through a table and may be invalidated out from under
+  # a reader. No value stored here is tensor-backed, and none should become one.
   # ----------------------------------------------------------------------------
 
   # A fixed joint's configuration space is a single point, so the one thing you
@@ -501,11 +503,13 @@ defmodule BB.Robot.State do
   end
 
   defp encode(%{type: :floating}, :configuration, %Transform{} = value) do
-    {:ok, value |> Transform.tensor() |> Nx.to_binary()}
+    {:ok, Transform.elements(value)}
   end
 
   defp encode(%{type: :floating}, :velocity, %Twist{linear: linear, angular: angular}) do
-    {:ok, Nx.to_binary(Nx.concatenate([Vec3.tensor(linear), Vec3.tensor(angular)]))}
+    {:ok,
+     {Vec3.x(linear), Vec3.y(linear), Vec3.z(linear), Vec3.x(angular), Vec3.y(angular),
+      Vec3.z(angular)}}
   end
 
   defp encode(joint, kind, value), do: {:error, invalid(joint, kind, value)}
@@ -517,29 +521,22 @@ defmodule BB.Robot.State do
   defp decode(:planar, :configuration, {x, y, theta}), do: Transform2D.new(x, y, theta)
   defp decode(:planar, :velocity, {vx, vy, omega}), do: %Twist2D{vx: vx, vy: vy, omega: omega}
 
-  defp decode(:floating, :configuration, bytes) do
-    bytes |> Nx.from_binary(:f64) |> Nx.reshape({4, 4}) |> Transform.from_tensor()
+  defp decode(:floating, :configuration, elements) do
+    Transform.from_elements(elements)
   end
 
-  defp decode(:floating, :velocity, bytes) do
-    components = Nx.from_binary(bytes, :f64)
-
-    %Twist{
-      linear: components |> Nx.slice([0], [3]) |> Vec3.from_tensor(),
-      angular: components |> Nx.slice([3], [3]) |> Vec3.from_tensor()
-    }
+  defp decode(:floating, :velocity, {lx, ly, lz, ax, ay, az}) do
+    %Twist{linear: Vec3.new(lx, ly, lz), angular: Vec3.new(ax, ay, az)}
   end
 
   defp encoded_default(:planar, :configuration), do: {0.0, 0.0, 0.0}
   defp encoded_default(:planar, :velocity), do: {0.0, 0.0, 0.0}
 
   defp encoded_default(:floating, :configuration) do
-    Transform.identity() |> Transform.tensor() |> Nx.to_binary()
+    Transform.elements(Transform.identity())
   end
 
-  defp encoded_default(:floating, :velocity) do
-    Nx.to_binary(Nx.broadcast(Nx.tensor(0.0, type: :f64), {6}))
-  end
+  defp encoded_default(:floating, :velocity), do: {0.0, 0.0, 0.0, 0.0, 0.0, 0.0}
 
   defp encoded_default(_type, _kind), do: 0.0
 

--- a/test/bb/math/quaternion_test.exs
+++ b/test/bb/math/quaternion_test.exs
@@ -20,13 +20,6 @@ defmodule BB.Math.QuaternionTest do
       assert inspect(Quaternion.identity(), limit: 2) ==
                "BB.Math.Quaternion.new(1.0, 0.0, ...)"
     end
-
-    test "falls back to typed tensor inspection for templates" do
-      inspected = inspect(%Quaternion{tensor: Nx.template({4}, :f64)})
-
-      assert inspected =~ "#BB.Math.Quaternion<#Nx.Tensor<"
-      assert inspected =~ "Nx.TemplateBackend"
-    end
   end
 
   describe "new/4" do
@@ -452,9 +445,7 @@ defmodule BB.Math.QuaternionTest do
     test "opposite quaternions (q and -q) have zero distance" do
       q1 = Quaternion.new(0.5, 0.5, 0.5, 0.5)
       # -q represents same rotation
-      q2 = %Quaternion{
-        tensor: Nx.multiply(q1.tensor, -1)
-      }
+      q2 = %Quaternion{w: -q1.w, x: -q1.x, y: -q1.y, z: -q1.z}
 
       assert_in_delta Quaternion.angular_distance(q1, q2), 0.0, @tolerance
     end

--- a/test/bb/math/vec3_test.exs
+++ b/test/bb/math/vec3_test.exs
@@ -16,13 +16,6 @@ defmodule BB.Math.Vec3Test do
     test "respects the inspection limit" do
       assert inspect(Vec3.new(1, 2, 3), limit: 2) == "BB.Math.Vec3.new(1.0, 2.0, ...)"
     end
-
-    test "falls back to typed tensor inspection for templates" do
-      inspected = inspect(%Vec3{tensor: Nx.template({3}, :f64)})
-
-      assert inspected =~ "#BB.Math.Vec3<#Nx.Tensor<"
-      assert inspected =~ "Nx.TemplateBackend"
-    end
   end
 
   describe "new/3" do

--- a/test/bb/robot/state_test.exs
+++ b/test/bb/robot/state_test.exs
@@ -164,8 +164,9 @@ defmodule BB.Robot.StateTest do
       assert [{{:configuration, :base}, stored}] =
                :ets.lookup(state.table, {:configuration, :base})
 
-      assert is_binary(stored)
-      assert byte_size(stored) == 128
+      assert is_tuple(stored)
+      assert tuple_size(stored) == 16
+      assert Enum.all?(Tuple.to_list(stored), &is_float/1)
     end
 
     test "reject a bare float, naming Transform as expected" do


### PR DESCRIPTION
This reverses the decision recorded in #147, so it wants that conversation before
it merges. The hardware measurements it was waiting on are in — see below.

Pairs with beam-bots/bb_pid_controller#90. The two changes are independent in
code; you need both to reproduce the end-to-end numbers below.

## What this changes

`BB.Math.Vec3`, `BB.Math.Quaternion` and `BB.Math.Transform` hold BEAM floats
instead of `Nx` tensors — three and four named fields respectively, and a flat
row-major 16-tuple for `Transform`. `tensor/1` and `from_tensor/1` stay, and now
convert rather than unwrap.

`BB.Robot.State` then stops round-tripping floating-joint state through
`Nx.to_binary/1`, storing the entries as a plain tuple like the `:planar` cases
always have.

## Why

#147 accepted the per-op cost of Nx on small fixed-size values on the grounds
that "machines running BB have ample CPU headroom". That premise doesn't hold on
a Nerves-class target — this started from a balance bot that couldn't close its
loop — and the cost turns out to be far larger than the trade-off assumed.

## Measured on hardware

A two-wheeled balance bot on a Nerves Starter Kit board (two Cortex-A7 cores),
100 Hz loop. Three runs each side, stable to within 0.06% run to run.

Reductions per second, by process:

| process | Nx-backed | scalar | |
|---|---|---|---|
| `imu` (BMI323) | 174,540 | 144,657 | 1.2× |
| `orientation` (Mahony) | 742,633 | 159,225 | 4.7× |
| `lean_angle` | 1,747,225 | 79,284 | 22.0× |
| `balancer` | 2,461 | 2,706 | 0.9× |
| **total** | **2,667,827** | **386,840** | **6.9×** |

Per IMU sample: 26,678 reductions → 3,868.

CPU went from 70.3% and 72.3% busy across the two cores to roughly 24% per core —
about a whole core given back, on a board that has two. On that board this is the
difference between the robot balancing and not.

The per-process split tracks what changed. `orientation` is the Mahony filter,
which was always scalar internally — the 4.7× is purely the `to_bb`/`from_bb`
conversion envelope collapsing around it. `lean_angle` calls
`Quaternion.to_euler/2`, which previously built a rotation matrix as nine tensors
plus two `Nx.stack`s and then ran ~25 eager ops including six `select`s for the
gimbal-lock branches; that's the 22×. `imu` is mostly SPI transfer and register
decoding, with only payload construction on the Nx path, hence 1.2×.

`balancer` is a custom control law, not `BB.PID.Kernel`, so it was never on the Nx
path either way. Its 10% *increase* is outside the run-to-run noise and is most
likely de-starvation — at 70% on both cores the Nx build appears not to have been
holding its configured tick rate.

Measured on this branch against `main`, same machine, `Nx.BinaryBackend` +
`Nx.Defn.Evaluator` (what a target gets with no backend installed):

| | main | branch |
|---|---|---|
| `Quaternion.multiply/2` | 779 µs | 0.65 µs |
| `Transform.compose/2` | 91 µs | 1.36 µs |
| `Vec3.new/3` | 2.45 µs | 0.03 µs |
| `Vec3.x/1` | 8.33 µs | 0.02 µs |
| `State.set_configuration/3` (floating) | 3.53 µs | 0.32 µs |
| `State.get_configuration/2` (floating) | 2.21 µs | 0.34 µs |

`Quaternion.multiply/2` was worst because it routed through a `defn`, which
retraces its expression graph every call — it allocated 227 KB per multiply.

This is not a small-target-only problem. Eager dispatch on three elements costs
more than the arithmetic on any machine, and **EXLA makes it worse, not better** —
a device round-trip dwarfs the work:

| | BinaryBackend | EXLA |
|---|---|---|
| `Vec3.x/1` | 8.33 µs | 5560 µs |
| `Vec3.new/3` | 2.45 µs | 268 µs |
| `Transform.compose/2` | 91 µs | 340 µs |

So "install a better backend" isn't the escape hatch, which is what #147's own
note anticipated.

It lands hardest on the message bus: a `BB.Message.Sensor.Imu` payload is two
`Vec3`s and a `Quaternion`, built by the driver and unwrapped again by the
estimator on every sample. That round trip went from 167 µs to 0.25 µs.

## Where Nx is untouched

Everything that builds **one tensor per computation** rather than one per
operation keeps it: `robot/kinematics/defn.ex` (batched FK and Jacobians),
`bb_ik_dls` (`Nx.LinAlg.solve` on the damped Jacobian), `bb_ik_fabrik` (the whole
chain as tensor rows), `bb_policy` (ONNX). That's where Nx earns its keep and
none of it changed.

`Covariance3`/`Covariance6` stay tensor-backed too — they're constructed from a
tensor and read back as one, and nothing populates them per sample. Converting
them would add a conversion to both ends of their only path. Their moduledocs
did claim to follow the now-defunct pattern; that's corrected.

## Source compatibility

All 92 pattern matches on the `:tensor` field were inside `lib/bb/math/`. Nothing
outside it needed changing, in this repo or any satellite. Verified by running
each satellite's suite against this branch with `BB_VERSION=local`, unmodified:

| package | result |
|---|---|
| `bb_estimator_ahrs` | 50 passed |
| `bb_ik_dls` | 41 passed |
| `bb_ik_fabrik` | 57 passed |
| `bb_sensor_bmi323` | 41 passed |
| `bb_pid_controller` | 65 passed |

`bb_estimator_ahrs` is the biggest beneficiary without a line changing in it —
its `to_bb/1`/`from_bb/1` boundary went 62.7 µs → 0.16 µs and 73.8 µs → 0.26 µs,
around a filter step that costs 1.4 µs. Its own scalar quaternion is now
redundant; that's a follow-up, not this PR.

## Two behaviour notes

Two `Inspect` tests went with the change — a float field can't hold an
`Nx.template`, so the fallback they covered is unreachable.

The `BB.Robot.State` test asserting a 128-byte binary now asserts what its name
says (that no tensor struct reaches the table) rather than the encoding that
achieved it. The rule it defends still holds and is still documented: nothing
backend-specific may reach ETS.

## Forward kinematics

The third commit takes the same treatment to the chain walk, which was pushing a
few dozen links through the batched `defn` and converting a single result back:

| | main | branch |
|---|---|---|
| `forward_kinematics/3` (6-DoF arm) | 3.80 ms | 53.7 µs |
| `all_link_transforms/2` (all links) | 5.00 ms | 59.6 µs |

`all_link_transforms/2` folds over `link_order` rather than running a batched
prefix-product scan — that ordering is root-first, so a link's parent is always
resolved before the link itself, which is the property the scan relied on.

This doesn't matter to a balance bot, which has no kinematic chain. It matters to
an arm on the same class of board.

The Jacobians stay in `defn`, where `grad` and the batch axis genuinely earn it,
so `chain_tensors/3` and `Defn.link_transforms/9` remain — `bb_ik_fabrik` calls
the latter directly from inside its own `defn`.

That does leave FK and the Jacobians on separate code paths. They're pinned by
tests that already existed: the analytic Jacobian is checked against central
finite differences of `forward_kinematics/3`, so drift in either fails. Both IK
solvers' suites also pass unchanged against this branch.

## Related

beam-bots/bb_estimator_ahrs#60 drops that package's parallel scalar quaternion,
which only existed because `BB.Math.Quaternion` used to be Nx-backed. Depends on
this PR.

Benchmarks are unchanged from #149's suite; the numbers above come from ad-hoc
scripts I can fold into `bench/` if that's wanted.
